### PR TITLE
feat(foundation): default to large on SSR UiViewport

### DIFF
--- a/packages/foundation/__tests__/responsive/viewport.spec.tsx
+++ b/packages/foundation/__tests__/responsive/viewport.spec.tsx
@@ -1,7 +1,7 @@
 import * as React from 'react';
 import { render, screen } from '@testing-library/react';
 import { act } from 'react-dom/test-utils';
-import ReactDOMServer from 'react-dom/server';
+import { renderToString } from 'react-dom/server';
 
 import { Breakpoints, UiViewport } from '../../src';
 import { BreakpointsSizes } from '../../src/responsive/breakpoints-sizes';
@@ -78,20 +78,52 @@ describe('using breakpoint enum', () => {
 
     expect(screen.getByText('Render in small')).toBeVisible();
   });
+});
 
-  test('should get null if is SSR and skipSSR is enabled', () => {
-    const component = (
-      <UiViewport criteria={Breakpoints.SMALL} skipSSr>
+describe('SSR', () => {
+  test('should render in SSR when large is in the criteria', () => {
+    global.innerWidth = BreakpointsSizes.m.min;
+    const component = renderToString(
+      <UiViewport criteria={Breakpoints.XLARGE}>
+        <p>Render in large</p>
+      </UiViewport>
+    );
+
+    expect(component).toContain('Render in large');
+  });
+
+  test('should render in SSR when xlarge is in the criteria', () => {
+    global.innerWidth = BreakpointsSizes.m.min;
+    const component = renderToString(
+      <UiViewport criteria={Breakpoints.XLARGE}>
+        <p>Render in xlarge</p>
+      </UiViewport>
+    );
+
+    expect(component).toContain('Render in xlarge');
+  });
+
+  test('should NOT render in SSR when SMALL is in the criteria', () => {
+    global.innerWidth = BreakpointsSizes.s.max;
+
+    const component = renderToString(
+      <UiViewport criteria={Breakpoints.SMALL}>
         <p>Render in small</p>
       </UiViewport>
     );
-    const containerComponent = document.createElement('div');
-    document.body.appendChild(containerComponent);
-    containerComponent.innerHTML = ReactDOMServer.renderToString(component);
 
-    const { container } = render(component, { hydrate: true, container: containerComponent });
+    expect(component).toBe('');
+  });
 
-    expect(container).toBeEmptyDOMElement();
+  test('should NOT render in SSR when skipSsr is provided', () => {
+    global.innerWidth = BreakpointsSizes.m.min;
+    const component = renderToString(
+      <UiViewport criteria={Breakpoints.XLARGE} skipSSr>
+        <p>Render in large</p>
+      </UiViewport>
+    );
+
+    expect(component).toBe('');
   });
 });
 

--- a/packages/foundation/src/hooks/use-viewport.ts
+++ b/packages/foundation/src/hooks/use-viewport.ts
@@ -13,7 +13,7 @@ export const useViewport = (): useViewportResponse => {
 
   const isSmall = width <= BreakpointsSizes.s.max;
   const isMedium = width >= BreakpointsSizes.m.min && width <= BreakpointsSizes.m.max;
-  const isLarge = width >= BreakpointsSizes.l.min && width < BreakpointsSizes.xl.min;
+  const isLarge = width >= BreakpointsSizes.l.min && width <= BreakpointsSizes.l.max;
   const isXLarge = width >= BreakpointsSizes.xl.min;
 
   return {

--- a/packages/foundation/src/responsive/viewport.tsx
+++ b/packages/foundation/src/responsive/viewport.tsx
@@ -9,18 +9,33 @@ interface ViewportProps {
   children?: React.ReactNode;
   /** Breakpoint(s) criteria where UiViewport render it children see [Breakpoints Enum](./packages-foundation-docs-breakpoints) */
   criteria: Breakpoints | BreakpointString;
-  /* Render null during SSR, useful when SSR doen't play nicely with styled components */
+  /* As we are defaulting to large when we are in SSR this prop is useful if you prefer to just render nothing in SSR */
   skipSSr?: boolean;
 }
 
 export const UiViewport: React.FC<ViewportProps> = ({ children, criteria, skipSSr }: ViewportProps) => {
   const [hydrated, setHydrated] = React.useState(false);
   const { isSmall, isMedium, isLarge, isXLarge } = useViewport();
+
   React.useEffect(() => {
     setHydrated(true);
   }, []);
 
-  if (!hydrated && skipSSr) {
+  if (skipSSr && !hydrated) {
+    return null;
+  }
+
+  // Only during SSR we won't take in consideration the user window
+  if (!hydrated) {
+    const isCriteriaLarge =
+      criteria === Breakpoints.LARGE || criteria === 'm|l' || criteria === 'l|xl' || criteria === 'm|l|xl';
+    const isCriteriaXLarge = criteria === Breakpoints.XLARGE || criteria === 'l|xl' || criteria === 'm|l|xl';
+
+    // Only render if criteria is large or Xlarge
+    if (isCriteriaLarge || isCriteriaXLarge) {
+      return <>{children}</>;
+    }
+
     // Returns null on first render if SSR and skipSSr is enabled, so the client and server match
     return null;
   }


### PR DESCRIPTION
## 🔥 UiViewport default to large
----------------------------------------------

### Description
I'm testing default to large and also making sure that the first render on client doesn't change what the server rendered, so we don't have the error logged in the console.

Trying to replicate what is explained here: https://react.dev/reference/react-dom/hydrate#handling-different-client-and-server-content 

### Screenshots

N/A
