### PR TITLE
refactor(foundation): UiViewport to gate render SSR

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,8 +1,5 @@
 // eslint-disable-next-line no-undef
 module.exports = {
-  flags: {
-    DEV_SSR: true,
-  },
   plugins: [
     `gatsby-plugin-styled-components`,
     {

--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -1,5 +1,8 @@
 // eslint-disable-next-line no-undef
 module.exports = {
+  flags: {
+    DEV_SSR: true,
+  },
   plugins: [
     `gatsby-plugin-styled-components`,
     {

--- a/packages/foundation/__tests__/responsive/viewport.spec.tsx
+++ b/packages/foundation/__tests__/responsive/viewport.spec.tsx
@@ -1,6 +1,7 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
+import ReactDOMServer from 'react-dom/server';
 
 import { Breakpoints, UiViewport } from '../../src';
 import { BreakpointsSizes } from '../../src/responsive/breakpoints-sizes';
@@ -76,6 +77,21 @@ describe('using breakpoint enum', () => {
     });
 
     expect(screen.getByText('Render in small')).toBeVisible();
+  });
+
+  test('should get null if is SSR and skipSSR is enabled', () => {
+    const component = (
+      <UiViewport criteria={Breakpoints.SMALL} skipSSr>
+        <p>Render in small</p>
+      </UiViewport>
+    );
+    const containerComponent = document.createElement('div');
+    document.body.appendChild(containerComponent);
+    containerComponent.innerHTML = ReactDOMServer.renderToString(component);
+
+    const { container } = render(component, { hydrate: true, container: containerComponent });
+
+    expect(container).toBeEmptyDOMElement();
   });
 });
 

--- a/packages/foundation/src/responsive/viewport.tsx
+++ b/packages/foundation/src/responsive/viewport.tsx
@@ -9,17 +9,19 @@ interface ViewportProps {
   children?: React.ReactNode;
   /** Breakpoint(s) criteria where UiViewport render it children see [Breakpoints Enum](./packages-foundation-docs-breakpoints) */
   criteria: Breakpoints | BreakpointString;
+  /* Render null during SSR, useful when SSR doen't play nicely with styled components */
+  skipSSr?: boolean;
 }
 
-export const UiViewport: React.FC<ViewportProps> = ({ children, criteria }: ViewportProps) => {
+export const UiViewport: React.FC<ViewportProps> = ({ children, criteria, skipSSr }: ViewportProps) => {
   const [hydrated, setHydrated] = React.useState(false);
   const { isSmall, isMedium, isLarge, isXLarge } = useViewport();
   React.useEffect(() => {
     setHydrated(true);
   }, []);
 
-  if (!hydrated) {
-    // Returns null on first render, so the client and server match
+  if (!hydrated && skipSSr) {
+    // Returns null on first render if SSR and skipSSr is enabled, so the client and server match
     return null;
   }
 

--- a/packages/foundation/src/responsive/viewport.tsx
+++ b/packages/foundation/src/responsive/viewport.tsx
@@ -12,7 +12,16 @@ interface ViewportProps {
 }
 
 export const UiViewport: React.FC<ViewportProps> = ({ children, criteria }: ViewportProps) => {
+  const [hydrated, setHydrated] = React.useState(false);
   const { isSmall, isMedium, isLarge, isXLarge } = useViewport();
+  React.useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  if (!hydrated) {
+    // Returns null on first render, so the client and server match
+    return null;
+  }
 
   if (isSmall) {
     const matchesCriteria = criteria === Breakpoints.SMALL || criteria === 's|m';

--- a/packages/header/src/ui-header.tsx
+++ b/packages/header/src/ui-header.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { ThemeContext, UiViewport, getThemeStyling } from '@uireact/foundation';
+import { ThemeContext, UiViewport, getThemeStyling, useViewport } from '@uireact/foundation';
 
 import { UiHeaderProps, privateUiHeaderProps } from './types';
 import { CenteredDiv } from './__private';
@@ -29,6 +29,7 @@ const Div = styled.div<privateUiHeaderProps>`
 
 export const UiHeader: React.FC<UiHeaderProps> = ({ centered, children, fixed }: UiHeaderProps) => {
   const themeContext = React.useContext(ThemeContext);
+  const { isLarge } = useViewport();
 
   return (
     <Div
@@ -40,7 +41,7 @@ export const UiHeader: React.FC<UiHeaderProps> = ({ centered, children, fixed }:
       {centered ? (
         <>
           <UiViewport criteria={'l|xl'}>
-            <CenteredDiv size="l">{children}</CenteredDiv>
+            <CenteredDiv size={isLarge ? 'l' : 'xl'}>{children}</CenteredDiv>
           </UiViewport>
           <UiViewport criteria={'s|m'}>{children}</UiViewport>
         </>

--- a/packages/header/src/ui-header.tsx
+++ b/packages/header/src/ui-header.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { Breakpoints, ThemeContext, UiViewport, getThemeStyling } from '@uireact/foundation';
+import { ThemeContext, UiViewport, getThemeStyling } from '@uireact/foundation';
 
 import { UiHeaderProps, privateUiHeaderProps } from './types';
 import { CenteredDiv } from './__private';
@@ -31,13 +31,15 @@ export const UiHeader: React.FC<UiHeaderProps> = ({ centered, children, fixed }:
   const themeContext = React.useContext(ThemeContext);
 
   return (
-    <Div customTheme={themeContext.theme} selectedTheme={themeContext.selectedTheme} fixed={fixed}>
+    <Div
+      customTheme={themeContext.theme}
+      selectedTheme={themeContext.selectedTheme}
+      fixed={fixed}
+      data-testid="UiHeader"
+    >
       {centered ? (
         <>
-          <UiViewport criteria={Breakpoints.XLARGE}>
-            <CenteredDiv size="xl">{children}</CenteredDiv>
-          </UiViewport>
-          <UiViewport criteria={Breakpoints.LARGE}>
+          <UiViewport criteria={'l|xl'}>
             <CenteredDiv size="l">{children}</CenteredDiv>
           </UiViewport>
           <UiViewport criteria={'s|m'}>{children}</UiViewport>

--- a/packages/view/src/ui-view.tsx
+++ b/packages/view/src/ui-view.tsx
@@ -42,7 +42,9 @@ const GlobalStyle = createGlobalStyle<privateViewProps>`
         ColorTokens.token_100
       )};`}
     `}
+
     font-weight: 400;
+    width: 100%;
   }
 `;
 


### PR DESCRIPTION
## 🔥 UiViewport prop to return null in SSR
----------------------------------------------

### Description
So, currently there is an issue with styled components and remix, or any react framework that uses SSR and doesn't expose babel configurations. 

For example for gatsby there is this plugin: https://github.com/inavac182/uireact/blob/main/gatsby-config.js#L4 that is used to enable the babel plugin for styled components.

In addition to this, in remix the whole root updates on hydration, including the head, rather than just a specific element in the react tree.

### Screenshots

N/A
