### PR TITLE
refactor(input): to extend full width

### DIFF
--- a/packages/form/__tests__/ui-textarea.spec.tsx
+++ b/packages/form/__tests__/ui-textarea.spec.tsx
@@ -12,6 +12,12 @@ describe('<UiTextArea />', () => {
     expect(screen.getByRole('textbox')).toBeVisible();
   });
 
+  it('renders fine with cols', () => {
+    uiRender(<UiTextArea name="text-area" cols={10} />);
+
+    expect(screen.getByRole('textbox')).toBeVisible();
+  });
+
   it('renders fine without name', () => {
     uiRender(<UiTextArea />);
 

--- a/packages/form/src/theme/input-mapper.ts
+++ b/packages/form/src/theme/input-mapper.ts
@@ -70,7 +70,7 @@ export const getDynamicInputMapper = (category: ColorCategories): ThemeMapper =>
       'border-color': {
         category: category,
         inverse: true,
-        token: ColorTokens.token_200,
+        token: ColorTokens.token_100,
       },
     },
     focus: {
@@ -87,7 +87,7 @@ export const getDynamicInputMapper = (category: ColorCategories): ThemeMapper =>
       'border-color': {
         category: category,
         inverse: true,
-        token: ColorTokens.token_200,
+        token: ColorTokens.token_150,
       },
     },
   };

--- a/packages/form/src/theme/textarea-mapper.ts
+++ b/packages/form/src/theme/textarea-mapper.ts
@@ -60,14 +60,14 @@ export const getDynamicTextareaMapper = (category: ColorCategories): ThemeMapper
       'border-color': {
         category: category,
         inverse: true,
-        token: ColorTokens.token_200,
+        token: ColorTokens.token_100,
       },
     },
     focus: {
       'border-color': {
         category: category,
         inverse: true,
-        token: ColorTokens.token_200,
+        token: ColorTokens.token_150,
       },
     },
   };

--- a/packages/form/src/ui-input.tsx
+++ b/packages/form/src/ui-input.tsx
@@ -33,6 +33,7 @@ const Input = styled.input<privateInputProps>`
 
     padding: 5px;
     outline: none;
+    width: 100%;
   `}
 `;
 
@@ -42,6 +43,7 @@ const WrapperDiv = styled.div`
 
 const InputDiv = styled.div`
   display: inline-block;
+  flex-grow: 1;
 `;
 
 export const UiInput: React.FC<UiInputProps> = ({

--- a/packages/form/src/ui-textarea.tsx
+++ b/packages/form/src/ui-textarea.tsx
@@ -17,6 +17,7 @@ const Textarea = styled.textarea<privateTextAreaProps>`
     )}
     font-size: ${getTextSize(props.customTheme, TextSize.regular)};
     ${props.resize === false ? 'resize: none;' : ''}
+    ${!props.cols ? 'width: 100%;' : ''}
   `}
 
   border-style: solid;
@@ -43,6 +44,7 @@ const WrapperDiv = styled.div`
 
 const InputDiv = styled.div`
   display: inline-block;
+  flex-grow: 1;
 `;
 
 export const UiTextArea: React.FC<UiTextAreaProps> = ({


### PR DESCRIPTION
## 🔥 UiInput and UiTextarea to cover full width
----------------------------------------------

### Description
The idea is that the parent form or container will establish the width of the form, without this clients would have to implement more logic to address/manipulate the width of the input.

### Screenshots

#### Before
<img width="435" alt="Screenshot 2023-05-31 at 12 35 26 PM" src="https://github.com/inavac182/uireact/assets/16787893/adee7148-a593-40b6-8dde-ce8b7e0966fe">


#### After
<img width="812" alt="Screenshot 2023-05-31 at 12 32 53 PM" src="https://github.com/inavac182/uireact/assets/16787893/50143f4e-9d5a-4b2b-be66-650c4b7f36a5">
