### PR TITLE
fix(checkbox): hide checkbox

### DIFF
--- a/packages/form/__tests__/ui-checkbox.spec.tsx
+++ b/packages/form/__tests__/ui-checkbox.spec.tsx
@@ -9,45 +9,48 @@ describe('<UiCheckbox />', () => {
   it('renders fine with label', () => {
     uiRender(<UiCheckbox label="Select this" name="checkbox" />);
 
-    expect(screen.getByRole('checkbox', { name: 'Select this' })).toBeVisible();
+    expect(screen.getByRole('checkbox', { hidden: true })).toBeInTheDocument();
+    expect(screen.getByRole('checkbox', { hidden: true })).not.toBeVisible();
+    expect(screen.getByText('Select this')).toBeVisible();
   });
 
   it('renders fine with label is at start', () => {
     uiRender(<UiCheckbox label="Select this" name="checkbox" labelPosition="START" />);
 
-    expect(screen.getByRole('checkbox', { name: 'Select this' })).toBeVisible();
+    expect(screen.getByRole('checkbox', { hidden: true })).toBeInTheDocument();
+    expect(screen.getByText('Select this')).toBeVisible();
   });
 
   it('renders fine when disabled', () => {
     uiRender(<UiCheckbox label="Select this" name="checkbox" disabled />);
 
-    expect(screen.getByRole('checkbox', { name: 'Select this' })).toBeDisabled();
+    expect(screen.getByRole('checkbox', { hidden: true })).toBeInTheDocument();
   });
 
   it('renders fine when using positive theme', () => {
     uiRender(<UiCheckbox name="checkbox" theme="POSITIVE" />);
 
-    expect(screen.getByRole('checkbox')).toBeVisible();
+    expect(screen.getByRole('checkbox', { hidden: true })).toBeInTheDocument();
   });
 
-  it('Is checked when clicked', () => {
+  it('Is checked when label is clicked', () => {
     uiRender(<UiCheckbox label="Select this" name="checkbox" />);
 
-    expect(screen.getByRole('checkbox', { name: 'Select this' })).not.toBeChecked();
-    expect(screen.getByRole('checkbox', { name: 'Select this' })).toBeVisible();
+    expect(screen.getByRole('checkbox', { hidden: true })).not.toBeChecked();
+    expect(screen.getByRole('checkbox', { hidden: true })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Select this' }));
+    fireEvent.click(screen.getByText('Select this'));
 
-    expect(screen.getByRole('checkbox', { name: 'Select this' })).toBeChecked();
+    expect(screen.getByRole('checkbox', { hidden: true })).toBeChecked();
   });
 
   it('Executes callback when clicked', () => {
     const onChangeCB = jest.fn();
     uiRender(<UiCheckbox label="Select this" name="checkbox" onChange={onChangeCB} />);
 
-    expect(screen.getByRole('checkbox', { name: 'Select this' })).toBeVisible();
+    expect(screen.getByRole('checkbox', { hidden: true })).toBeInTheDocument();
 
-    fireEvent.click(screen.getByRole('checkbox', { name: 'Select this' }));
+    fireEvent.click(screen.getByText('Select this'));
 
     expect(onChangeCB).toHaveBeenCalledTimes(1);
   });

--- a/packages/form/src/ui-checkbox.tsx
+++ b/packages/form/src/ui-checkbox.tsx
@@ -26,6 +26,7 @@ const Label = styled.label<privateCheckboxProps>`
 const CheckboxInput = styled.input<privateCheckboxProps>`
   height: 0;
   width: 0;
+  visibility: hidden;
 
   :checked + label .ui-react-checkbox-button {
     left: calc(100% - 2px);


### PR DESCRIPTION
## 🔥 UiCheckbox - hide input
----------------------------------------------

### Description
I'm hiding the checkbox input as the label is what shows the animation and should be used to check/uncheck the input.

### Screenshots

#### Before
<img width="347" alt="Screenshot 2023-05-10 at 2 26 57 PM" src="https://github.com/inavac182/uireact/assets/16787893/bd500c10-8ff7-4819-815c-080283ef681c">

#### After
<img width="278" alt="Screenshot 2023-05-10 at 2 27 04 PM" src="https://github.com/inavac182/uireact/assets/16787893/dc47f1cb-fd85-4bfd-a8eb-fb08076eea34">
