### PR TITLE
chore(config): adding tslib deep

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,8 @@
         "react": "^17.0.2",
         "react-dom": "^17.0.2",
         "react-router-dom": "^5.2.0",
-        "react-scripts": "^4.0.3"
+        "react-scripts": "^4.0.3",
+        "tslib": "^2.5.0"
       },
       "devDependencies": {
         "@commitlint/config-conventional": "^12.0.1",
@@ -1957,10 +1958,6 @@
       "peerDependencies": {
         "cosmiconfig": ">=6"
       }
-    },
-    "node_modules/@endemolshinegroup/cosmiconfig-typescript-loader/node_modules/tslib": {
-      "version": "2.1.0",
-      "license": "0BSD"
     },
     "node_modules/@eslint/eslintrc": {
       "version": "0.4.0",
@@ -8497,10 +8494,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/camel-case/node_modules/tslib": {
-      "version": "2.1.0",
-      "license": "0BSD"
-    },
     "node_modules/camelcase": {
       "version": "5.3.1",
       "license": "MIT",
@@ -8911,6 +8904,11 @@
       "engines": {
         "node": ">=6.0"
       }
+    },
+    "node_modules/chrome-trace-event/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/ci-info": {
       "version": "2.0.0",
@@ -11454,6 +11452,11 @@
         "rimraf": "bin.js"
       }
     },
+    "node_modules/devcert/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
     "node_modules/dezalgo": {
       "version": "1.0.3",
       "dev": true,
@@ -12252,10 +12255,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/dot-case/node_modules/tslib": {
-      "version": "2.1.0",
-      "license": "0BSD"
-    },
     "node_modules/dot-prop": {
       "version": "5.3.0",
       "license": "MIT",
@@ -13036,7 +13035,6 @@
     },
     "node_modules/eslint-config-react-app": {
       "version": "5.2.1",
-      "dev": true,
       "license": "MIT",
       "dependencies": {
         "confusing-browser-globals": "^1.0.9"
@@ -13282,7 +13280,6 @@
     },
     "node_modules/eslint-plugin-flowtype": {
       "version": "3.13.0",
-      "dev": true,
       "license": "BSD-3-Clause",
       "dependencies": {
         "lodash": "^4.17.15"
@@ -17144,37 +17141,6 @@
         "url": "https://opencollective.com/eslint"
       }
     },
-    "node_modules/gatsby/node_modules/eslint-config-react-app": {
-      "version": "5.2.1",
-      "license": "MIT",
-      "dependencies": {
-        "confusing-browser-globals": "^1.0.9"
-      },
-      "peerDependencies": {
-        "@typescript-eslint/eslint-plugin": "2.x",
-        "@typescript-eslint/parser": "2.x",
-        "babel-eslint": "10.x",
-        "eslint": "6.x",
-        "eslint-plugin-flowtype": "3.x || 4.x",
-        "eslint-plugin-import": "2.x",
-        "eslint-plugin-jsx-a11y": "6.x",
-        "eslint-plugin-react": "7.x",
-        "eslint-plugin-react-hooks": "1.x || 2.x"
-      }
-    },
-    "node_modules/gatsby/node_modules/eslint-plugin-flowtype": {
-      "version": "3.13.0",
-      "license": "BSD-3-Clause",
-      "dependencies": {
-        "lodash": "^4.17.15"
-      },
-      "engines": {
-        "node": ">=4"
-      },
-      "peerDependencies": {
-        "eslint": ">=5.0.0"
-      }
-    },
     "node_modules/gatsby/node_modules/eslint-plugin-react-hooks": {
       "version": "1.7.0",
       "license": "MIT",
@@ -20032,10 +19998,6 @@
       "engines": {
         "node": ">=8"
       }
-    },
-    "node_modules/graphql-config/node_modules/tslib": {
-      "version": "2.1.0",
-      "license": "0BSD"
     },
     "node_modules/graphql-playground-html": {
       "version": "1.6.29",
@@ -25192,10 +25154,6 @@
       "version": "1.1.4",
       "license": "MIT"
     },
-    "node_modules/lower-case/node_modules/tslib": {
-      "version": "2.1.0",
-      "license": "0BSD"
-    },
     "node_modules/lowercase-keys": {
       "version": "1.0.1",
       "license": "MIT",
@@ -26503,10 +26461,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/no-case/node_modules/tslib": {
-      "version": "2.1.0",
-      "license": "0BSD"
-    },
     "node_modules/node-dir": {
       "version": "0.1.17",
       "license": "MIT",
@@ -27712,10 +27666,6 @@
         "tslib": "^2.0.3"
       }
     },
-    "node_modules/param-case/node_modules/tslib": {
-      "version": "2.1.0",
-      "license": "0BSD"
-    },
     "node_modules/parent-module": {
       "version": "1.0.1",
       "license": "MIT",
@@ -27909,10 +27859,6 @@
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
       }
-    },
-    "node_modules/pascal-case/node_modules/tslib": {
-      "version": "2.1.0",
-      "license": "0BSD"
     },
     "node_modules/pascalcase": {
       "version": "0.1.1",
@@ -32344,6 +32290,11 @@
         "npm": ">=2.0.0"
       }
     },
+    "node_modules/rxjs/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+    },
     "node_modules/safe-buffer": {
       "version": "5.2.1",
       "funding": [
@@ -35096,8 +35047,9 @@
       }
     },
     "node_modules/tslib": {
-      "version": "1.14.1",
-      "license": "0BSD"
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "node_modules/tslint-config-prettier": {
       "version": "1.18.0",
@@ -35134,6 +35086,11 @@
       "peerDependencies": {
         "typescript": ">=2.8.0 || >= 3.2.0-dev || >= 3.3.0-dev || >= 3.4.0-dev || >= 3.5.0-dev || >= 3.6.0-dev || >= 3.6.0-beta || >= 3.7.0-dev || >= 3.7.0-beta"
       }
+    },
+    "node_modules/tsutils/node_modules/tslib": {
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+      "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
     },
     "node_modules/tty-browserify": {
       "version": "0.0.0",
@@ -38410,11 +38367,11 @@
     },
     "packages/card": {
       "name": "@uireact/card",
-      "version": "0.8.2",
+      "version": "0.9.0",
       "dev": true,
       "license": "MIT",
       "devDependencies": {
-        "@uireact/foundation": "^0.5.0"
+        "@uireact/foundation": "^0.5.1"
       },
       "peerDependencies": {
         "@types/styled-components": "^5.1.0",
@@ -38425,7 +38382,7 @@
     },
     "packages/foundation": {
       "name": "@uireact/foundation",
-      "version": "0.5.0",
+      "version": "0.5.1",
       "dev": true,
       "license": "MIT",
       "peerDependencies": {
@@ -39731,11 +39688,6 @@
         "make-error": "^1",
         "ts-node": "^9",
         "tslib": "^2"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0"
-        }
       }
     },
     "@eslint/eslintrc": {
@@ -42576,7 +42528,7 @@
     "@uireact/card": {
       "version": "file:packages/card",
       "requires": {
-        "@uireact/foundation": "^0.5.0"
+        "@uireact/foundation": "^0.5.1"
       }
     },
     "@uireact/foundation": {
@@ -44272,11 +44224,6 @@
       "requires": {
         "pascal-case": "^3.1.2",
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0"
-        }
       }
     },
     "camelcase": {
@@ -44552,6 +44499,13 @@
       "version": "1.0.2",
       "requires": {
         "tslib": "^1.9.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "ci-info": {
@@ -46296,6 +46250,11 @@
           "requires": {
             "glob": "^7.1.3"
           }
+        },
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
         }
       }
     },
@@ -46872,11 +46831,6 @@
       "requires": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0"
-        }
       }
     },
     "dot-prop": {
@@ -47437,7 +47391,6 @@
     },
     "eslint-config-react-app": {
       "version": "5.2.1",
-      "dev": true,
       "requires": {
         "confusing-browser-globals": "^1.0.9"
       }
@@ -47587,7 +47540,6 @@
     },
     "eslint-plugin-flowtype": {
       "version": "3.13.0",
-      "dev": true,
       "requires": {
         "lodash": "^4.17.15"
       }
@@ -49306,18 +49258,6 @@
             "semver": {
               "version": "6.3.0"
             }
-          }
-        },
-        "eslint-config-react-app": {
-          "version": "5.2.1",
-          "requires": {
-            "confusing-browser-globals": "^1.0.9"
-          }
-        },
-        "eslint-plugin-flowtype": {
-          "version": "3.13.0",
-          "requires": {
-            "lodash": "^4.17.15"
           }
         },
         "eslint-plugin-react-hooks": {
@@ -52115,9 +52055,6 @@
             "path-type": "^4.0.0",
             "yaml": "^1.7.2"
           }
-        },
-        "tslib": {
-          "version": "2.1.0"
         }
       }
     },
@@ -55580,11 +55517,6 @@
       "version": "2.0.2",
       "requires": {
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0"
-        }
       }
     },
     "lower-case-first": {
@@ -56455,11 +56387,6 @@
       "requires": {
         "lower-case": "^2.0.2",
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0"
-        }
       }
     },
     "node-dir": {
@@ -57263,11 +57190,6 @@
       "requires": {
         "dot-case": "^3.0.4",
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0"
-        }
       }
     },
     "parent-module": {
@@ -57400,11 +57322,6 @@
       "requires": {
         "no-case": "^3.0.4",
         "tslib": "^2.0.3"
-      },
-      "dependencies": {
-        "tslib": {
-          "version": "2.1.0"
-        }
       }
     },
     "pascalcase": {
@@ -60394,6 +60311,13 @@
       "version": "6.6.7",
       "requires": {
         "tslib": "^1.9.0"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "safe-buffer": {
@@ -62231,7 +62155,9 @@
       }
     },
     "tslib": {
-      "version": "1.14.1"
+      "version": "2.5.0",
+      "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.5.0.tgz",
+      "integrity": "sha512-336iVw3rtn2BUK7ORdIAHTyxHGRIHVReokCR3XjbckJMK7ms8FysBfhLR8IXnAgy7T0PTPNBWKiH514FOW/WSg=="
     },
     "tslint-config-prettier": {
       "version": "1.18.0",
@@ -62248,6 +62174,13 @@
       "version": "3.21.0",
       "requires": {
         "tslib": "^1.8.1"
+      },
+      "dependencies": {
+        "tslib": {
+          "version": "1.14.1",
+          "resolved": "https://registry.npmjs.org/tslib/-/tslib-1.14.1.tgz",
+          "integrity": "sha512-Xni35NKzjgMrwevysHTCArtLDpPvye8zV/0E4EyYn43P7/7qvQwPh9BGkHewbMulVntbigmcT7rdX3BNo9wRJg=="
+        }
       }
     },
     "tty-browserify": {

--- a/package.json
+++ b/package.json
@@ -84,6 +84,7 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-router-dom": "^5.2.0",
-    "react-scripts": "^4.0.3"
+    "react-scripts": "^4.0.3",
+    "tslib": "^2.5.0"
   }
 }

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -28,7 +28,8 @@
     "@types/styled-components": "^5.1.0",
     "react": ">= 17 < 19",
     "react-dom": ">= 17 < 19",
-    "styled-components": "^5.1.1"
+    "styled-components": "^5.1.1",
+    "tslib": "^2.5.0"
   },
   "gitHead": "ecb2ada34a996bfeaa9cde73506c9371b22af87c"
 }

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -28,7 +28,8 @@
     "@types/styled-components": "^5.1.0",
     "react": ">= 17 < 19",
     "react-dom": ">= 17 < 19",
-    "styled-components": "^5.1.1"
+    "styled-components": "^5.1.1",
+    "tslib": "^2.5.0"
   },
   "gitHead": "ecb2ada34a996bfeaa9cde73506c9371b22af87c"
 }

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -27,7 +27,8 @@
     "@types/styled-components": "^5.1.0",
     "react": ">= 17 < 19",
     "react-dom": ">= 17 < 19",
-    "styled-components": "^5.1.1"
+    "styled-components": "^5.1.1",
+    "tslib": "^2.5.0"
   },
   "gitHead": "ecb2ada34a996bfeaa9cde73506c9371b22af87c"
 }

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -28,6 +28,7 @@
     "@types/styled-components": "^5.1.0",
     "react": ">= 17 < 19",
     "react-dom": ">= 17 < 19",
-    "styled-components": "^5.1.1"
+    "styled-components": "^5.1.1",
+    "tslib": "^2.5.0"
   }
 }

--- a/packages/navbar/package.json
+++ b/packages/navbar/package.json
@@ -28,6 +28,7 @@
     "@types/styled-components": "^5.1.0",
     "react": ">= 17 < 19",
     "react-dom": ">= 17 < 19",
-    "styled-components": "^5.1.1"
+    "styled-components": "^5.1.1",
+    "tslib": "^2.5.0"
   }
 }


### PR DESCRIPTION
As we are using `importHelpers` flag for build, the clients using the library get a not found library "tslib" as is not listed in the dependencies.

Adding this here will show up as a needed dependency and therefore communicate to clients that they need to provide this deep.