### PR TITLE
fix(progress-indicator): render class name

### DIFF
--- a/packages/progress-indicator/src/private/item.tsx
+++ b/packages/progress-indicator/src/private/item.tsx
@@ -16,9 +16,9 @@ const Div = styled.div<privateDivItemProps>`
           border-color: ${getThemeColor(
             props.customTheme,
             props.selectedTheme,
-            ColorCategories.fonts,
+            ColorCategories.primary,
             ColorTokens.token_100,
-            true
+            false
           )};
           font-weight: bold;
         `

--- a/packages/progress-indicator/src/private/item.tsx
+++ b/packages/progress-indicator/src/private/item.tsx
@@ -20,7 +20,6 @@ const Div = styled.div<privateDivItemProps>`
             ColorTokens.token_100,
             false
           )};
-          font-weight: bold;
         `
         : ''
     }

--- a/packages/progress-indicator/src/ui-progress-indicator.tsx
+++ b/packages/progress-indicator/src/ui-progress-indicator.tsx
@@ -14,7 +14,6 @@ const Div = styled.div<privateProgressIndicatorProps>`
   justify-content: flex-start;
   align-items: center;
   gap: 5px;
-  padding: 10px 0px 10px 0px;
   overflow-y: auto;
 `;
 
@@ -31,6 +30,7 @@ const getNumberOfSteps = (children: React.ReactNode) => {
 export const UiProgressIndicator: React.FC<UiProgressIndicatorProps> = ({
   allowGoBack,
   children,
+  className,
   current = 1,
   handleCompletedStepClick,
 }: UiProgressIndicatorProps) => {
@@ -78,7 +78,7 @@ export const UiProgressIndicator: React.FC<UiProgressIndicatorProps> = ({
   }, [children, theme]);
 
   return (
-    <Div customTheme={theme.theme} selectedTheme={theme.selectedTheme}>
+    <Div customTheme={theme.theme} className={className} selectedTheme={theme.selectedTheme}>
       {ProgressIndicatorContent}
     </Div>
   );


### PR DESCRIPTION
## 🔥 Render class name in progress indicator
----------------------------------------------

### Description
Rendering class name into progress indicator, also fixing the issue with the border that is not using the primary color.

### Screenshots

#### Before
<img width="152" alt="Screenshot 2023-06-19 at 7 56 11 PM" src="https://github.com/inavac182/uireact/assets/16787893/06a83f50-33a8-491e-a18c-79e9061b2349">

#### After
<img width="296" alt="Screenshot 2023-06-19 at 7 56 00 PM" src="https://github.com/inavac182/uireact/assets/16787893/3ec63623-5b9a-4d42-b00e-4dff196af0e6">
