### PR TITLE
chore(config): clean up package jsons

### DIFF
--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -30,6 +30,5 @@
     "react-dom": ">= 17 < 19",
     "styled-components": "^5.1.1",
     "tslib": "^2.5.0"
-  },
-  "gitHead": "ecb2ada34a996bfeaa9cde73506c9371b22af87c"
+  }
 }

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -30,6 +30,5 @@
     "react-dom": ">= 17 < 19",
     "styled-components": "^5.1.1",
     "tslib": "^2.5.0"
-  },
-  "gitHead": "ecb2ada34a996bfeaa9cde73506c9371b22af87c"
+  }
 }

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -29,6 +29,5 @@
     "react-dom": ">= 17 < 19",
     "styled-components": "^5.1.1",
     "tslib": "^2.5.0"
-  },
-  "gitHead": "ecb2ada34a996bfeaa9cde73506c9371b22af87c"
+  }
 }

--- a/utils/template/jest.config.js
+++ b/utils/template/jest.config.js
@@ -12,10 +12,10 @@ module.exports = {
   ],
   coverageThreshold: {
       global: {
-          branches: 90,
-          functions: 90,
-          lines: 90,
-          statements: 90
+          branches: 100,
+          functions: 100,
+          lines: 100,
+          statements: 100
       }
   },
   coverageReporters: ['cobertura', 'html', 'text', 'text-summary'],

--- a/utils/template/package.json
+++ b/utils/template/package.json
@@ -1,5 +1,6 @@
 {
   "name": "@uireact/COMPONENT-NAME",
+  "private": true,
   "description": "COMPONENT-NAME package needed for @uireact packages",
   "repository": "https://github.com/inavac182/ui-react",
   "license": "MIT",


### PR DESCRIPTION
## 🔥 Cleaning up package json
----------------------------------------------

### Description
Some package jsons had `gitHead` which is not needed but due to publishing packages locally this was added, now that publishes happen in gh action we shouldn't need this. Also changed the template configs to start with a 100% coverage since creation.

### Screenshots

N/A
