### PR TITLE
fix(grid): render class name prop grid item

### DIFF
--- a/packages/grid/__tests__/grid.spec.tsx
+++ b/packages/grid/__tests__/grid.spec.tsx
@@ -130,3 +130,25 @@ test('renders the grid when width is specified', () => {
   expect(screen.getByText('Item 1')).toBeVisible();
   expect(screen.getByText('Item 2')).toBeVisible();
 });
+
+test('renders grid item with class name', () => {
+  render(
+    <UiGrid cols={2} justifyItems="center" colsGap={3} rowsGap={10}>
+      <UiGridItem className="someclass">Item 1</UiGridItem>
+      <UiGridItem>Item 2</UiGridItem>
+    </UiGrid>
+  );
+
+  expect(screen.getByText('Item 1')).toHaveClass('someclass');
+});
+
+test('renders grid item with test id', () => {
+  render(
+    <UiGrid cols={2} justifyItems="center" colsGap={3} rowsGap={10}>
+      <UiGridItem testId="someTestId">Item 1</UiGridItem>
+      <UiGridItem>Item 2</UiGridItem>
+    </UiGrid>
+  );
+
+  expect(screen.getByTestId('someTestId')).toBeVisible();
+});

--- a/packages/grid/src/grid-item.tsx
+++ b/packages/grid/src/grid-item.tsx
@@ -2,8 +2,9 @@ import React from 'react';
 import styled from 'styled-components';
 
 import { getItemSpan } from './private';
+import { UiReactElementProps } from '@uireact/foundation';
 
-interface GridItemProps {
+type GridItemProps = {
   /** Aligns the item inside its grid block */
   alignSelf?: 'start' | 'end' | 'center' | 'stretch';
   /** Number of columns that the item will take */
@@ -14,7 +15,7 @@ interface GridItemProps {
   placeSelf?: 'start' | 'end' | 'center' | 'stretch';
   /** Number of rows that the item will take */
   rows?: number;
-}
+} & UiReactElementProps;
 
 type UiGridItemProps = GridItemProps & {
   children?: React.ReactNode;
@@ -30,6 +31,18 @@ const Div = styled.div<GridItemProps>`
   `}
 `;
 
-export const UiGridItem: React.FC<UiGridItemProps> = (props: UiGridItemProps) => <Div {...props}>{props.children}</Div>;
+export const UiGridItem: React.FC<UiGridItemProps> = (props: UiGridItemProps) => (
+  <Div
+    alignSelf={props.alignSelf}
+    cols={props.cols}
+    className={props.className}
+    justifySelf={props.justifySelf}
+    placeSelf={props.placeSelf}
+    rows={props.rows}
+    data-testid={props.testId}
+  >
+    {props.children}
+  </Div>
+);
 
 UiGridItem.displayName = 'UiGridItem';


### PR DESCRIPTION
## 🔥 Fix class name in grid item
----------------------------------------------

### Description
Noticed that grid item was not being used in the grid items.

### Screenshots

N/A