### PR TITLE
feat(dialog): using uiheading in dialog toolbar

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -32,6 +32,7 @@
         "@uireact/card": "file:packages/card/src/",
         "@uireact/dialog": "file:packages/dialog/src/",
         "@uireact/foundation": "file:packages/foundation/src/",
+        "@uireact/text": "file:packages/text/src/",
         "@uireact/view": "file:packages/view/src/",
         "@wojtekmaj/enzyme-adapter-react-17": "^0.6.0",
         "babel-plugin-styled-components": "^1.12.0",
@@ -6041,6 +6042,10 @@
     },
     "node_modules/@uireact/foundation": {
       "resolved": "packages/foundation/src",
+      "link": true
+    },
+    "node_modules/@uireact/text": {
+      "resolved": "packages/text/src",
       "link": true
     },
     "node_modules/@uireact/view": {
@@ -38442,6 +38447,9 @@
     "packages/foundationsrc": {
       "extraneous": true
     },
+    "packages/text/src": {
+      "dev": true
+    },
     "packages/view": {
       "name": "@uireact/view",
       "version": "0.1.0",
@@ -42606,6 +42614,9 @@
     },
     "@uireact/foundation": {
       "version": "file:packages/foundation/src"
+    },
+    "@uireact/text": {
+      "version": "file:packages/text/src"
     },
     "@uireact/view": {
       "version": "file:packages/view/src"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "@uireact/card": "file:packages/card/src/",
     "@uireact/dialog": "file:packages/dialog/src/",
     "@uireact/foundation": "file:packages/foundation/src/",
+    "@uireact/text": "file:packages/text/src/",
     "@uireact/view": "file:packages/view/src/",
     "@wojtekmaj/enzyme-adapter-react-17": "^0.6.0",
     "babel-plugin-styled-components": "^1.12.0",

--- a/packages/dialog/docs/utils/DialogsExample.tsx
+++ b/packages/dialog/docs/utils/DialogsExample.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
 import { UiButton } from '@uireact/button';
-import { DefaultTheme, Sizing, ThemeColor, UiSpacing } from '@uireact/foundation';
+import { DefaultTheme, Sizing, TextSize, ThemeColor, UiSpacing } from '@uireact/foundation';
 import { UiView } from '@uireact/view';
+import { UiText } from '@uireact/text';
 
 import { UiDialog, UiDialogType, useDialog } from '../../src';
 
@@ -23,8 +24,8 @@ export const DialogsExample: React.FC<DialogsExampleProps> = ({ type, title, hid
     <UiView theme={DefaultTheme} selectedTheme={ThemeColor.dark}>
       <UiButton onClick={onClickCB}>Open dialog</UiButton>
       <UiDialog dialogId="example" type={type} title={title} hideCloseIcon={hideCloseIcon}>
-        <UiSpacing margin={{ inline: Sizing.four }}>
-          <p>Some content</p>
+        <UiSpacing margin={{ all: Sizing.four }}>
+          <UiText size={TextSize.large}>Some content</UiText>
         </UiSpacing>
       </UiDialog>
     </UiView>

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -24,11 +24,13 @@
     "watch": "npm run tsc:watch"
   },
   "devDependencies": {
-    "@uireact/foundation": "^0.7.1"
+    "@uireact/foundation": "^0.7.1",
+    "@uireact/text": "^0.0.1"
   },
   "peerDependencies": {
     "@types/styled-components": "^5.1.0",
     "@uireact/foundation": "^0.7.1",
+    "@uireact/text": "^0.0.1",
     "react": ">= 17 < 19",
     "react-dom": ">= 17 < 19",
     "styled-components": "^5.1.1",

--- a/packages/dialog/src/__private/dialog-toolbar.tsx
+++ b/packages/dialog/src/__private/dialog-toolbar.tsx
@@ -4,6 +4,8 @@ import styled from 'styled-components';
 
 import { UiReactPrivateElementProps, getThemeStyling, ThemeContext } from '@uireact/foundation';
 
+import { UiHeading } from '@uireact/text';
+
 import { dialogToolbarMapper } from '../theme/dialog-toolbar-mapper';
 
 type DialogToolbarProps = {
@@ -28,7 +30,6 @@ const Div = styled.div<UiReactPrivateElementProps>`
 
   border-style: solid;
   border-width: 0 0 5px 0;
-  text-align: center;
   padding-top: 5px;
   padding-bottom: 5px;
 `;
@@ -39,7 +40,7 @@ export const DialogToolbar: React.FC<DialogToolbarProps> = ({ closeCB, hideClose
   return (
     <Div customTheme={theme.theme} selectedTheme={theme.selectedTheme}>
       {!hideCloseIcon && <Button onClick={closeCB}>❌</Button>}
-      {title}
+      <UiHeading centered>{title}</UiHeading>
     </Div>
   );
 };

--- a/packages/dialog/src/__private/dialog-wrapper.tsx
+++ b/packages/dialog/src/__private/dialog-wrapper.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 type DialogWrapperProps = {
-  children: React.ReactElement;
+  children?: React.ReactElement;
 };
 
 const Div = styled.div`

--- a/packages/dialog/src/ui-dialog.tsx
+++ b/packages/dialog/src/ui-dialog.tsx
@@ -15,9 +15,7 @@ const Button = styled.button`
   margin: 0;
   padding: 0;
   cursor: pointer;
-  position: absolute;
-  top: 5px;
-  left: 5px;
+  padding-left: 10px;
 `;
 
 export const UiDialog: React.FC<UiDialogProps> = ({

--- a/packages/foundation/src/spacing/spacing.tsx
+++ b/packages/foundation/src/spacing/spacing.tsx
@@ -23,7 +23,6 @@ type SizingDistribution = {
 };
 
 export type UiSpacingProps = UiReactElementProps & {
-  children: React.ReactNode;
   /** Margin to use based on [SizingDistribution](./packages-foundation-docs-spacing#sizingdistribution) */
   margin?: SizingDistribution;
   /** Padding to use based on [SizingDistribution](./packages-foundation-docs-spacing#sizingdistribution) */

--- a/packages/text/docs/docs.mdx
+++ b/packages/text/docs/docs.mdx
@@ -22,7 +22,7 @@ import { UiText, UiHeading } from '../src';
 
 ## Installation
 
-> npm i @uireact/foundation @uireact/button
+> npm i @uireact/foundation @uireact/text
 
 ## UiText
 


### PR DESCRIPTION
## 🔥 Using UiHeading inside dialog toolbar
----------------------------------------------

### Description
Using UiHeading as it will wrap the text correctly in theme styling.

### Screenshots

#### Before
<img width="398" alt="Screenshot 2023-05-08 at 9 19 03 PM" src="https://user-images.githubusercontent.com/16787893/236992878-9d918af3-a7cb-49d3-8cbf-cb61b5c63f0d.png">



#### After
<img width="365" alt="Screenshot 2023-05-08 at 9 18 44 PM" src="https://user-images.githubusercontent.com/16787893/236992852-10392724-0b74-4e59-b24e-5693b25d4483.png">

