### PR TITLE
feat(button): adding cristal button

### DIFF
--- a/packages/button/__tests__/button.spec.tsx
+++ b/packages/button/__tests__/button.spec.tsx
@@ -43,6 +43,12 @@ describe('<UiButton />', () => {
     expect(screen.getByRole('button')).toBeVisible();
   });
 
+  test('renders when is cristal', () => {
+    uiRender(<UiButton cristal>MyButton</UiButton>);
+
+    expect(screen.getByRole('button')).toBeVisible();
+  });
+
   test('renders full height', () => {
     uiRender(<UiButton fullHeight>MyButton</UiButton>);
 

--- a/packages/button/__tests__/theme/mapper.spec.ts
+++ b/packages/button/__tests__/theme/mapper.spec.ts
@@ -9,7 +9,7 @@ describe('getDynamicMapper', () => {
     expect(mapper.normal?.color?.inverse).toBeFalsy();
   });
 
-  it('should get correct mapper when is clear', () => {
+  it('should get correct mapper when is cristal', () => {
     const mapper = getDynamicMapper(ColorCategories.primary, true);
 
     expect(mapper.normal?.background).toBeUndefined();

--- a/packages/button/__tests__/theme/mapper.spec.ts
+++ b/packages/button/__tests__/theme/mapper.spec.ts
@@ -9,6 +9,13 @@ describe('getDynamicMapper', () => {
     expect(mapper.normal?.color?.inverse).toBeFalsy();
   });
 
+  it('should get correct mapper when is clear', () => {
+    const mapper = getDynamicMapper(ColorCategories.primary, true);
+
+    expect(mapper.normal?.background).toBeUndefined();
+    expect(mapper.normal?.['border-color']).toBeUndefined();
+  });
+
   it('should get correct mapper when is secondary', () => {
     const mapper = getDynamicMapper(ColorCategories.secondary);
 

--- a/packages/button/docs/button.mdx
+++ b/packages/button/docs/button.mdx
@@ -5,6 +5,9 @@ menu: Forms
 
 import { Props } from 'docz';
 
+import { UiCard } from '@uireact/card';
+import { UiFlexGrid } from '@uireact/flex';
+
 import Playground from '../../../src/Playground';
 import { UiButton } from '../src/';
 import { UiSpacing, Sizing } from '../../foundation/src/';
@@ -90,4 +93,17 @@ import * as packageJson from '../package.json';
       <UiSpacing margin={{ all: Sizing.three }}>Button! 🌋</UiSpacing>
     </UiButton>
   </UiGrid>
+</Playground>
+
+#### Cristal button
+
+<Playground>
+  <UiCard>
+    <UiFlexGrid gap="three">
+      <UiButton theme="tertiary" cristal>
+        <UiSpacing margin={{ all: Sizing.three }}>Button! ✨</UiSpacing>
+      </UiButton>
+      Some content
+    </UiFlexGrid>
+  </UiCard>
 </Playground>

--- a/packages/button/src/theme/mapper.ts
+++ b/packages/button/src/theme/mapper.ts
@@ -1,6 +1,6 @@
 import { ColorCategories, ColorTokens, ThemeMapper } from '@uireact/foundation';
 
-export const getDynamicMapper = (category: ColorCategories): ThemeMapper => {
+export const getDynamicMapper = (category: ColorCategories, cristal?: boolean): ThemeMapper => {
   return {
     normal: {
       color: {
@@ -8,16 +8,20 @@ export const getDynamicMapper = (category: ColorCategories): ThemeMapper => {
         inverse: false,
         token: ColorTokens.token_100,
       },
-      background: {
-        category: category,
-        inverse: false,
-        token: ColorTokens.token_100,
-      },
-      'border-color': {
-        category: category,
-        inverse: false,
-        token: ColorTokens.token_50,
-      },
+      background: !cristal
+        ? {
+            category: category,
+            inverse: false,
+            token: ColorTokens.token_100,
+          }
+        : undefined,
+      'border-color': !cristal
+        ? {
+            category: category,
+            inverse: false,
+            token: ColorTokens.token_50,
+          }
+        : undefined,
     },
     hover: {
       background: {

--- a/packages/button/src/types/ui-button-props.ts
+++ b/packages/button/src/types/ui-button-props.ts
@@ -12,6 +12,8 @@ export type UiButtonProps = {
   testId?: string;
   /** className attribute */
   className?: string;
+  /** render button without normal background */
+  cristal?: boolean;
   /** Button theme */
   theme?: ColorCategory;
   /** If button should take full height */

--- a/packages/button/src/ui-button.tsx
+++ b/packages/button/src/ui-button.tsx
@@ -9,17 +9,18 @@ import { getDynamicMapper } from './theme';
 
 const StyledButton = styled.button<privateButtonProps>`
   ${(props) => {
-    const mapper = getDynamicMapper(getColorCategory(props.theme));
+    const mapper = getDynamicMapper(getColorCategory(props.theme), props.cristal);
 
     return `
       ${getThemeStyling(props.customTheme, props.selectedTheme, mapper)}
       ${props.fullWidth ? 'width: 100%;' : ''}
       ${props.fullHeight ? 'height: 100%;' : ''}
+      ${props.cristal ? 'border-width: 0;' : 'border-width: 1px;'}
+      ${props.cristal ? 'background: unset;' : ''}
     `;
   }}
 
   font-weight: bold;
-  border-width: 1px;
   border-style: solid;
   border-radius: 3px;
   padding-left: 10px;
@@ -33,6 +34,7 @@ export const UiButton: React.FC<UiButtonProps> = ({
   className,
   disabled,
   children,
+  cristal,
   theme = 'primary',
   fullHeight,
   fullWidth,
@@ -48,6 +50,7 @@ export const UiButton: React.FC<UiButtonProps> = ({
       theme={theme}
       onClick={onClick}
       data-testid={testId}
+      cristal={cristal}
       className={className}
       disabled={disabled}
       fullHeight={fullHeight}


### PR DESCRIPTION
## 🔥 UiButton cristal
----------------------------------------------

### Description
Adding a cristal prop for UiButton to render without main background, useful when rendering 2 buttons and you need one to have a higher visual weight, the 2nd one can be cristal so will look like a fallback action.

### Screensh
![Jun-09-2023 16-05-02](https://github.com/inavac182/uireact/assets/16787893/3b500ebd-397c-48c2-bb57-7a63a94240b8)
ots

