### PR TITLE
BREAKING CHANGE: moving dialog controller to foundation

### DIFF
--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -40,7 +40,7 @@ At the time of putting this doc together these are the ones you need:
 Once the peers are installed you can go ahead and install the @uireact packages, let's start with the most important ones:
 
 ```
-npm i @uireact/foundation @uireact/view @uireact/dialog
+npm i @uireact/foundation @uireact/view
 ```
 
 ## 3. Create your theme ✨

--- a/packages/dialog/src/hooks/index.ts
+++ b/packages/dialog/src/hooks/index.ts
@@ -1,1 +1,1 @@
-export * from './use-dialogs-controller';
+export * from './use-dialog-hook';

--- a/packages/dialog/src/hooks/use-dialog-hook.ts
+++ b/packages/dialog/src/hooks/use-dialog-hook.ts
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { UiDialogsControllerContext } from '.';
+import { UiDialogsControllerContext } from '@uireact/foundation';
 
 type DialogActions = {
   openDialog: () => void;

--- a/packages/dialog/src/index.ts
+++ b/packages/dialog/src/index.ts
@@ -1,4 +1,3 @@
 export * from './hooks';
 export * from './ui-dialog';
-export * from './provider';
 export * from './types';

--- a/packages/dialog/src/provider/index.ts
+++ b/packages/dialog/src/provider/index.ts
@@ -1,2 +1,0 @@
-export * from './dialogs-provider';
-export * from './use-dialog-hook';

--- a/packages/foundation/__tests__/hooks/use-dialog-controller.spec.tsx
+++ b/packages/foundation/__tests__/hooks/use-dialog-controller.spec.tsx
@@ -1,7 +1,7 @@
 import { renderHook } from '@testing-library/react-hooks/server';
 import { act } from '@testing-library/react';
 
-import { useDialogController } from '@uireact/dialog/hooks';
+import { useDialogController } from '../../src/hooks';
 
 describe('useDialogController', () => {
   it('Should retrieve correct controller', () => {

--- a/packages/foundation/__tests__/providers/dialogs-context.spec.tsx
+++ b/packages/foundation/__tests__/providers/dialogs-context.spec.tsx
@@ -1,0 +1,69 @@
+import React from 'react';
+
+import { fireEvent, render, screen } from '@testing-library/react';
+
+import { UiDialogsControllerContext } from '../../src/providers';
+import { IDialogController } from '../../src/types';
+
+const openDialogFn = jest.fn();
+const closeDialogFn = jest.fn();
+
+const dialogContext: IDialogController = {
+  openDialog: openDialogFn,
+  closeDialog: closeDialogFn,
+  openedDialogs: [],
+};
+
+const ChildComponent = () => {
+  const dialogsContext = React.useContext(UiDialogsControllerContext);
+
+  return (
+    <>
+      <button onClick={() => dialogsContext.openDialog('dialog1')}>open</button>
+      <button onClick={() => dialogsContext.closeDialog('dialog2')}>close</button>
+    </>
+  );
+};
+
+const MockedComponent = () => {
+  return (
+    <UiDialogsControllerContext.Provider value={dialogContext}>
+      <ChildComponent />
+    </UiDialogsControllerContext.Provider>
+  );
+};
+
+describe('UiDialogsControllerContext', () => {
+  it('Should execute open dialog fn', () => {
+    render(<MockedComponent />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'open' }));
+
+    expect(openDialogFn).toHaveBeenCalledTimes(1);
+    expect(openDialogFn).toHaveBeenCalledWith('dialog1');
+  });
+
+  it('Should execute close dialog fn', () => {
+    render(<MockedComponent />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'close' }));
+
+    expect(closeDialogFn).toHaveBeenCalledTimes(1);
+    expect(closeDialogFn).toHaveBeenCalledWith('dialog2');
+  });
+
+  it('Should error oute if no dialog provider is set up', () => {
+    const consoleError = console.error;
+
+    console.error = jest.fn();
+
+    render(<ChildComponent />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'open' }));
+
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('No dialog controller implemented');
+
+    console.error = consoleError;
+  });
+});

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@uireact/foundation",
   "description": "Foundation package needed for @uireact packages",
-  "repository": "https://github.com/inavac182/ui-react",
+  "repository": "https://github.com/inavac182/uireact",
   "license": "MIT",
   "version": "0.17.3",
   "publishConfig": {

--- a/packages/foundation/src/hooks/index.ts
+++ b/packages/foundation/src/hooks/index.ts
@@ -1,1 +1,2 @@
+export * from './use-dialogs-controller';
 export * from './use-viewport';

--- a/packages/foundation/src/hooks/use-dialogs-controller.ts
+++ b/packages/foundation/src/hooks/use-dialogs-controller.ts
@@ -1,5 +1,6 @@
 import React from 'react';
-import { IDialogController } from '@uireact/dialog';
+
+import { IDialogController } from '../types';
 
 export const useDialogController = (): IDialogController => {
   const [openedDialogs, setOpenedDialogs] = React.useState<string[]>([]);

--- a/packages/foundation/src/providers/dialogs-context.ts
+++ b/packages/foundation/src/providers/dialogs-context.ts
@@ -1,10 +1,6 @@
 import React from 'react';
 
-export type IDialogController = {
-  openDialog: (dialogId: string) => void;
-  closeDialog: (dialogId: string) => void;
-  openedDialogs: string[];
-};
+import { IDialogController } from '../types';
 
 const noOpDialogControl = () => {
   console.error('No dialog controller implemented');

--- a/packages/foundation/src/providers/index.ts
+++ b/packages/foundation/src/providers/index.ts
@@ -1,1 +1,2 @@
+export * from './dialogs-context';
 export * from './theme-context';

--- a/packages/foundation/src/types/dialog-controller.ts
+++ b/packages/foundation/src/types/dialog-controller.ts
@@ -1,0 +1,5 @@
+export type IDialogController = {
+  openDialog: (dialogId: string) => void;
+  closeDialog: (dialogId: string) => void;
+  openedDialogs: string[];
+};

--- a/packages/foundation/src/types/index.ts
+++ b/packages/foundation/src/types/index.ts
@@ -1,5 +1,6 @@
 export * from './breakpoints-enum';
 export * from './breakpoints-object';
+export * from './dialog-controller';
 export * from './enums';
 export * from './themes';
 export * from './theme-mapper';

--- a/packages/view/__tests__/ui-view.spec.tsx
+++ b/packages/view/__tests__/ui-view.spec.tsx
@@ -1,8 +1,9 @@
 import React from 'react';
 
 import { fireEvent, render, screen } from '@testing-library/react';
-import { DefaultTheme, ThemeColor } from '@uireact/foundation';
-import { IDialogController, UiDialog, useDialog } from '@uireact/dialog';
+
+import { DefaultTheme, ThemeColor, IDialogController } from '@uireact/foundation';
+import { UiDialog, useDialog } from '@uireact/dialog';
 
 import { UiView } from '../src/ui-view';
 

--- a/packages/view/docs/view.mdx
+++ b/packages/view/docs/view.mdx
@@ -27,7 +27,7 @@ This component will set up the global styles and providers for @uireact to work 
 
 ## Installation ⚙️
 
-> npm i @uireact/foundation @uireact/view @uireact/dialog
+> npm i @uireact/foundation @uireact/view
 
 ## Examples 🤓
 

--- a/packages/view/src/types/ui-view-props.ts
+++ b/packages/view/src/types/ui-view-props.ts
@@ -1,5 +1,10 @@
-import { Theme, ThemeColor, UiReactElementProps, UiReactPrivateElementProps } from '@uireact/foundation';
-import { IDialogController } from '@uireact/dialog';
+import {
+  Theme,
+  ThemeColor,
+  UiReactElementProps,
+  UiReactPrivateElementProps,
+  IDialogController,
+} from '@uireact/foundation';
 
 export type UiViewProps = {
   dialogController?: IDialogController;

--- a/packages/view/src/ui-view.tsx
+++ b/packages/view/src/ui-view.tsx
@@ -13,7 +13,7 @@ import {
   getTextSize,
   getThemeColor,
 } from '@uireact/foundation';
-import { UiDialogsControllerContext, useDialogController } from '@uireact/dialog';
+import { UiDialogsControllerContext, useDialogController } from '@uireact/foundation';
 
 import { UiViewProps, privateViewProps } from './types/ui-view-props';
 import { themeMapper } from './theme';


### PR DESCRIPTION
## 🔥 Moving dialog context to foundation
----------------------------------------------

### Description
As the view requires the dialog context and types, I'm moving those to the foundation so consumers doesn't have to install 3 different packages to start using the library.

### Screenshots
N/A