### PR TITLE
feat(link): prop to use react router link

### DIFF
--- a/packages/text/__tests__/ui-link.spec.tsx
+++ b/packages/text/__tests__/ui-link.spec.tsx
@@ -1,4 +1,5 @@
 import React from 'react';
+import { MemoryRouter } from 'react-router-dom';
 
 import { fireEvent, screen } from '@testing-library/react';
 
@@ -33,6 +34,28 @@ describe('<UiLink />', () => {
   it('renders fine with category', () => {
     uiRender(
       <UiLink href="#" theme="positive">
+        Link
+      </UiLink>
+    );
+
+    expect(screen.getByRole('link', { name: 'Link' })).toBeVisible();
+  });
+
+  it('renders fine when uses internal link', () => {
+    uiRender(
+      <MemoryRouter initialEntries={['/']}>
+        <UiLink href="#" useReactLink theme="positive">
+          Link
+        </UiLink>
+      </MemoryRouter>
+    );
+
+    expect(screen.getByRole('link', { name: 'Link' })).toBeVisible();
+  });
+
+  it('renders fine when uses internal link but doesnt provide href', () => {
+    uiRender(
+      <UiLink useReactLink theme="positive">
         Link
       </UiLink>
     );

--- a/packages/text/__tests__/ui-link.spec.tsx
+++ b/packages/text/__tests__/ui-link.spec.tsx
@@ -43,6 +43,8 @@ describe('<UiLink />', () => {
 
   it('renders fine when uses internal link', () => {
     uiRender(
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      //@ts-ignore
       <MemoryRouter initialEntries={['/']}>
         <UiLink href="#" useReactLink theme="positive">
           Link

--- a/packages/text/docs/link-docs.mdx
+++ b/packages/text/docs/link-docs.mdx
@@ -4,6 +4,7 @@ menu: Typography
 ---
 
 import { Props } from 'docz';
+import { MemoryRouter } from 'react-router-dom';
 
 import * as packageJson from '../package.json';
 import Playground from '../../../src/Playground';
@@ -42,6 +43,18 @@ import { UiLink } from '../src';
   <UiLink handleClick={() => console.log('Link Clicked')} theme="negative">
     Some text
   </UiLink>
+</Playground>
+
+## UiLink using React router dom Link
+
+The prop `useReactLink` will render the Link from react-router-dom. This is so you can make use of the internal react routing.
+
+<Playground>
+  <MemoryRouter initialEntries={['/']}>
+    <UiLink href="?param=value" target="_blank" theme="error" useReactLink>
+      Some text
+    </UiLink>
+  </MemoryRouter>
 </Playground>
 
 ### Props

--- a/packages/text/src/types/ui-link-props.ts
+++ b/packages/text/src/types/ui-link-props.ts
@@ -1,3 +1,5 @@
+import { HTMLAttributeReferrerPolicy } from 'react';
+
 import { ColorCategory, TextSize, UiReactElementProps, UiReactPrivateElementProps } from '@uireact/foundation';
 
 export type UiLinkProps = {
@@ -10,13 +12,16 @@ export type UiLinkProps = {
   /** React ref */
   ref?: React.Ref<HTMLAnchorElement>;
   /** referrer policy */
-  referrerpolicy?: string;
+  referrerpolicy?: HTMLAttributeReferrerPolicy;
   /** Link size, default REGULAR */
   size?: TextSize;
   /** Link target */
   target?: string;
+  /** If uses react router dome link, YOU HAVE TO PROVIDE A HREF */
+  useReactLink?: boolean;
 } & UiReactElementProps;
 
 export type privateLinkProps = Omit<UiLinkProps, 'theme'> & {
   category: ColorCategory;
+  to?: string;
 } & UiReactPrivateElementProps;

--- a/packages/text/src/ui-link.tsx
+++ b/packages/text/src/ui-link.tsx
@@ -1,5 +1,7 @@
 import React from 'react';
 
+import { Link } from 'react-router-dom';
+
 import styled from 'styled-components';
 
 import { TextSize, ThemeContext, getColorCategory, getTextSize, getThemeStyling } from '@uireact/foundation';
@@ -22,6 +24,23 @@ const Anchor = styled.a<privateLinkProps>`
   }
 `;
 
+const StyledLinkWrapper = styled.span<privateLinkProps>`
+  a {
+    ${(props) => `
+      ${getThemeStyling(props.customTheme, props.selectedTheme, getDynamicLinkMapper(getColorCategory(props.category)))}
+      font-size: ${getTextSize(props.customTheme, props.size || TextSize.regular)};
+    `}
+
+    cursor: pointer;
+    outline: none;
+    text-decoration: none;
+
+    :hover {
+      text-decoration: underline;
+    }
+  }
+`;
+
 export const UiLink: React.FC<UiLinkProps> = ({
   theme = 'secondary',
   children,
@@ -31,8 +50,33 @@ export const UiLink: React.FC<UiLinkProps> = ({
   referrerpolicy,
   size,
   target,
+  useReactLink,
+  testId,
 }: UiLinkProps) => {
   const themeContext = React.useContext(ThemeContext);
+
+  if (useReactLink && href) {
+    return (
+      <StyledLinkWrapper
+        category={theme}
+        customTheme={themeContext.theme}
+        onClick={handleClick}
+        selectedTheme={themeContext.selectedTheme}
+        size={size}
+      >
+        <Link
+          to={href}
+          data-testid={testId}
+          role="link"
+          target={target}
+          ref={ref}
+          referrerPolicy={referrerpolicy || 'no-referrer'}
+        >
+          {children}
+        </Link>
+      </StyledLinkWrapper>
+    );
+  }
 
   return (
     <Anchor
@@ -46,6 +90,7 @@ export const UiLink: React.FC<UiLinkProps> = ({
       size={size}
       target={target}
       role="link"
+      data-testid={testId}
     >
       {children}
     </Anchor>


### PR DESCRIPTION
## 🔥 useReactLink in UiLink
----------------------------------------------

### Description
This prop will be used to render the `Link` from the react router dom rather than a normal anchor.

### Screenshots
N/A
