### PR TITLE
refactor(navbar): styling for corners

### DIFF
--- a/packages/navbar/__tests__/navbar.spec.tsx
+++ b/packages/navbar/__tests__/navbar.spec.tsx
@@ -69,6 +69,20 @@ describe('<UiNavbar />', () => {
     expect(screen.getByText('Option 3')).toBeVisible();
   });
 
+  it('Should render navbar when roundedCorners is used', () => {
+    render(
+      <UiNavbar category="secondary" roundedCorners>
+        <UiNavbarItem>Option 1</UiNavbarItem>
+        <UiNavbarItem active>Option 2</UiNavbarItem>
+        <UiNavbarItem>Option 3</UiNavbarItem>
+      </UiNavbar>
+    );
+
+    expect(screen.getByText('Option 1')).toBeVisible();
+    expect(screen.getByText('Option 2')).toBeVisible();
+    expect(screen.getByText('Option 3')).toBeVisible();
+  });
+
   it('Should render navbar when an option is active', () => {
     render(
       <UiNavbar category="secondary">

--- a/packages/navbar/__tests__/utils/get-border-radius-styling.spec.ts
+++ b/packages/navbar/__tests__/utils/get-border-radius-styling.spec.ts
@@ -1,0 +1,27 @@
+import { getBorderRadiusStyling } from '../../src/utils';
+
+describe('getBorderRadiusStyling()', () => {
+  it('Should get correct style for inline first', () => {
+    const style = getBorderRadiusStyling('inline', true, false);
+
+    expect(style).toBe('border-radius: 5px 0 0 5px;');
+  });
+
+  it('Should get correct style for inline last', () => {
+    const style = getBorderRadiusStyling('inline', false, true);
+
+    expect(style).toBe('border-radius: 0 5px 5px 0;');
+  });
+
+  it('Should get correct style for stacked first', () => {
+    const style = getBorderRadiusStyling('stacked', true, false);
+
+    expect(style).toBe('border-radius: 5px 5px 0 0;');
+  });
+
+  it('Should get correct style for stacked last', () => {
+    const style = getBorderRadiusStyling('stacked', false, true);
+
+    expect(style).toBe('border-radius: 0 0 5px 5px;');
+  });
+});

--- a/packages/navbar/docs/navbar.mdx
+++ b/packages/navbar/docs/navbar.mdx
@@ -32,26 +32,50 @@ import * as packageJson from '../package.json';
 <Playground>
   <UiNavbar orientation="stacked">
     <UiNavbarItem>
-      <UiLink href="uireact.com" fullWidth>
+      <UiLink href="https://uireact.io" fullWidth>
         Option 1
       </UiLink>
     </UiNavbarItem>
     <UiNavbarItem>
-      <UiLink href="uireact.com" fullWidth>
+      <UiLink href="https://uireact.io" fullWidth>
         Option 2
       </UiLink>
     </UiNavbarItem>
     <UiNavbarItem active>
-      <UiLink href="uireact.com" fullWidth>
+      <UiLink href="https://uireact.io" fullWidth>
         Option 3
       </UiLink>
     </UiNavbarItem>
     <UiNavbarItem>
-      <UiLink href="uireact.com" fullWidth>
+      <UiLink href="https://uireact.io" fullWidth>
         Option 4
       </UiLink>
     </UiNavbarItem>
   </UiNavbar>
+</Playground>
+
+## Usage as a stacked navbar inside card
+
+<Playground>
+  <UiCard noPadding>
+    <UiNavbar orientation="stacked" roundedCorners>
+      <UiNavbarItem>
+        <UiLink href="https://uireact.io" fullWidth>
+          Option 1
+        </UiLink>
+      </UiNavbarItem>
+      <UiNavbarItem>
+        <UiLink href="https://uireact.io" fullWidth>
+          Option 2
+        </UiLink>
+      </UiNavbarItem>
+      <UiNavbarItem active>
+        <UiLink href="https://uireact.io" fullWidth>
+          Option 3
+        </UiLink>
+      </UiNavbarItem>
+    </UiNavbar>
+  </UiCard>
 </Playground>
 
 ## Usage as an inline navbar

--- a/packages/navbar/docs/navbar.mdx
+++ b/packages/navbar/docs/navbar.mdx
@@ -54,7 +54,7 @@ import * as packageJson from '../package.json';
   </UiNavbar>
 </Playground>
 
-## Usage as a stacked navbar inside card
+## Usage inside a card
 
 <Playground>
   <UiCard noPadding>

--- a/packages/navbar/src/navbar-item.tsx
+++ b/packages/navbar/src/navbar-item.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { ColorTokens, ThemeContext, getColorCategory, getThemeColor } from '@uireact/foundation';
+import { ThemeContext } from '@uireact/foundation';
 
 import styled from 'styled-components';
 
@@ -8,35 +8,15 @@ import { UiNavbarItemProps, privateNavbarItemProps } from './types';
 
 const Div = styled.div<privateNavbarItemProps>`
   ${(props) => `
-    ${
-      props.active
-        ? `background: ${getThemeColor(
-            props.customTheme,
-            props.selectedTheme,
-            getColorCategory(props.category),
-            ColorTokens.token_150,
-            false
-          )};`
-        : ''
-    }
+    ${!props.active ? 'background: transparent !important;' : ''}
   `}
 `;
 
-export const UiNavbarItem: React.FC<UiNavbarItemProps> = ({
-  active,
-  // istanbul ignore next
-  category = 'primary',
-  children,
-}: UiNavbarItemProps) => {
+export const UiNavbarItem: React.FC<UiNavbarItemProps> = ({ active, children }: UiNavbarItemProps) => {
   const themeContext = React.useContext(ThemeContext);
 
   return (
-    <Div
-      active={active}
-      category={category}
-      customTheme={themeContext.theme}
-      selectedTheme={themeContext.selectedTheme}
-    >
+    <Div active={active} customTheme={themeContext.theme} selectedTheme={themeContext.selectedTheme}>
       {children}
     </Div>
   );

--- a/packages/navbar/src/navbar.tsx
+++ b/packages/navbar/src/navbar.tsx
@@ -11,6 +11,10 @@ import { getFlexAlignment } from './utils';
 const NavbarWrapper = styled.div<privateNavbarProps>`
   display: flex;
 
+  a: hover {
+    text-decoration: none;
+  }
+
   ${(props: privateNavbarProps) => {
     return `
       flex-direction: ${props.orientation === 'stacked' ? 'column' : 'row'};
@@ -24,10 +28,17 @@ export const UiNavbar: React.FC<UiNavbarProps> = ({
   category = 'primary',
   children,
   orientation = 'inline',
+  roundedCorners,
 }: UiNavbarProps) => {
   const themeContext = React.useContext(ThemeContext);
 
   const NavbarContent = React.useMemo(() => {
+    let numberOfItems = 0;
+
+    React.Children.map(children, () => {
+      numberOfItems++;
+    });
+
     const elements: React.ReactElement[] = [];
 
     React.Children.map(children, (child, index) => {
@@ -39,6 +50,9 @@ export const UiNavbar: React.FC<UiNavbarProps> = ({
           customTheme={themeContext.theme}
           selectedTheme={themeContext.selectedTheme}
           key={`navbar-item-${index}`}
+          isFirst={index === 0}
+          isLast={index === numberOfItems - 1}
+          roundedCorners={roundedCorners}
         >
           {child}
         </NavbarItemWrapper>

--- a/packages/navbar/src/navbar.tsx
+++ b/packages/navbar/src/navbar.tsx
@@ -33,12 +33,7 @@ export const UiNavbar: React.FC<UiNavbarProps> = ({
   const themeContext = React.useContext(ThemeContext);
 
   const NavbarContent = React.useMemo(() => {
-    let numberOfItems = 0;
-
-    React.Children.map(children, () => {
-      numberOfItems++;
-    });
-
+    const numberOfItems = React.Children.count(children);
     const elements: React.ReactElement[] = [];
 
     React.Children.map(children, (child, index) => {

--- a/packages/navbar/src/private/navbar-item-wrapper.tsx
+++ b/packages/navbar/src/private/navbar-item-wrapper.tsx
@@ -13,6 +13,7 @@ import {
 
 import { UiNavbarProps } from '../types';
 import { getNavbarItemMapper } from '../theme';
+import { getBorderRadiusStyling } from '../utils';
 
 type NavbarItemWrapperProps = UiNavbarProps & {
   category: ColorCategory;
@@ -24,14 +25,12 @@ const Div = styled.div<NavbarItemWrapperProps>`
   ${(props) => `
     ${props.orientation === 'stacked' ? 'width: 100%;' : ''}
     ${getThemeStyling(props.customTheme, props.selectedTheme, getNavbarItemMapper(props.category))}
-    ${props.roundedCorners && props.isFirst ? 'border-radius: 5px 5px 0 0;' : ''}
-    ${props.roundedCorners && props.isLast ? 'border-radius: 0 0 5px 5px;' : ''}
+    ${props.roundedCorners ? getBorderRadiusStyling(props.orientation, props.isFirst, props.isLast) : ''}
   `}
 
   div {
     ${(props) => `
-      ${props.roundedCorners && props.isFirst ? 'border-radius: 5px 5px 0 0;' : ''}
-      ${props.roundedCorners && props.isLast ? 'border-radius: 0 0 5px 5px;' : ''}
+      ${props.roundedCorners ? getBorderRadiusStyling(props.orientation, props.isFirst, props.isLast) : ''}
       background: ${getThemeColor(
         props.customTheme,
         props.selectedTheme,

--- a/packages/navbar/src/private/navbar-item-wrapper.tsx
+++ b/packages/navbar/src/private/navbar-item-wrapper.tsx
@@ -2,20 +2,45 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { ColorCategory, UiReactPrivateElementProps, getThemeStyling } from '@uireact/foundation';
+import {
+  ColorCategory,
+  ColorTokens,
+  UiReactPrivateElementProps,
+  getColorCategory,
+  getThemeColor,
+  getThemeStyling,
+} from '@uireact/foundation';
 
-import { UiNavbarItemProps, UiNavbarProps } from '../types';
+import { UiNavbarProps } from '../types';
 import { getNavbarItemMapper } from '../theme';
 
 type NavbarItemWrapperProps = UiNavbarProps & {
   category: ColorCategory;
+  isFirst?: boolean;
+  isLast?: boolean;
 } & UiReactPrivateElementProps;
 
 const Div = styled.div<NavbarItemWrapperProps>`
   ${(props) => `
     ${props.orientation === 'stacked' ? 'width: 100%;' : ''}
     ${getThemeStyling(props.customTheme, props.selectedTheme, getNavbarItemMapper(props.category))}
+    ${props.roundedCorners && props.isFirst ? 'border-radius: 5px 5px 0 0;' : ''}
+    ${props.roundedCorners && props.isLast ? 'border-radius: 0 0 5px 5px;' : ''}
   `}
+
+  div {
+    ${(props) => `
+      ${props.roundedCorners && props.isFirst ? 'border-radius: 5px 5px 0 0;' : ''}
+      ${props.roundedCorners && props.isLast ? 'border-radius: 0 0 5px 5px;' : ''}
+      background: ${getThemeColor(
+        props.customTheme,
+        props.selectedTheme,
+        getColorCategory(props.category),
+        ColorTokens.token_150,
+        false
+      )};
+    `}
+  }
 
   transition: background 0.2s;
 `;
@@ -26,13 +51,12 @@ export const NavbarItemWrapper: React.FC<NavbarItemWrapperProps> = ({
   category,
   children,
   customTheme,
+  isFirst,
+  isLast,
+  roundedCorners,
   selectedTheme,
 }: NavbarItemWrapperProps) => {
   if (React.isValidElement(children)) {
-    const content = React.cloneElement<UiNavbarItemProps>(children as React.ReactElement<UiNavbarItemProps>, {
-      category: category,
-    });
-
     return (
       <Div
         align={align}
@@ -40,8 +64,11 @@ export const NavbarItemWrapper: React.FC<NavbarItemWrapperProps> = ({
         customTheme={customTheme}
         selectedTheme={selectedTheme}
         orientation={orientation}
+        roundedCorners={roundedCorners}
+        isFirst={isFirst}
+        isLast={isLast}
       >
-        {content}
+        {children}
       </Div>
     );
   }

--- a/packages/navbar/src/types/navbar-item-props.ts
+++ b/packages/navbar/src/types/navbar-item-props.ts
@@ -1,13 +1,9 @@
-import { ColorCategory, UiReactElementProps, UiReactPrivateElementProps } from '@uireact/foundation';
+import { UiReactElementProps, UiReactPrivateElementProps } from '@uireact/foundation';
 
 export type UiNavbarItemProps = {
   children?: React.ReactNode;
   /** If the current option is active */
   active?: boolean;
-  /** Selected category for navbar */
-  category?: ColorCategory;
 } & UiReactElementProps;
 
-export type privateNavbarItemProps = UiNavbarItemProps & {
-  category: ColorCategory;
-} & UiReactPrivateElementProps;
+export type privateNavbarItemProps = UiNavbarItemProps & UiReactPrivateElementProps;

--- a/packages/navbar/src/types/navbar-props.ts
+++ b/packages/navbar/src/types/navbar-props.ts
@@ -12,6 +12,8 @@ export type UiNavbarProps = {
   category?: ColorCategory;
   /** Navbar alignment */
   align?: Alignment;
+  /** If top and bottom item render rounded corners, useful for rendering navbar inside cards */
+  roundedCorners?: boolean;
 } & Omit<UiReactElementProps, 'children'>;
 
 export type privateNavbarProps = UiNavbarProps & {

--- a/packages/navbar/src/utils/get-border-radius-styling.ts
+++ b/packages/navbar/src/utils/get-border-radius-styling.ts
@@ -1,0 +1,34 @@
+import { Orientation } from '../types';
+
+export const getBorderRadiusStyling = (orientation?: Orientation, isFirst?: boolean, isLast?: boolean): string => {
+  let topLeft = '0';
+  let topRight = '0';
+  let bottomLeft = '0';
+  let bottomRight = '0';
+
+  if (orientation === 'inline') {
+    if (isFirst) {
+      topLeft = '5px';
+      bottomLeft = '5px';
+    }
+
+    if (isLast) {
+      topRight = '5px';
+      bottomRight = '5px';
+    }
+  }
+
+  if (orientation === 'stacked') {
+    if (isFirst) {
+      topLeft = '5px';
+      topRight = '5px';
+    }
+
+    if (isLast) {
+      bottomLeft = '5px';
+      bottomRight = '5px';
+    }
+  }
+
+  return `border-radius: ${topLeft} ${topRight} ${bottomRight} ${bottomLeft};`;
+};

--- a/packages/navbar/src/utils/index.ts
+++ b/packages/navbar/src/utils/index.ts
@@ -1,1 +1,2 @@
 export * from './get-flex-alignment';
+export * from './get-border-radius-styling';


### PR DESCRIPTION
## 🔥 UiNavbar styling for rounded corners
----------------------------------------------

### Description
Common usage of this component I think will be rendered inside a card, the cards can have rounded corners so I added a prop for that, I'm also removing the link text underline as in navbars links don't use this decoration.

### Screenshots

#### Before
<img width="170" alt="Screenshot 2023-06-09 at 2 58 07 PM" src="https://github.com/inavac182/uireact/assets/16787893/49ce6c3c-6e2f-4a99-9881-54b9f7740ef8">

#### After
<img width="201" alt="Screenshot 2023-06-09 at 2 51 11 PM" src="https://github.com/inavac182/uireact/assets/16787893/d7dcb5b1-0f71-4abd-9756-83950b28cf76">
<img width="854" alt="Screenshot 2023-06-09 at 2 51 02 PM" src="https://github.com/inavac182/uireact/assets/16787893/d595fa20-1fed-46ea-ba4b-00ea7fd224e4">
