### PR TITLE
fix(navbar): style to child div

### DIFF
--- a/packages/navbar/src/private/navbar-item-wrapper.tsx
+++ b/packages/navbar/src/private/navbar-item-wrapper.tsx
@@ -28,7 +28,7 @@ const Div = styled.div<NavbarItemWrapperProps>`
     ${props.roundedCorners ? getBorderRadiusStyling(props.orientation, props.isFirst, props.isLast) : ''}
   `}
 
-  div {
+  > div {
     ${(props) => `
       ${props.roundedCorners ? getBorderRadiusStyling(props.orientation, props.isFirst, props.isLast) : ''}
       background: ${getThemeColor(


### PR DESCRIPTION
## 🔥 Fix UiNavbarItem style
----------------------------------------------

### Description
The `div` style was applying to all divs, but the desired behavior is that only the immediate child div gets the style.

### Screenshots
N/A