### PR TITLE
fix(icon): adding fill support for coloration

### DIFF
--- a/packages/foundation/src/types/theme-mapper.ts
+++ b/packages/foundation/src/types/theme-mapper.ts
@@ -16,6 +16,7 @@ export enum ThemeMapperStyles {
   color = 'color',
   background = 'background',
   borderColor = 'border-color',
+  fill = 'fill',
 }
 
 export type ThemeMapperValue = {

--- a/packages/icons/docs/utils/icons-list.tsx
+++ b/packages/icons/docs/utils/icons-list.tsx
@@ -27,7 +27,8 @@ export const IconsList: React.FC = () => {
               <UiGridItem key={`icon-grid-item-component-${key}`}>
                 <UiText size={TextSize.xlarge} centered>
                   <UiIcon icon={key} />
-                  <UiText>{key}</UiText>
+                  <br />
+                  {key}
                 </UiText>
               </UiGridItem>
             ))}

--- a/packages/icons/src/theme/icon-mapper.ts
+++ b/packages/icons/src/theme/icon-mapper.ts
@@ -8,6 +8,11 @@ export const getDynamicMapper = (category: ColorCategories): ThemeMapper => {
         inverse: false,
         token: ColorTokens.token_100,
       },
+      fill: {
+        category: category,
+        inverse: true,
+        token: ColorTokens.token_100,
+      },
     },
   };
 };

--- a/packages/icons/src/ui-icon.tsx
+++ b/packages/icons/src/ui-icon.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { ColorCategories, TextSize, ThemeContext, getTextSize, getThemeStyling } from '@uireact/foundation';
+import { ColorCategories, ThemeContext, getThemeStyling } from '@uireact/foundation';
 
 import { UiIconProps, privateIconProps } from './types';
 import { getDynamicMapper } from './theme';
@@ -15,10 +15,6 @@ const Span = styled.span<privateIconProps>`
       props.selectedTheme,
       getDynamicMapper(props.category || ColorCategories.fonts)
     )}
-
-    img {
-      width: ${getTextSize(props.customTheme, props.size || TextSize.small)};
-    }
   `}
 `;
 


### PR DESCRIPTION
## 🔥 UiIcon color
----------------------------------------------

### Description
Adding support for `fill` property in theme mapper so we can set the SVG color the same as text and controlled by the theme.

### Screenshots

#### After
![May-13-2023 18-49-27](https://github.com/inavac182/uireact/assets/16787893/72cc313d-3c1e-4b6d-a749-7f8d994ceaf2)

#### Before
![May-13-2023 18-49-22](https://github.com/inavac182/uireact/assets/16787893/072885f8-1b04-414e-b375-4a7808913604)

