### PR TITLE
chore(docs): default dark theme docs

### DIFF
--- a/src/Playground.tsx
+++ b/src/Playground.tsx
@@ -15,7 +15,7 @@ type CustomPlaygroundProps = {
 } & PlaygroundProps;
 
 const CustomPlayground = (props: CustomPlaygroundProps): React.ReactNode => {
-  const [selectedTheme, setTheme] = React.useState<ThemeColor>(ThemeColor.light);
+  const [selectedTheme, setTheme] = React.useState<ThemeColor>(ThemeColor.dark);
   const toogleTheme = () => {
     setTheme(selectedTheme === ThemeColor.light ? ThemeColor.dark : ThemeColor.light);
   };


### PR DESCRIPTION
## 🔥 Defaulting dark theme in docs
----------------------------------------------

### Description
As the playground is black, the dark theme looks better as default.

### Screenshots

#### Before
<img width="1261" alt="Screenshot 2023-06-29 at 12 47 53 PM" src="https://github.com/inavac182/uireact/assets/16787893/00067d73-f15b-4c5c-8715-0e315c1eb766">

#### After
<img width="825" alt="Screenshot 2023-06-29 at 12 47 48 PM" src="https://github.com/inavac182/uireact/assets/16787893/74d7215c-cace-4b3c-8755-f2e231d028b3">
