### PR TITLE
feat(grid): adding GridBreakpointsDistribution

### DIFF
--- a/packages/button/docs/button.mdx
+++ b/packages/button/docs/button.mdx
@@ -42,7 +42,7 @@ import * as packageJson from '../package.json';
 #### With fullWidth
 
 <Playground>
-  <UiGrid cols={2} rows={1} colsGap="20px" justifyItems="center">
+  <UiGrid cols={2} rows={1} colsGap={20} justifyItems="center">
     <UiButton fullWidth>
       <UiSpacing margin={{ all: Sizing.three }}>Button! 💅🏾</UiSpacing>
     </UiButton>
@@ -67,7 +67,7 @@ import * as packageJson from '../package.json';
 #### Types of button:
 
 <Playground>
-  <UiGrid cols={7} colsGap="5px" justifyItems="center">
+  <UiGrid cols={{ small: 1, medium: 5, large: 7, xlarge: 7 }} colsGap={5} rowsGap={5} justifyItems="center">
     <UiButton fullWidth>
       <UiSpacing margin={{ all: Sizing.three }}>Button! 🐬</UiSpacing>
     </UiButton>

--- a/packages/foundation/src/hooks/use-viewport.ts
+++ b/packages/foundation/src/hooks/use-viewport.ts
@@ -1,7 +1,7 @@
 import { useWindowDimensions } from './use-window-dimensions';
 import { BreakpointsSizes } from '../responsive/breakpoints-sizes';
 
-type useViewportResponse = {
+export type useViewportResponse = {
   isSmall: boolean;
   isMedium: boolean;
   isLarge: boolean;

--- a/packages/grid/__tests__/grid.spec.tsx
+++ b/packages/grid/__tests__/grid.spec.tsx
@@ -1,11 +1,91 @@
 import * as React from 'react';
-import { render, screen } from '@testing-library/react';
+import { act, render, screen } from '@testing-library/react';
 
 import { UiGrid, UiGridItem } from '../src';
+
+beforeEach(() => {
+  global.innerWidth = 1200;
+});
 
 test('renders the grid when is rendered with 2 items', () => {
   render(
     <UiGrid cols={2} justifyItems="center" colsGap={3} rowsGap={10}>
+      <UiGridItem placeSelf="center">Item 1</UiGridItem>
+      <UiGridItem>Item 2</UiGridItem>
+    </UiGrid>
+  );
+
+  expect(screen.getByText('Item 1')).toBeVisible();
+  expect(screen.getByText('Item 2')).toBeVisible();
+});
+
+test('renders the grid when using a breakpoints object as cols', () => {
+  global.innerWidth = 300;
+
+  const MockedComponent = () => (
+    <UiGrid cols={{ small: 1, medium: 1, large: 2, xlarge: 2 }} justifyItems="center" colsGap={3} rowsGap={10}>
+      <UiGridItem placeSelf="center">Item 1</UiGridItem>
+      <UiGridItem>Item 2</UiGridItem>
+    </UiGrid>
+  );
+
+  const { rerender } = render(<MockedComponent />);
+
+  expect(screen.getByText('Item 1')).toBeVisible();
+  expect(screen.getByText('Item 2')).toBeVisible();
+
+  act(() => {
+    global.innerWidth = 600;
+    global.dispatchEvent(new Event('resize'));
+  });
+
+  rerender(<MockedComponent />);
+
+  expect(screen.getByText('Item 1')).toBeVisible();
+  expect(screen.getByText('Item 2')).toBeVisible();
+
+  act(() => {
+    global.innerWidth = 1050;
+    global.dispatchEvent(new Event('resize'));
+  });
+
+  rerender(<MockedComponent />);
+
+  expect(screen.getByText('Item 1')).toBeVisible();
+  expect(screen.getByText('Item 2')).toBeVisible();
+
+  act(() => {
+    global.innerWidth = 1500;
+    global.dispatchEvent(new Event('resize'));
+  });
+
+  rerender(<MockedComponent />);
+
+  expect(screen.getByText('Item 1')).toBeVisible();
+  expect(screen.getByText('Item 2')).toBeVisible();
+});
+
+test('renders the grid when using a breakpoints object is unrecognized', () => {
+  global.innerWidth = 1500;
+
+  const MockedComponent = () => (
+    // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+    //@ts-ignore
+    <UiGrid cols="XXXX" justifyItems="center" colsGap={3} rowsGap={10}>
+      <UiGridItem placeSelf="center">Item 1</UiGridItem>
+      <UiGridItem>Item 2</UiGridItem>
+    </UiGrid>
+  );
+
+  render(<MockedComponent />);
+
+  expect(screen.getByText('Item 1')).toBeVisible();
+  expect(screen.getByText('Item 2')).toBeVisible();
+});
+
+test('renders the grid when using a breakpoints object as rows', () => {
+  render(
+    <UiGrid rows={{ small: 1, medium: 1, large: 2, xlarge: 2 }} justifyItems="center" colsGap={3} rowsGap={10}>
       <UiGridItem placeSelf="center">Item 1</UiGridItem>
       <UiGridItem>Item 2</UiGridItem>
     </UiGrid>

--- a/packages/grid/docs/grid.mdx
+++ b/packages/grid/docs/grid.mdx
@@ -68,7 +68,7 @@ import * as packageJson from '../package.json';
 
 > Also notice that in Item 1 we are making use of the [UiViewport](./packages-foundation-docs-viewport) to render/remove it depending on the breakpoint
 
-### 1. Using GridBreakpointsDistribution prop
+### 3. Using GridBreakpointsDistribution prop
 
 <Playground>
   <UiGrid cols={{ small: 1, medium: 2, large: 3, xlarge: 3 }} rows={2} colsGap={20} rowsGap={10}>

--- a/packages/grid/docs/grid.mdx
+++ b/packages/grid/docs/grid.mdx
@@ -68,6 +68,22 @@ import * as packageJson from '../package.json';
 
 > Also notice that in Item 1 we are making use of the [UiViewport](./packages-foundation-docs-viewport) to render/remove it depending on the breakpoint
 
+### 1. Using GridBreakpointsDistribution prop
+
+<Playground>
+  <UiGrid cols={{ small: 1, medium: 2, large: 3, xlarge: 3 }} rows={2} colsGap={20} rowsGap={10}>
+    <UiCard>
+      <UiText>Item 1!</UiText>
+    </UiCard>
+    <UiCard>
+      <UiText>Item 2!</UiText>
+    </UiCard>
+    <UiCard>
+      <UiText>Item 3!</UiText>
+    </UiCard>
+  </UiGrid>
+</Playground>
+
 ## UiGrid Props
 
 <Props of={UiGrid} />

--- a/packages/grid/docs/grid.mdx
+++ b/packages/grid/docs/grid.mdx
@@ -21,7 +21,7 @@ import * as packageJson from '../package.json';
   </a>
 </sup>
 
-> Structure and organize the UI
+> Structure and organize the UI using columns
 
 ## Installation
 
@@ -69,6 +69,8 @@ import * as packageJson from '../package.json';
 > Also notice that in Item 1 we are making use of the [UiViewport](./packages-foundation-docs-viewport) to render/remove it depending on the breakpoint
 
 ### 3. Using GridBreakpointsDistribution prop
+
+This prop give you the ability to set a number of cols/rows depending on the breakpoint.
 
 <Playground>
   <UiGrid cols={{ small: 1, medium: 2, large: 3, xlarge: 3 }} rows={2} colsGap={20} rowsGap={10}>

--- a/packages/grid/src/grid.tsx
+++ b/packages/grid/src/grid.tsx
@@ -1,13 +1,23 @@
 import React from 'react';
+
 import styled from 'styled-components';
 
+import { useViewport, useViewportResponse } from '@uireact/foundation';
+
 import { getGridTemplate } from './private';
+
+export type GridBreakpointsDistribution = {
+  small: number;
+  medium: number;
+  large: number;
+  xlarge: number;
+};
 
 interface GridProps {
   /** Sets the grid-auto-flow property */
   autoFlow?: 'row' | 'column' | 'row dense' | 'column dense';
   /** Number of columns that the grid will have, default is 1 */
-  cols?: number;
+  cols?: number | GridBreakpointsDistribution;
   /** Gap between each colum */
   colsGap?: number;
   /** Size of each col: px or % */
@@ -21,14 +31,14 @@ interface GridProps {
   /** Sets the justify property of all grid items */
   justifyItems?: 'start' | 'end' | 'center' | 'stretch';
   /** Number of rows that the grid will have, default is 1 */
-  rows?: number;
+  rows?: number | GridBreakpointsDistribution;
   /** Gap between each row */
   rowsGap?: number;
   /** Size of each row: px or % */
   rowSize?: string;
 }
 
-type UiGridProps = GridProps & {
+export type UiGridProps = GridProps & {
   children?: React.ReactNode;
 };
 
@@ -46,6 +56,61 @@ const Div = styled.div<GridProps>`
   `}
 `;
 
-export const UiGrid: React.FC<UiGridProps> = (props: UiGridProps) => <Div {...props}>{props.children}</Div>;
+const getSpanValueFromBreakpoint = (
+  viewport: useViewportResponse,
+  gridBreakpointsDistribution: GridBreakpointsDistribution
+): number => {
+  if (viewport.isSmall) {
+    return gridBreakpointsDistribution.small;
+  }
+
+  if (viewport.isMedium) {
+    return gridBreakpointsDistribution.medium;
+  }
+
+  if (viewport.isLarge) {
+    return gridBreakpointsDistribution.large;
+  }
+
+  // istanbul ignore next
+  if (viewport.isXLarge) {
+    return gridBreakpointsDistribution.xlarge;
+  }
+
+  // istanbul ignore next
+  return 1;
+};
+
+export const UiGrid: React.FC<UiGridProps> = (props: UiGridProps) => {
+  const viewport = useViewport();
+  const cols = !props.cols
+    ? 1
+    : typeof props.cols === 'number'
+    ? props.cols
+    : getSpanValueFromBreakpoint(viewport, props.cols);
+  const rows = !props.rows
+    ? 1
+    : typeof props.rows === 'number'
+    ? props.rows
+    : getSpanValueFromBreakpoint(viewport, props.rows);
+
+  return (
+    <Div
+      autoFlow={props.autoFlow}
+      cols={cols}
+      colsGap={props.colsGap}
+      colSize={props.colSize}
+      gridHeight={props.gridHeight}
+      gridWidth={props.gridWidth}
+      inlineGrid={props.inlineGrid}
+      justifyItems={props.justifyItems}
+      rows={rows}
+      rowsGap={props.rowsGap}
+      rowSize={props.rowSize}
+    >
+      {props.children}
+    </Div>
+  );
+};
 
 UiGrid.displayName = 'UiGrid';

--- a/packages/grid/src/grid.tsx
+++ b/packages/grid/src/grid.tsx
@@ -5,44 +5,9 @@ import styled from 'styled-components';
 import { useViewport, useViewportResponse } from '@uireact/foundation';
 
 import { getGridTemplate } from './private';
+import { GridBreakpointsDistribution, UiGridProps, privateGridProps } from './types';
 
-export type GridBreakpointsDistribution = {
-  small: number;
-  medium: number;
-  large: number;
-  xlarge: number;
-};
-
-interface GridProps {
-  /** Sets the grid-auto-flow property */
-  autoFlow?: 'row' | 'column' | 'row dense' | 'column dense';
-  /** Number of columns that the grid will have, default is 1 */
-  cols?: number | GridBreakpointsDistribution;
-  /** Gap between each colum */
-  colsGap?: number;
-  /** Size of each col: px or % */
-  colSize?: string;
-  /** Total width of the grid */
-  gridWidth?: string;
-  /** Total height of the grid */
-  gridHeight?: string;
-  /** Sets if the grid items will be inline */
-  inlineGrid?: boolean;
-  /** Sets the justify property of all grid items */
-  justifyItems?: 'start' | 'end' | 'center' | 'stretch';
-  /** Number of rows that the grid will have, default is 1 */
-  rows?: number | GridBreakpointsDistribution;
-  /** Gap between each row */
-  rowsGap?: number;
-  /** Size of each row: px or % */
-  rowSize?: string;
-}
-
-export type UiGridProps = GridProps & {
-  children?: React.ReactNode;
-};
-
-const Div = styled.div<GridProps>`
+const Div = styled.div<privateGridProps>`
   ${(props) => `
     display: ${props.inlineGrid ? 'inline-grid' : 'grid'};
     ${getGridTemplate(props.cols, props.colSize, 'cols')}
@@ -97,6 +62,7 @@ export const UiGrid: React.FC<UiGridProps> = (props: UiGridProps) => {
   return (
     <Div
       autoFlow={props.autoFlow}
+      className={props.className}
       cols={cols}
       colsGap={props.colsGap}
       colSize={props.colSize}

--- a/packages/grid/src/index.ts
+++ b/packages/grid/src/index.ts
@@ -1,2 +1,3 @@
 export * from './grid';
 export * from './grid-item';
+export type { UiGridProps, GridBreakpointsDistribution } from './types';

--- a/packages/grid/src/private/calculate-grid-template.ts
+++ b/packages/grid/src/private/calculate-grid-template.ts
@@ -1,4 +1,11 @@
-export const getGridTemplate = (spans = 1, size = '1fr', template: 'cols' | 'rows'): string =>
-  `${template === 'cols' ? 'grid-template-columns' : 'grid-template-rows'}: repeat(${spans}, ${
+import { GridBreakpointsDistribution } from '../';
+
+export const getGridTemplate = (
+  spans: number | GridBreakpointsDistribution = 1,
+  size = '1fr',
+  template: 'cols' | 'rows'
+): string => {
+  return `${template === 'cols' ? 'grid-template-columns' : 'grid-template-rows'}: repeat(${spans}, ${
     size === '' ? '1fr' : size
   });`;
+};

--- a/packages/grid/src/private/calculate-grid-template.ts
+++ b/packages/grid/src/private/calculate-grid-template.ts
@@ -1,11 +1,4 @@
-import { GridBreakpointsDistribution } from '../';
-
-export const getGridTemplate = (
-  spans: number | GridBreakpointsDistribution = 1,
-  size = '1fr',
-  template: 'cols' | 'rows'
-): string => {
-  return `${template === 'cols' ? 'grid-template-columns' : 'grid-template-rows'}: repeat(${spans}, ${
+export const getGridTemplate = (spans = 1, size = '1fr', template: 'cols' | 'rows'): string =>
+  `${template === 'cols' ? 'grid-template-columns' : 'grid-template-rows'}: repeat(${spans}, ${
     size === '' ? '1fr' : size
   });`;
-};

--- a/packages/grid/src/types/grid-props.ts
+++ b/packages/grid/src/types/grid-props.ts
@@ -1,0 +1,38 @@
+import { UiReactElementProps } from '@uireact/foundation';
+
+export type GridBreakpointsDistribution = {
+  small: number;
+  medium: number;
+  large: number;
+  xlarge: number;
+};
+
+export type UiGridProps = {
+  /** Sets the grid-auto-flow property */
+  autoFlow?: 'row' | 'column' | 'row dense' | 'column dense';
+  /** Number of columns that the grid will have, default is 1 */
+  cols?: number | GridBreakpointsDistribution;
+  /** Gap between each colum */
+  colsGap?: number;
+  /** Size of each col: px or % */
+  colSize?: string;
+  /** Total width of the grid */
+  gridWidth?: string;
+  /** Total height of the grid */
+  gridHeight?: string;
+  /** Sets if the grid items will be inline */
+  inlineGrid?: boolean;
+  /** Sets the justify property of all grid items */
+  justifyItems?: 'start' | 'end' | 'center' | 'stretch';
+  /** Number of rows that the grid will have, default is 1 */
+  rows?: number | GridBreakpointsDistribution;
+  /** Gap between each row */
+  rowsGap?: number;
+  /** Size of each row: px or % */
+  rowSize?: string;
+} & UiReactElementProps;
+
+export type privateGridProps = UiGridProps & {
+  cols: number;
+  rows: number;
+};

--- a/packages/grid/src/types/index.ts
+++ b/packages/grid/src/types/index.ts
@@ -1,0 +1,1 @@
+export * from './grid-props';


### PR DESCRIPTION
## 🔥 UiGrid using breakpoints for sizing
----------------------------------------------

### Description
I've added a prop for breakpoints distribution so we can set up different values for cols / rows depending on the breakpoint the user is currently. 

### Screenshots

#### Before
<img width="666" alt="Screenshot 2023-05-16 at 9 01 24 PM" src="https://github.com/inavac182/uireact/assets/16787893/66e95919-6626-425f-9fa7-bc497b39f967">


#### After
![May-16-2023 21-03-11](https://github.com/inavac182/uireact/assets/16787893/aa24865c-f23d-43ff-8de8-10988c84cc44)

