### PR TITLE
feat(dialog): adding dialog toolbar

### DIFF
--- a/packages/dialog/__tests__/ui-dialog.spec.tsx
+++ b/packages/dialog/__tests__/ui-dialog.spec.tsx
@@ -9,9 +9,11 @@ import { UiDialog, UiDialogType, useDialog } from '../src';
 
 type MockedComponentProps = {
   type?: UiDialogType;
+  title?: string;
+  hideCloseIcon?: boolean;
 };
 
-const MockedComponent = ({ type }: MockedComponentProps) => {
+const MockedComponent = ({ hideCloseIcon, title, type }: MockedComponentProps) => {
   const { actions } = useDialog('mockedDialog');
   const seconDialogData = useDialog('secondDialog');
 
@@ -27,7 +29,7 @@ const MockedComponent = ({ type }: MockedComponentProps) => {
     <>
       <button onClick={openCB}>Open Dialog</button>
       <button onClick={openSecondCB}>Open Second Dialog</button>
-      <UiDialog dialogId="mockedDialog" type={type}>
+      <UiDialog dialogId="mockedDialog" type={type} title={title} hideCloseIcon={hideCloseIcon}>
         <p>Dialog content</p>
       </UiDialog>
     </>
@@ -186,5 +188,43 @@ describe('<UiDialog />', () => {
     expect(console.error).toHaveBeenCalledWith('No dialog controller implemented');
 
     console.error = consoleError;
+  });
+
+  describe('With dialog toolbar', () => {
+    it('Should render dialog toolbar', () => {
+      uiRender(<MockedComponent title="Dialog toolbar" />);
+
+      expect(screen.queryByText('Dialog content')).not.toBeInTheDocument();
+      fireEvent.click(screen.getByText('Open Dialog'));
+
+      expect(screen.getByText('Dialog content')).toBeVisible();
+      expect(screen.getByText('Dialog toolbar')).toBeVisible();
+    });
+
+    it('Should close dialog using close icon inside dialog toolbar', () => {
+      uiRender(<MockedComponent title="Dialog toolbar" type={UiDialogType.FULLSCREEN} />);
+
+      expect(screen.queryByText('Dialog content')).not.toBeInTheDocument();
+      fireEvent.click(screen.getByText('Open Dialog'));
+
+      expect(screen.getByText('Dialog content')).toBeVisible();
+      expect(screen.getByText('Dialog toolbar')).toBeVisible();
+
+      fireEvent.click(screen.getByRole('button', { name: '❌' }));
+
+      expect(screen.queryByText('Dialog content')).not.toBeInTheDocument();
+    });
+  });
+
+  describe('Close icon', () => {
+    it('Should hide close icon', () => {
+      uiRender(<MockedComponent hideCloseIcon />);
+
+      expect(screen.queryByText('Dialog content')).not.toBeInTheDocument();
+      fireEvent.click(screen.getByText('Open Dialog'));
+
+      expect(screen.getByText('Dialog content')).toBeVisible();
+      expect(screen.queryByRole('button', { name: '❌' })).not.toBeInTheDocument();
+    });
   });
 });

--- a/packages/dialog/docs/docs.mdx
+++ b/packages/dialog/docs/docs.mdx
@@ -32,7 +32,7 @@ This dialog renders on top of the content
 Renders centered on top of the content and with a grayed out background that if clicked will close the dialog.
 
 <Playground>
-  <DialogsExample />
+  <DialogsExample title="Dialog title" />
 </Playground>
 
 ## Fullscreen dialog

--- a/packages/dialog/docs/utils/DialogsExample.tsx
+++ b/packages/dialog/docs/utils/DialogsExample.tsx
@@ -8,9 +8,11 @@ import { UiDialog, UiDialogType, useDialog } from '../../src';
 
 type DialogsExampleProps = {
   type?: UiDialogType;
+  title?: string;
+  hideCloseIcon?: boolean;
 };
 
-export const DialogsExample: React.FC<DialogsExampleProps> = ({ type }: DialogsExampleProps) => {
+export const DialogsExample: React.FC<DialogsExampleProps> = ({ type, title, hideCloseIcon }: DialogsExampleProps) => {
   const { actions } = useDialog('example');
 
   const onClickCB = () => {
@@ -20,7 +22,7 @@ export const DialogsExample: React.FC<DialogsExampleProps> = ({ type }: DialogsE
   return (
     <UiView theme={DefaultTheme} selectedTheme={ThemeColor.dark}>
       <UiButton onClick={onClickCB}>Open dialog</UiButton>
-      <UiDialog dialogId="example" type={type}>
+      <UiDialog dialogId="example" type={type} title={title} hideCloseIcon={hideCloseIcon}>
         <UiSpacing margin={{ inline: Sizing.four }}>
           <p>Some content</p>
         </UiSpacing>

--- a/packages/dialog/src/__private/dialog-content.tsx
+++ b/packages/dialog/src/__private/dialog-content.tsx
@@ -11,6 +11,7 @@ const Div = styled.div<privateUiDialogProps>`
   ${(props) => getThemeStyling(props.customTheme, props.selectedTheme, mapper)}
 
   z-index: 10;
+  min-width: 200px;
 
   ${(props) => {
     if (props.type === UiDialogType.CENTERED) {

--- a/packages/dialog/src/__private/dialog-toolbar.tsx
+++ b/packages/dialog/src/__private/dialog-toolbar.tsx
@@ -1,0 +1,47 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { UiReactPrivateElementProps, getThemeStyling, ThemeContext } from '@uireact/foundation';
+
+import { dialogToolbarMapper } from '../theme/dialog-toolbar-mapper';
+
+type DialogToolbarProps = {
+  title: string;
+  hideCloseIcon?: boolean;
+  closeCB?: () => void;
+};
+
+const Button = styled.button`
+  background: none;
+  border: none;
+  margin: 0;
+  padding: 0;
+  cursor: pointer;
+  position: absolute;
+  top: 10px;
+  left: 5px;
+`;
+
+const Div = styled.div<UiReactPrivateElementProps>`
+  ${(props) => getThemeStyling(props.customTheme, props.selectedTheme, dialogToolbarMapper)}
+
+  border-style: solid;
+  border-width: 0 0 5px 0;
+  text-align: center;
+  padding-top: 5px;
+  padding-bottom: 5px;
+`;
+
+export const DialogToolbar: React.FC<DialogToolbarProps> = ({ closeCB, hideCloseIcon, title }: DialogToolbarProps) => {
+  const theme = React.useContext(ThemeContext);
+
+  return (
+    <Div customTheme={theme.theme} selectedTheme={theme.selectedTheme}>
+      {!hideCloseIcon && <Button onClick={closeCB}>❌</Button>}
+      {title}
+    </Div>
+  );
+};
+
+DialogToolbar.displayName = 'DialogToolbar';

--- a/packages/dialog/src/__private/index.ts
+++ b/packages/dialog/src/__private/index.ts
@@ -1,3 +1,4 @@
 export * from './dialog-background';
 export * from './dialog-content';
+export * from './dialog-toolbar';
 export * from './dialog-wrapper';

--- a/packages/dialog/src/theme/dialog-toolbar-mapper.ts
+++ b/packages/dialog/src/theme/dialog-toolbar-mapper.ts
@@ -1,0 +1,11 @@
+import { ColorCategories, ColorTokens, ThemeMapper } from '@uireact/foundation';
+
+export const dialogToolbarMapper: ThemeMapper = {
+  normal: {
+    'border-color': {
+      category: ColorCategories.backgrounds,
+      inverse: false,
+      token: ColorTokens.token_10,
+    },
+  },
+};

--- a/packages/dialog/src/theme/index.ts
+++ b/packages/dialog/src/theme/index.ts
@@ -1,1 +1,2 @@
+export * from './dialog-toolbar-mapper';
 export * from './mapper';

--- a/packages/dialog/src/theme/mapper.ts
+++ b/packages/dialog/src/theme/mapper.ts
@@ -5,7 +5,7 @@ export const mapper: ThemeMapper = {
     background: {
       category: ColorCategories.backgrounds,
       inverse: false,
-      token: ColorTokens.token_10,
+      token: ColorTokens.token_50,
     },
     color: {
       category: ColorCategories.fonts,

--- a/packages/dialog/src/types/ui-dialog-props.ts
+++ b/packages/dialog/src/types/ui-dialog-props.ts
@@ -11,8 +11,12 @@ export enum UiDialogType {
 export type UiDialogProps = {
   /** Dialog id */
   dialogId: string;
+  /** Hide X icon */
+  hideCloseIcon?: boolean;
   /** Position where the dialog will be rendered */
   type?: UiDialogType;
+  /** Dialog title */
+  title?: string;
 } & UiReactElementProps;
 
 export type privateUiDialogProps = {

--- a/packages/dialog/src/ui-dialog.tsx
+++ b/packages/dialog/src/ui-dialog.tsx
@@ -4,7 +4,7 @@ import styled from 'styled-components';
 
 import { ThemeContext } from '@uireact/foundation';
 
-import { DialogBackground, DialogContent, DialogWrapper } from './__private';
+import { DialogBackground, DialogContent, DialogToolbar, DialogWrapper } from './__private';
 
 import { UiDialogProps, UiDialogType } from './types';
 import { useDialog } from '.';
@@ -24,6 +24,8 @@ export const UiDialog: React.FC<UiDialogProps> = ({
   children,
   dialogId,
   type = UiDialogType.CENTERED,
+  hideCloseIcon,
+  title,
 }: UiDialogProps) => {
   const { isOpen, actions } = useDialog(dialogId);
   const theme = React.useContext(ThemeContext);
@@ -56,7 +58,8 @@ export const UiDialog: React.FC<UiDialogProps> = ({
   if (type !== UiDialogType.CENTERED) {
     return (
       <DialogContent customTheme={theme.theme} selectedTheme={theme.selectedTheme} type={type}>
-        <Button onClick={closeCB}>❌</Button>
+        {title && <DialogToolbar title={title} hideCloseIcon={hideCloseIcon} closeCB={closeCB} />}
+        {!title && !hideCloseIcon && <Button onClick={closeCB}>❌</Button>}
         {children}
       </DialogContent>
     );
@@ -67,7 +70,8 @@ export const UiDialog: React.FC<UiDialogProps> = ({
       <>
         <DialogBackground onClick={closeCB} />
         <DialogContent customTheme={theme.theme} selectedTheme={theme.selectedTheme} type={type}>
-          <Button onClick={closeCB}>❌</Button>
+          {title && <DialogToolbar title={title} hideCloseIcon={hideCloseIcon} closeCB={closeCB} />}
+          {!title && !hideCloseIcon && <Button onClick={closeCB}>❌</Button>}
           {children}
         </DialogContent>
       </>


### PR DESCRIPTION
## 🔥 Dialog toolbar
----------------------------------------------

### Description
Adding dialog toolbar to render dialog title and also adding prop to hide close dialog icon

### Screenshots

#### Before
<img width="358" alt="Screenshot 2023-05-08 at 6 16 41 PM" src="https://user-images.githubusercontent.com/16787893/236969660-06e64719-d026-4de3-967f-ec4e878a3762.png">


#### After
<img width="435" alt="Screenshot 2023-05-08 at 6 06 00 PM" src="https://user-images.githubusercontent.com/16787893/236969626-499331d0-8871-4936-bec8-bba22cca689c.png">

