### PR TITLE
feat(dialog): adding default dialog controller

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,7 +40,7 @@ At the time of putting this doc together these are the ones you need:
 Once the peers are installed you can go ahead and install the @uireact packages, let's start with the most important ones:
 
 ```
-npm i @uireact/foundation @uireact/view
+npm i @uireact/foundation @uireact/view @uireact/dialog
 ```
 
 ## 3. Create your theme ✨

--- a/packages/dialog/__tests__/hooks/use-dialog-controller.spec.tsx
+++ b/packages/dialog/__tests__/hooks/use-dialog-controller.spec.tsx
@@ -1,0 +1,64 @@
+import { renderHook } from '@testing-library/react-hooks/server';
+import { act } from '@testing-library/react';
+
+import { useDialogController } from '@uireact/dialog/hooks';
+
+describe('useDialogController', () => {
+  it('Should retrieve correct controller', () => {
+    const { result } = renderHook(() => useDialogController());
+
+    expect(result.current.openedDialogs).toHaveLength(0);
+    expect(result.current.openDialog).not.toBeNull();
+    expect(result.current.closeDialog).not.toBeNull();
+  });
+
+  it('Should add dialogs', () => {
+    const { result, hydrate } = renderHook(() => useDialogController());
+
+    hydrate();
+    act(() => {
+      result.current.openDialog('newDialog');
+    });
+
+    expect(result.current.openedDialogs).toHaveLength(1);
+    expect(result.current.openedDialogs[0]).toBe('newDialog');
+  });
+
+  it('Should NOT add the same dialog twice', () => {
+    const { result, hydrate } = renderHook(() => useDialogController());
+
+    hydrate();
+    act(() => {
+      result.current.openDialog('newDialog');
+    });
+
+    expect(result.current.openedDialogs).toHaveLength(1);
+    expect(result.current.openedDialogs[0]).toBe('newDialog');
+
+    act(() => {
+      result.current.openDialog('newDialog');
+    });
+
+    expect(result.current.openedDialogs).toHaveLength(1);
+    expect(result.current.openedDialogs[0]).toBe('newDialog');
+  });
+
+  it('Should remove dialogs', () => {
+    const { result, hydrate } = renderHook(() => useDialogController());
+
+    hydrate();
+
+    act(() => {
+      result.current.openDialog('newDialog');
+    });
+
+    expect(result.current.openedDialogs).toHaveLength(1);
+    expect(result.current.openedDialogs[0]).toBe('newDialog');
+
+    act(() => {
+      result.current.closeDialog('newDialog');
+    });
+
+    expect(result.current.openedDialogs).toHaveLength(0);
+  });
+});

--- a/packages/dialog/src/hooks/index.ts
+++ b/packages/dialog/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './use-dialogs-controller';

--- a/packages/dialog/src/hooks/use-dialogs-controller.ts
+++ b/packages/dialog/src/hooks/use-dialogs-controller.ts
@@ -1,0 +1,32 @@
+import React from 'react';
+import { IDialogController } from '@uireact/dialog';
+
+export const useDialogController = (): IDialogController => {
+  const [openedDialogs, setOpenedDialogs] = React.useState<string[]>([]);
+
+  const openDialog = React.useCallback(
+    (dialogId: string) => {
+      const found = openedDialogs.filter((id) => id === dialogId);
+
+      if (!found || found.length === 0) {
+        const newOpenedDialogs = [...openedDialogs, dialogId];
+        setOpenedDialogs(newOpenedDialogs);
+      }
+    },
+    [openedDialogs, setOpenedDialogs]
+  );
+
+  const closeDialog = React.useCallback(
+    (dialogId: string) => {
+      const newOpenedDialogs = openedDialogs.filter((id) => id !== dialogId);
+      setOpenedDialogs(newOpenedDialogs);
+    },
+    [openedDialogs, setOpenedDialogs]
+  );
+
+  return {
+    openDialog,
+    closeDialog,
+    openedDialogs,
+  };
+};

--- a/packages/dialog/src/index.ts
+++ b/packages/dialog/src/index.ts
@@ -1,3 +1,4 @@
+export * from './hooks';
 export * from './ui-dialog';
 export * from './provider';
 export * from './types';

--- a/packages/view/docs/view.mdx
+++ b/packages/view/docs/view.mdx
@@ -27,7 +27,7 @@ This component will set up the global styles and providers for @uireact to work 
 
 ## Installation ⚙️
 
-> npm i @uireact/foundation @uireact/view
+> npm i @uireact/foundation @uireact/view @uireact/dialog
 
 ## Examples 🤓
 

--- a/packages/view/package.json
+++ b/packages/view/package.json
@@ -24,7 +24,7 @@
     "watch": "npm run tsc:watch"
   },
   "devDependencies": {
-    "@uireact/dialog": "^0.5.3",
+    "@uireact/dialog": "^0.6.0",
     "@uireact/foundation": "^0.17.0"
   },
   "peerDependencies": {

--- a/packages/view/src/types/ui-view-props.ts
+++ b/packages/view/src/types/ui-view-props.ts
@@ -2,7 +2,7 @@ import { Theme, ThemeColor, UiReactElementProps, UiReactPrivateElementProps } fr
 import { IDialogController } from '@uireact/dialog';
 
 export type UiViewProps = {
-  dialogController: IDialogController;
+  dialogController?: IDialogController;
   /** If content should render centered and not fullscreen */
   centeredContent?: boolean;
   /** Selected color from theme */

--- a/packages/view/src/ui-view.tsx
+++ b/packages/view/src/ui-view.tsx
@@ -13,7 +13,7 @@ import {
   getTextSize,
   getThemeColor,
 } from '@uireact/foundation';
-import { UiDialogsControllerContext } from '@uireact/dialog';
+import { UiDialogsControllerContext, useDialogController } from '@uireact/dialog';
 
 import { UiViewProps, privateViewProps } from './types/ui-view-props';
 import { themeMapper } from './theme';
@@ -58,9 +58,11 @@ export const UiView: React.FC<UiViewProps> = ({
   selectedTheme,
   children,
 }: UiViewProps) => {
+  const defaultDialogController = useDialogController();
+
   return (
     <ThemeContext.Provider value={{ theme, selectedTheme }}>
-      <UiDialogsControllerContext.Provider value={dialogController}>
+      <UiDialogsControllerContext.Provider value={dialogController ?? defaultDialogController}>
         <GlobalStyle customTheme={theme} selectedTheme={selectedTheme} />
         <Div customTheme={theme} selectedTheme={selectedTheme} className={className} data-testid="UiView">
           {centeredContent ? (


### PR DESCRIPTION
## 🔥 UiDialog default dialog controller
----------------------------------------------

### Description
Adding a default dialog controller that the `UiView` will use if no dialog context is provided from the client. 

### Screenshots
N/A
