### PR TITLE
feat(navbar): stretchItems prop

### DIFF
--- a/packages/navbar/__tests__/navbar.spec.tsx
+++ b/packages/navbar/__tests__/navbar.spec.tsx
@@ -17,6 +17,29 @@ describe('<UiNavbar />', () => {
     expect(screen.getByText('Option 2')).toBeVisible();
   });
 
+  it('Should render navbar with test id', () => {
+    render(
+      <UiNavbar testId="my-navbar">
+        <UiNavbarItem>Option 1</UiNavbarItem>
+        <UiNavbarItem>Option 2</UiNavbarItem>
+      </UiNavbar>
+    );
+
+    expect(screen.getByTestId('my-navbar')).toBeVisible();
+  });
+
+  it('Should render navbar with class name', () => {
+    render(
+      <UiNavbar testId="my-navbar" className="some-class">
+        <UiNavbarItem>Option 1</UiNavbarItem>
+        <UiNavbarItem>Option 2</UiNavbarItem>
+      </UiNavbar>
+    );
+
+    expect(screen.getByTestId('my-navbar')).toBeVisible();
+    expect(screen.getByTestId('my-navbar')).toHaveClass('some-class');
+  });
+
   it('Should render navbar when orientation is inline', () => {
     render(
       <UiNavbar orientation="inline">

--- a/packages/navbar/__tests__/navbar.spec.tsx
+++ b/packages/navbar/__tests__/navbar.spec.tsx
@@ -29,6 +29,18 @@ describe('<UiNavbar />', () => {
     expect(screen.getByText('Option 2')).toBeVisible();
   });
 
+  it('Should render navbar when orientation is inline and stretched', () => {
+    render(
+      <UiNavbar orientation="inline" stretchItems>
+        <UiNavbarItem>Option 1</UiNavbarItem>
+        <UiNavbarItem>Option 2</UiNavbarItem>
+      </UiNavbar>
+    );
+
+    expect(screen.getByText('Option 1')).toBeVisible();
+    expect(screen.getByText('Option 2')).toBeVisible();
+  });
+
   it('Should render navbar when norientation is stacked', () => {
     render(
       <UiNavbar orientation="stacked">

--- a/packages/navbar/docs/navbar.mdx
+++ b/packages/navbar/docs/navbar.mdx
@@ -81,7 +81,7 @@ import * as packageJson from '../package.json';
 ## Usage as an inline navbar
 
 <Playground>
-  <UiNavbar orientation="inline" align="start">
+  <UiNavbar orientation="inline" align="start" stretchItems>
     <UiNavbarItem>
       <UiText>Option 1</UiText>
     </UiNavbarItem>

--- a/packages/navbar/src/navbar.tsx
+++ b/packages/navbar/src/navbar.tsx
@@ -27,8 +27,11 @@ export const UiNavbar: React.FC<UiNavbarProps> = ({
   align = 'start',
   category = 'primary',
   children,
+  className,
   orientation = 'inline',
   roundedCorners,
+  stretchItems,
+  testId,
 }: UiNavbarProps) => {
   const themeContext = React.useContext(ThemeContext);
 
@@ -48,6 +51,7 @@ export const UiNavbar: React.FC<UiNavbarProps> = ({
           isFirst={index === 0}
           isLast={index === numberOfItems - 1}
           roundedCorners={roundedCorners}
+          stretchItems={stretchItems}
         >
           {child}
         </NavbarItemWrapper>
@@ -60,9 +64,11 @@ export const UiNavbar: React.FC<UiNavbarProps> = ({
   return (
     <NavbarWrapper
       align={align}
+      className={className}
       customTheme={themeContext.theme}
       selectedTheme={themeContext.selectedTheme}
       orientation={orientation}
+      data-testId={testId}
     >
       <>{NavbarContent}</>
     </NavbarWrapper>

--- a/packages/navbar/src/navbar.tsx
+++ b/packages/navbar/src/navbar.tsx
@@ -68,7 +68,7 @@ export const UiNavbar: React.FC<UiNavbarProps> = ({
       customTheme={themeContext.theme}
       selectedTheme={themeContext.selectedTheme}
       orientation={orientation}
-      data-testId={testId}
+      data-testid={testId}
     >
       <>{NavbarContent}</>
     </NavbarWrapper>

--- a/packages/navbar/src/private/navbar-item-wrapper.tsx
+++ b/packages/navbar/src/private/navbar-item-wrapper.tsx
@@ -26,6 +26,7 @@ const Div = styled.div<NavbarItemWrapperProps>`
     ${props.orientation === 'stacked' ? 'width: 100%;' : ''}
     ${getThemeStyling(props.customTheme, props.selectedTheme, getNavbarItemMapper(props.category))}
     ${props.roundedCorners ? getBorderRadiusStyling(props.orientation, props.isFirst, props.isLast) : ''}
+    ${props.stretchItems ? 'flex-grow: 1; text-align: center;' : ''}
   `}
 
   > div {
@@ -54,6 +55,7 @@ export const NavbarItemWrapper: React.FC<NavbarItemWrapperProps> = ({
   isLast,
   roundedCorners,
   selectedTheme,
+  stretchItems,
 }: NavbarItemWrapperProps) => {
   if (React.isValidElement(children)) {
     return (
@@ -66,6 +68,7 @@ export const NavbarItemWrapper: React.FC<NavbarItemWrapperProps> = ({
         roundedCorners={roundedCorners}
         isFirst={isFirst}
         isLast={isLast}
+        stretchItems={stretchItems}
       >
         {children}
       </Div>

--- a/packages/navbar/src/types/navbar-props.ts
+++ b/packages/navbar/src/types/navbar-props.ts
@@ -14,6 +14,8 @@ export type UiNavbarProps = {
   align?: Alignment;
   /** If top and bottom item render rounded corners, useful for rendering navbar inside cards */
   roundedCorners?: boolean;
+  /** If items should be stretched, useful when navbar is rendered to cover whole width */
+  stretchItems?: boolean;
 } & Omit<UiReactElementProps, 'children'>;
 
 export type privateNavbarProps = UiNavbarProps & {


### PR DESCRIPTION
## 🔥 stretchItems prop for UiNavbar
----------------------------------------------

### Description
There are use cases where the navbar has to take the whole width available and for the items to be rendering fine they need to be stretched so they can cover the whole width consistently.

### Screenshots

#### Before
<img width="527" alt="Screenshot 2023-06-09 at 5 47 16 PM" src="https://github.com/inavac182/uireact/assets/16787893/edff52cf-02e1-4be0-8b76-86f2685dab0a">

#### After
<img width="859" alt="Screenshot 2023-06-09 at 5 40 47 PM" src="https://github.com/inavac182/uireact/assets/16787893/32eaa6cb-0594-43e1-a71c-615862da9f06">

