### PR TITLE
feat(menu): adding fullscreenOnMobile impl

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,4 +1,7 @@
 // eslint-disable-next-line no-undef
 module.exports = {
+  flags: {
+    DEV_SSR: true,
+  },
   plugins: [`gatsby-plugin-styled-components`],
 };

--- a/packages/dialog/__tests__/ui-dialog.spec.tsx
+++ b/packages/dialog/__tests__/ui-dialog.spec.tsx
@@ -11,9 +11,12 @@ type MockedComponentProps = {
   type?: UiDialogType;
   title?: string;
   hideCloseIcon?: boolean;
+  handleDialogClose?: () => void;
 };
 
-const MockedComponent = ({ hideCloseIcon, title, type }: MockedComponentProps) => {
+const handleDialogClose = jest.fn();
+
+const MockedComponent = ({ hideCloseIcon, title, type, handleDialogClose }: MockedComponentProps) => {
   const { actions } = useDialog('mockedDialog');
   const seconDialogData = useDialog('secondDialog');
 
@@ -29,7 +32,13 @@ const MockedComponent = ({ hideCloseIcon, title, type }: MockedComponentProps) =
     <>
       <button onClick={openCB}>Open Dialog</button>
       <button onClick={openSecondCB}>Open Second Dialog</button>
-      <UiDialog dialogId="mockedDialog" type={type} title={title} hideCloseIcon={hideCloseIcon}>
+      <UiDialog
+        dialogId="mockedDialog"
+        type={type}
+        title={title}
+        handleDialogClose={handleDialogClose}
+        hideCloseIcon={hideCloseIcon}
+      >
         <p>Dialog content</p>
       </UiDialog>
     </>
@@ -62,8 +71,12 @@ const MockedNotCorrectlySetupComponent = () => {
 };
 
 describe('<UiDialog />', () => {
+  afterEach(() => {
+    handleDialogClose.mockClear();
+  });
+
   it('opens and closes dialog using ❌ button', () => {
-    uiRender(<MockedComponent />);
+    uiRender(<MockedComponent handleDialogClose={handleDialogClose} />);
 
     expect(screen.queryByText('Dialog content')).not.toBeInTheDocument();
     fireEvent.click(screen.getByText('Open Dialog'));
@@ -72,10 +85,11 @@ describe('<UiDialog />', () => {
     fireEvent.click(screen.getByRole('button', { name: '❌' }));
 
     expect(screen.queryByText('Dialog content')).not.toBeInTheDocument();
+    expect(handleDialogClose).toHaveBeenCalledTimes(1);
   });
 
   it('opens and closes dialog using esc key', () => {
-    uiRender(<MockedComponent />);
+    uiRender(<MockedComponent handleDialogClose={handleDialogClose} />);
 
     expect(screen.queryByText('Dialog content')).not.toBeInTheDocument();
     fireEvent.click(screen.getByText('Open Dialog'));
@@ -85,6 +99,7 @@ describe('<UiDialog />', () => {
     fireEvent.keyDown(dialog, { key: 'Escape', code: 'Escape' });
 
     expect(screen.queryByText('Dialog content')).not.toBeInTheDocument();
+    expect(handleDialogClose).toHaveBeenCalledTimes(1);
   });
 
   it('opens and closes dialog when is type bottom', () => {
@@ -202,7 +217,9 @@ describe('<UiDialog />', () => {
     });
 
     it('Should close dialog using close icon inside dialog toolbar', () => {
-      uiRender(<MockedComponent title="Dialog toolbar" type={UiDialogType.FULLSCREEN} />);
+      uiRender(
+        <MockedComponent title="Dialog toolbar" type={UiDialogType.FULLSCREEN} handleDialogClose={handleDialogClose} />
+      );
 
       expect(screen.queryByText('Dialog content')).not.toBeInTheDocument();
       fireEvent.click(screen.getByText('Open Dialog'));
@@ -213,6 +230,7 @@ describe('<UiDialog />', () => {
       fireEvent.click(screen.getByRole('button', { name: '❌' }));
 
       expect(screen.queryByText('Dialog content')).not.toBeInTheDocument();
+      expect(handleDialogClose).toHaveBeenCalledTimes(1);
     });
   });
 

--- a/packages/dialog/src/types/ui-dialog-props.ts
+++ b/packages/dialog/src/types/ui-dialog-props.ts
@@ -17,6 +17,8 @@ export type UiDialogProps = {
   type?: UiDialogType;
   /** Dialog title */
   title?: string;
+  /** CB to be triggered when dialog is closed */
+  handleDialogClose?: () => void;
 } & UiReactElementProps;
 
 export type privateUiDialogProps = {

--- a/packages/dialog/src/ui-dialog.tsx
+++ b/packages/dialog/src/ui-dialog.tsx
@@ -21,6 +21,7 @@ const Button = styled.button`
 export const UiDialog: React.FC<UiDialogProps> = ({
   children,
   dialogId,
+  handleDialogClose,
   type = UiDialogType.CENTERED,
   hideCloseIcon,
   title,
@@ -30,6 +31,7 @@ export const UiDialog: React.FC<UiDialogProps> = ({
 
   const closeCB = React.useCallback(() => {
     actions.closeDialog();
+    handleDialogClose?.();
   }, [actions]);
 
   const escCB = React.useCallback(

--- a/packages/foundation/__tests__/hooks/get-window.dimensions.spec.ts
+++ b/packages/foundation/__tests__/hooks/get-window.dimensions.spec.ts
@@ -1,0 +1,15 @@
+/**
+ * @jest-environment node
+ */
+
+import { getWindowDimensions } from '../../src/hooks/utils/get-window-deimensions';
+import { BreakpointsSizes } from '../../src/responsive/breakpoints-sizes';
+
+describe('getWindowDimensions', () => {
+  it('Should get default value when window is not present', () => {
+    const { width, height } = getWindowDimensions();
+
+    expect(width).toBe(BreakpointsSizes.l.min);
+    expect(height).toBe(BreakpointsSizes.l.min);
+  });
+});

--- a/packages/foundation/__tests__/hooks/use-viewport.spec.ts
+++ b/packages/foundation/__tests__/hooks/use-viewport.spec.ts
@@ -1,0 +1,57 @@
+import { renderHook } from '@testing-library/react-hooks/server';
+
+import { useViewport } from '../../src';
+
+describe('useViewport', () => {
+  it('returns isSmall truthy when is small breakpoint', () => {
+    global.innerWidth = 350;
+
+    const { result, hydrate } = renderHook(() => useViewport());
+
+    hydrate();
+
+    expect(result.current.isSmall).toBeTruthy();
+    expect(result.current.isMedium).toBeFalsy();
+    expect(result.current.isLarge).toBeFalsy();
+    expect(result.current.isXLarge).toBeFalsy();
+  });
+
+  it('returns isMedium truthy when is medium breakpoint', () => {
+    global.innerWidth = 500;
+
+    const { result, hydrate } = renderHook(() => useViewport());
+
+    hydrate();
+
+    expect(result.current.isSmall).toBeTruthy();
+    expect(result.current.isMedium).toBeFalsy();
+    expect(result.current.isLarge).toBeFalsy();
+    expect(result.current.isXLarge).toBeFalsy();
+  });
+
+  it('returns isLarge truthy when is large breakpoint', () => {
+    global.innerWidth = 1000;
+
+    const { result, hydrate } = renderHook(() => useViewport());
+
+    hydrate();
+
+    expect(result.current.isSmall).toBeFalsy();
+    expect(result.current.isMedium).toBeFalsy();
+    expect(result.current.isLarge).toBeTruthy();
+    expect(result.current.isXLarge).toBeFalsy();
+  });
+
+  it('returns isXLarge truthy when is xlarge breakpoint', () => {
+    global.innerWidth = 1450;
+
+    const { result, hydrate } = renderHook(() => useViewport());
+
+    hydrate();
+
+    expect(result.current.isSmall).toBeFalsy();
+    expect(result.current.isMedium).toBeFalsy();
+    expect(result.current.isLarge).toBeFalsy();
+    expect(result.current.isXLarge).toBeTruthy();
+  });
+});

--- a/packages/foundation/__tests__/hooks/use-window-dimensions.spec.ts
+++ b/packages/foundation/__tests__/hooks/use-window-dimensions.spec.ts
@@ -3,28 +3,51 @@ import { renderHook } from '@testing-library/react-hooks/server';
 import { BreakpointsSizes } from '../../src/responsive/breakpoints-sizes';
 import { useWindowDimensions } from '../../src/hooks/use-window-dimensions';
 
-test('useWindowDimensions() returns correct sizing when is hydrated', () => {
-  const { result, hydrate } = renderHook(() => useWindowDimensions());
+describe('useWindowDimensions', () => {
+  test('useWindowDimensions() returns correct sizing when is hydrated', () => {
+    const { result, hydrate } = renderHook(() => useWindowDimensions());
 
-  hydrate();
+    hydrate();
 
-  expect(result.current.width).toBe(window.innerWidth);
-  expect(result.current.height).toBe(window.innerHeight);
-});
+    expect(result.current.width).toBe(window.innerWidth);
+    expect(result.current.height).toBe(window.innerHeight);
+  });
 
-test('useWindowDimensions() returns correct size when is NOT hydrated', () => {
-  const { result } = renderHook(() => useWindowDimensions());
+  test('useWindowDimensions() defaults to large size when window.innerWidth is null', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    //@ts-ignore
+    global.window.innerWidth = null;
+    const { result } = renderHook(() => useWindowDimensions());
 
-  expect(result.current.width).toBe(BreakpointsSizes.l.min);
-});
+    expect(result.current.width).toBe(BreakpointsSizes.l.min);
+  });
 
-test('useWindowDimensions() call window.addEventListener when hydrated', () => {
-  const addEventListener = global.addEventListener;
-  global.addEventListener = jest.fn();
-  const { hydrate } = renderHook(() => useWindowDimensions());
+  test('useWindowDimensions() defaults to large size when window.innerHeight is null', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    //@ts-ignore
+    global.window.innerHeight = null;
+    const { result } = renderHook(() => useWindowDimensions());
 
-  hydrate();
+    expect(result.current.width).toBe(BreakpointsSizes.l.min);
+  });
 
-  expect(global.addEventListener).toHaveBeenCalled();
-  global.addEventListener = addEventListener;
+  test('useWindowDimensions() defaults to large size when window is null', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    //@ts-ignore
+    global.window = null;
+    const { result } = renderHook(() => useWindowDimensions());
+
+    expect(result.current.width).toBe(BreakpointsSizes.l.min);
+  });
+
+  test('useWindowDimensions() call window.addEventListener when hydrated', () => {
+    const addEventListener = global.addEventListener;
+    global.addEventListener = jest.fn();
+    const { hydrate } = renderHook(() => useWindowDimensions());
+
+    hydrate();
+
+    expect(global.addEventListener).toHaveBeenCalled();
+    global.addEventListener = addEventListener;
+  });
 });

--- a/packages/foundation/__tests__/hooks/use-window-dimensions.spec.ts
+++ b/packages/foundation/__tests__/hooks/use-window-dimensions.spec.ts
@@ -1,6 +1,5 @@
 import { renderHook } from '@testing-library/react-hooks/server';
 
-import { BreakpointsSizes } from '../../src/responsive/breakpoints-sizes';
 import { useWindowDimensions } from '../../src/hooks/use-window-dimensions';
 
 describe('useWindowDimensions', () => {
@@ -11,33 +10,6 @@ describe('useWindowDimensions', () => {
 
     expect(result.current.width).toBe(window.innerWidth);
     expect(result.current.height).toBe(window.innerHeight);
-  });
-
-  test('useWindowDimensions() defaults to large size when window.innerWidth is null', () => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    //@ts-ignore
-    global.window.innerWidth = null;
-    const { result } = renderHook(() => useWindowDimensions());
-
-    expect(result.current.width).toBe(BreakpointsSizes.l.min);
-  });
-
-  test('useWindowDimensions() defaults to large size when window.innerHeight is null', () => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    //@ts-ignore
-    global.window.innerHeight = null;
-    const { result } = renderHook(() => useWindowDimensions());
-
-    expect(result.current.width).toBe(BreakpointsSizes.l.min);
-  });
-
-  test('useWindowDimensions() defaults to large size when window is null', () => {
-    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-    //@ts-ignore
-    global.window = null;
-    const { result } = renderHook(() => useWindowDimensions());
-
-    expect(result.current.width).toBe(BreakpointsSizes.l.min);
   });
 
   test('useWindowDimensions() call window.addEventListener when hydrated', () => {

--- a/packages/foundation/src/hooks/index.ts
+++ b/packages/foundation/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './use-viewport';

--- a/packages/foundation/src/hooks/use-viewport.ts
+++ b/packages/foundation/src/hooks/use-viewport.ts
@@ -1,0 +1,25 @@
+import { useWindowDimensions } from './use-window-dimensions';
+import { BreakpointsSizes } from '../responsive/breakpoints-sizes';
+
+type useViewportResponse = {
+  isSmall: boolean;
+  isMedium: boolean;
+  isLarge: boolean;
+  isXLarge: boolean;
+};
+
+export const useViewport = (): useViewportResponse => {
+  const { width } = useWindowDimensions();
+
+  const isSmall = width <= BreakpointsSizes.s.max;
+  const isMedium = width >= BreakpointsSizes.m.min && width <= BreakpointsSizes.m.max;
+  const isLarge = width >= BreakpointsSizes.l.min && width < BreakpointsSizes.xl.min;
+  const isXLarge = width >= BreakpointsSizes.xl.min;
+
+  return {
+    isSmall,
+    isMedium,
+    isLarge,
+    isXLarge,
+  };
+};

--- a/packages/foundation/src/hooks/use-window-dimensions.ts
+++ b/packages/foundation/src/hooks/use-window-dimensions.ts
@@ -1,27 +1,5 @@
 import { useState, useEffect } from 'react';
-
-import { BreakpointsSizes } from '../responsive/breakpoints-sizes';
-
-interface WindowDimensions {
-  width: number;
-  height: number;
-}
-
-const getWindowDimensions = (): WindowDimensions => {
-  if (!window || !window.innerWidth || !window.innerHeight) {
-    return {
-      width: BreakpointsSizes.l.min,
-      height: BreakpointsSizes.l.min,
-    };
-  }
-
-  const { innerWidth: width, innerHeight: height } = window;
-
-  return {
-    width,
-    height,
-  };
-};
+import { WindowDimensions, getWindowDimensions } from './utils/get-window-deimensions';
 
 export const useWindowDimensions = (): WindowDimensions => {
   const [windowDimensions, setWindowDimensions] = useState(getWindowDimensions());

--- a/packages/foundation/src/hooks/use-window-dimensions.ts
+++ b/packages/foundation/src/hooks/use-window-dimensions.ts
@@ -8,6 +8,13 @@ interface WindowDimensions {
 }
 
 const getWindowDimensions = (): WindowDimensions => {
+  if (!window || !window.innerWidth || !window.innerHeight) {
+    return {
+      width: BreakpointsSizes.l.min,
+      height: BreakpointsSizes.l.min,
+    };
+  }
+
   const { innerWidth: width, innerHeight: height } = window;
 
   return {
@@ -17,10 +24,7 @@ const getWindowDimensions = (): WindowDimensions => {
 };
 
 export const useWindowDimensions = (): WindowDimensions => {
-  const [windowDimensions, setWindowDimensions] = useState({
-    width: BreakpointsSizes.l.min,
-    height: BreakpointsSizes.l.min,
-  });
+  const [windowDimensions, setWindowDimensions] = useState(getWindowDimensions());
 
   useEffect(() => {
     const handleResize = (): void => {
@@ -31,10 +35,6 @@ export const useWindowDimensions = (): WindowDimensions => {
 
     return (): void => window.removeEventListener('resize', handleResize);
   });
-
-  useEffect(() => {
-    setWindowDimensions(getWindowDimensions());
-  }, []);
 
   return windowDimensions;
 };

--- a/packages/foundation/src/hooks/utils/get-window-deimensions.ts
+++ b/packages/foundation/src/hooks/utils/get-window-deimensions.ts
@@ -1,0 +1,22 @@
+import { BreakpointsSizes } from '../../responsive/breakpoints-sizes';
+
+export interface WindowDimensions {
+  width: number;
+  height: number;
+}
+
+export const getWindowDimensions = (): WindowDimensions => {
+  if (typeof window !== 'undefined') {
+    const { innerWidth: width, innerHeight: height } = window;
+
+    return {
+      width,
+      height,
+    };
+  }
+
+  return {
+    width: BreakpointsSizes.l.min,
+    height: BreakpointsSizes.l.min,
+  };
+};

--- a/packages/foundation/src/index.ts
+++ b/packages/foundation/src/index.ts
@@ -1,3 +1,4 @@
+export * from './hooks';
 export * from './providers';
 export * from './responsive';
 export * from './spacing';

--- a/packages/foundation/src/responsive/viewport.tsx
+++ b/packages/foundation/src/responsive/viewport.tsx
@@ -1,10 +1,9 @@
 import * as React from 'react';
 
 import { Breakpoints } from '../types';
-import { useWindowDimensions } from '../hooks/use-window-dimensions';
-import { BreakpointsSizes } from './breakpoints-sizes';
+import { useViewport } from '../hooks';
 
-type BreakpointString = 's|m' | 'm|l' | 'l|xl';
+type BreakpointString = 's|m' | 'm|l' | 'l|xl' | 'm|l|xl';
 
 interface ViewportProps {
   children?: React.ReactNode;
@@ -13,12 +12,8 @@ interface ViewportProps {
 }
 
 export const UiViewport: React.FC<ViewportProps> = ({ children, criteria }) => {
-  const { width } = useWindowDimensions();
+  const { isSmall, isMedium, isLarge, isXLarge } = useViewport();
   const childrenMemo = React.useMemo(() => <>{children}</>, [children]);
-  const isSmall = width <= BreakpointsSizes.s.max;
-  const isMedium = width >= BreakpointsSizes.m.min && width <= BreakpointsSizes.m.max;
-  const isLarge = width >= BreakpointsSizes.l.min && width < BreakpointsSizes.xl.min;
-  const isXLarge = width >= BreakpointsSizes.xl.min;
 
   if (isSmall) {
     const matchesCriteria = criteria === Breakpoints.SMALL || criteria === 's|m';
@@ -28,7 +23,8 @@ export const UiViewport: React.FC<ViewportProps> = ({ children, criteria }) => {
   }
 
   if (isMedium) {
-    const matchesCriteria = criteria === Breakpoints.MEDIUM || criteria === 's|m' || criteria === 'm|l';
+    const matchesCriteria =
+      criteria === Breakpoints.MEDIUM || criteria === 's|m' || criteria === 'm|l' || criteria === 'm|l|xl';
 
     if (matchesCriteria) {
       return childrenMemo;
@@ -36,7 +32,8 @@ export const UiViewport: React.FC<ViewportProps> = ({ children, criteria }) => {
   }
 
   if (isLarge) {
-    const matchesCriteria = criteria === Breakpoints.LARGE || criteria === 'm|l' || criteria === 'l|xl';
+    const matchesCriteria =
+      criteria === Breakpoints.LARGE || criteria === 'm|l' || criteria === 'l|xl' || criteria === 'm|l|xl';
 
     if (matchesCriteria) {
       return childrenMemo;
@@ -44,7 +41,7 @@ export const UiViewport: React.FC<ViewportProps> = ({ children, criteria }) => {
   }
 
   if (isXLarge) {
-    const matchesCriteria = criteria === Breakpoints.XLARGE || criteria === 'l|xl';
+    const matchesCriteria = criteria === Breakpoints.XLARGE || criteria === 'l|xl' || criteria === 'm|l|xl';
 
     if (matchesCriteria) {
       return childrenMemo;

--- a/packages/menu/docs/utils/menu-example.tsx
+++ b/packages/menu/docs/utils/menu-example.tsx
@@ -29,7 +29,7 @@ export const MenuExample: React.FC = () => {
         <div>
           <UiButton onClick={handleMenuOpen}>Open Menu</UiButton>
         </div>
-        <UiMenu visible={isVisible} closeMenuCB={closeMenu}>
+        <UiMenu visible={isVisible} closeMenuCB={closeMenu} fullscreenOnSmall>
           <UiSpacing margin={{ all: Sizing.five }}>
             <UiText centered>Menu Content</UiText>
             <div>

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -24,11 +24,13 @@
     "watch": "npm run tsc:watch"
   },
   "devDependencies": {
-    "@uireact/foundation": "^0.7.1"
+    "@uireact/foundation": "^0.7.1",
+    "@uireact/dialog": "^0.4.0"
   },
   "peerDependencies": {
     "@types/styled-components": "^5.1.0",
     "@uireact/foundation": "^0.7.1",
+    "@uireact/dialog": "^0.4.0",
     "react": ">= 17 < 19",
     "react-dom": ">= 17 < 19",
     "styled-components": "^5.1.1",

--- a/packages/menu/src/types/menu-props.ts
+++ b/packages/menu/src/types/menu-props.ts
@@ -3,6 +3,8 @@ import { UiReactElementProps, UiReactPrivateElementProps } from '@uireact/founda
 export type UiMenuProps = {
   /** If the menu should go to fullscreen on small breakpoint */
   fullscreenOnSmall?: boolean;
+  /** Menu identifier to be used when is fullscreen on small */
+  menuId?: string;
   /** Menu visibility, default FALSE */
   visible: boolean;
   /** CB for when menu is closed */


### PR DESCRIPTION
## 🔥 UiMenu with fullscreenOnMobile
----------------------------------------------

### Description
Adding implementation for fullscreenOnMobile, which makes the menu to render as a dialog when is small breakpoint, useful for use cases where the menus are small to interact with when is a small breakpoint.

### Screenshots

#### Before
<img width="554" alt="Screenshot 2023-05-10 at 9 59 00 PM" src="https://github.com/inavac182/uireact/assets/16787893/81fdfbae-2ab9-4249-aac9-34f0a41df237">

#### After
![May-10-2023 21-23-59](https://github.com/inavac182/uireact/assets/16787893/95092973-9410-4cd9-a368-fa92c4b3425f)
