### PR TITLE
feat(foundation): adding warning color category

### DIFF
--- a/packages/foundation/__tests__/themes/get-color-category.spec.ts
+++ b/packages/foundation/__tests__/themes/get-color-category.spec.ts
@@ -1,0 +1,60 @@
+import { ColorCategories } from '@uireact/foundation';
+import { getColorCategory } from '../../src';
+
+describe('getColorCategory', () => {
+  it('Should get correct category when is primary', () => {
+    const category = getColorCategory('primary');
+
+    expect(category).toBe(ColorCategories.primary);
+  });
+
+  it('Should get correct category when is secondary', () => {
+    const category = getColorCategory('secondary');
+
+    expect(category).toBe(ColorCategories.secondary);
+  });
+
+  it('Should get correct category when is tertiary', () => {
+    const category = getColorCategory('tertiary');
+
+    expect(category).toBe(ColorCategories.tertiary);
+  });
+
+  it('Should get correct category when is positive', () => {
+    const category = getColorCategory('positive');
+
+    expect(category).toBe(ColorCategories.positive);
+  });
+
+  it('Should get correct category when is negative', () => {
+    const category = getColorCategory('negative');
+
+    expect(category).toBe(ColorCategories.negative);
+  });
+
+  it('Should get correct category when is error', () => {
+    const category = getColorCategory('error');
+
+    expect(category).toBe(ColorCategories.error);
+  });
+
+  it('Should get correct category when is warning', () => {
+    const category = getColorCategory('warning');
+
+    expect(category).toBe(ColorCategories.warning);
+  });
+
+  it('Should get default category when is null', () => {
+    const category = getColorCategory();
+
+    expect(category).toBe(ColorCategories.fonts);
+  });
+
+  it('Should get default category when is unrecognized', () => {
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    //@ts-ignore
+    const category = getColorCategory('XXXXX');
+
+    expect(category).toBe(ColorCategories.fonts);
+  });
+});

--- a/packages/foundation/docs/themes.mdx
+++ b/packages/foundation/docs/themes.mdx
@@ -84,7 +84,7 @@ export const DefaultTheme: Theme = {
 Our take on UX design nowadays is that you should be ready to provide with 2 colorations in your UI, dark and light, this to help
 the UX of your applications when used during daylight 🌞 or during night time 🌙
 
-In our theme structure you will see 2 props `dark` and `light`, so each of them is typed as `Color`. The [Color type](https://github.com/inavac182/uireact/blob/main/packages/foundation/src/types/themes/internal/colors.ts#L4)
+In our theme structure you will see 2 props `dark` and `light`, so each of them is typed as `Color`. The [Coloration type](https://github.com/inavac182/uireact/blob/main/packages/foundation/src/types/themes/internal/coloration.ts#L4)
 is generated from the enum [ColorCategories](https://github.com/inavac182/uireact/blob/main/packages/foundation/src/types/enums/color-categories.ts#L1) and this is its structure:
 
 ```
@@ -104,9 +104,11 @@ is generated from the enum [ColorCategories](https://github.com/inavac182/uireac
     positive: { ... },
       ▶︎ Commonly used to show a reaction to an action that was successfully performed, e.g. A form submition.
     negative: { ... },
-      ▶︎ Used to show a fallback action, meaning the less ideal action that we intend our users to do
+      ▶︎ Used to show a fallback action, meaning the less ideal action that we intend our users to do.
     error: { ... },
       ▶︎ As its name says, this is used to show bright error messages, e.g. A form submittion that failed to be validated.
+    warning: { ... },
+      ▶︎ Used to show a warning message, for instance an expiration messaging.
   },
   ...
 }
@@ -115,7 +117,7 @@ is generated from the enum [ColorCategories](https://github.com/inavac182/uireac
 
 ### Tokens
 
-Each coloration should include 5 levels of the main color, these are referrer to as tokens:
+Each coloration should include 5 levels of color, each level is referrer to it as token, the token 100 is the main base color:
 
 ```
 {

--- a/packages/foundation/docs/viewport.mdx
+++ b/packages/foundation/docs/viewport.mdx
@@ -51,8 +51,8 @@ The [Breakpoints](./packages-foundation-docs-breakpoints#definition) enum is use
 ### Multiple breakpoints
 
 <Playground>
-  <UiViewport criteria="l|s">
-    <UiBox>Hey, I appear in Large and Small!!</UiBox>
+  <UiViewport criteria="m|l|xl">
+    <UiBox>Hey, I appear in medium, large and xlarge!!</UiBox>
   </UiViewport>
 </Playground>
 

--- a/packages/foundation/src/themes/default-colors/dark.ts
+++ b/packages/foundation/src/themes/default-colors/dark.ts
@@ -1,6 +1,6 @@
-import { Colors } from '../../types/themes/internal';
+import { Coloration } from '../../types/themes/internal';
 
-export const Dark: Colors = {
+export const Dark: Coloration = {
   backgrounds: {
     token_10: '#135a9c',
     token_50: '#054580',
@@ -56,5 +56,12 @@ export const Dark: Colors = {
     token_100: '#FD6A6A',
     token_150: '#FF5A5A',
     token_200: '#FF3D3D',
+  },
+  warning: {
+    token_10: '#EFE804',
+    token_50: '#DED802',
+    token_100: '#C8C204',
+    token_150: '#BFB903',
+    token_200: '#ACA702',
   },
 };

--- a/packages/foundation/src/themes/default-colors/light.ts
+++ b/packages/foundation/src/themes/default-colors/light.ts
@@ -1,6 +1,6 @@
-import { Colors } from '../../types/themes/internal';
+import { Coloration } from '../../types/themes/internal';
 
-export const Light: Colors = {
+export const Light: Coloration = {
   backgrounds: {
     token_10: '#fcfcfc',
     token_50: '#fcf7f7',
@@ -56,5 +56,12 @@ export const Light: Colors = {
     token_100: '#FD6A6A',
     token_150: '#FF5A5A',
     token_200: '#FF3D3D',
+  },
+  warning: {
+    token_10: '#FCEE2F',
+    token_50: '#EEE12D',
+    token_100: '#E8DB27',
+    token_150: '#D8CC20',
+    token_200: '#CBC01B',
   },
 };

--- a/packages/foundation/src/themes/get-color-category.ts
+++ b/packages/foundation/src/themes/get-color-category.ts
@@ -1,0 +1,22 @@
+import { ColorCategories, ColorCategory } from '../types/enums/color-categories';
+
+export const getColorCategory = (category?: ColorCategory): ColorCategories => {
+  switch (category) {
+    case 'error':
+      return ColorCategories.error;
+    case 'warning':
+      return ColorCategories.warning;
+    case 'negative':
+      return ColorCategories.negative;
+    case 'positive':
+      return ColorCategories.positive;
+    case 'primary':
+      return ColorCategories.primary;
+    case 'secondary':
+      return ColorCategories.secondary;
+    case 'tertiary':
+      return ColorCategories.tertiary;
+    default:
+      return ColorCategories.fonts;
+  }
+};

--- a/packages/foundation/src/themes/index.ts
+++ b/packages/foundation/src/themes/index.ts
@@ -1,4 +1,5 @@
 export * from './default-theme';
+export * from './get-color-category';
 export * from './get-next-theme-token';
 export * from './get-theme-color';
 export * from './get-theme-styling';

--- a/packages/foundation/src/types/enums/color-categories.ts
+++ b/packages/foundation/src/types/enums/color-categories.ts
@@ -7,4 +7,13 @@ export enum ColorCategories {
   positive = 'positive',
   negative = 'negative',
   error = 'error',
+  warning = 'warning',
 }
+
+/**
+ * The intention of this type is that we can use it to set props from components that can have
+ * different colorations. E.G.
+ *
+ * <UiBadge theme="primary" /> where `theme` prop could be typed as ColorCategory.
+ */
+export type ColorCategory = 'primary' | 'secondary' | 'tertiary' | 'positive' | 'negative' | 'error' | 'warning';

--- a/packages/foundation/src/types/enums/color-tokens.ts
+++ b/packages/foundation/src/types/enums/color-tokens.ts
@@ -5,3 +5,5 @@ export enum ColorTokens {
   token_150 = 'token_150',
   token_200 = 'token_200',
 }
+
+export type Token = '10' | '50' | '100' | '150' | '200';

--- a/packages/foundation/src/types/enums/color-tokens.ts
+++ b/packages/foundation/src/types/enums/color-tokens.ts
@@ -6,4 +6,11 @@ export enum ColorTokens {
   token_200 = 'token_200',
 }
 
+/**
+ * The intention of this type is that we can use it to set props from components that can have
+ * different weight colorations. E.G.
+ *
+ * <UiText weight="50" /> where `weight` correspond to a different level of token
+ */
+
 export type Token = '10' | '50' | '100' | '150' | '200';

--- a/packages/foundation/src/types/themes/internal/coloration.ts
+++ b/packages/foundation/src/types/themes/internal/coloration.ts
@@ -1,6 +1,6 @@
 import { Tokens } from '.';
 import { ColorCategories } from '../../enums';
 
-export type Colors = {
+export type Coloration = {
   [key in ColorCategories]: Tokens;
 };

--- a/packages/foundation/src/types/themes/internal/index.ts
+++ b/packages/foundation/src/types/themes/internal/index.ts
@@ -1,4 +1,4 @@
-export * from './colors';
+export * from './coloration';
 export * from './sizes';
 export * from './texts';
 export * from './spacing';

--- a/packages/foundation/src/types/themes/theme.ts
+++ b/packages/foundation/src/types/themes/theme.ts
@@ -1,4 +1,4 @@
-import { Texts, Sizes, Colors, Spacing } from './internal';
+import { Texts, Sizes, Coloration, Spacing } from './internal';
 
 export type Theme = {
   /** Identifier of the theme */
@@ -8,9 +8,9 @@ export type Theme = {
   /** Set of sizes for theme */
   sizes: Sizes;
   /** Set of color tokens for the light theme */
-  light: Colors;
+  light: Coloration;
   /** Set of color tokens for the dark theme */
-  dark: Colors;
+  dark: Coloration;
   /** Set of tokens spacing */
   spacing: Spacing;
 };


### PR DESCRIPTION
## 🔥 Adding warning color category
----------------------------------------------

### Description
Adding `warning` color category to themes coloration.

### Screenshots

#### Before
<img width="1394" alt="Screenshot 2023-05-14 at 10 46 17 PM" src="https://github.com/inavac182/uireact/assets/16787893/c1d8597b-b129-46a5-9289-965b664b7410">


#### After
<img width="1315" alt="Screenshot 2023-05-14 at 10 45 58 PM" src="https://github.com/inavac182/uireact/assets/16787893/a693e08c-dcf7-4b24-95c2-8d858130627e">

