### PR TITLE
chore(docs): ignore examples

### DIFF
--- a/doczrc.js
+++ b/doczrc.js
@@ -1,6 +1,6 @@
 export default {
   editBranch: 'main',
-  ignore: ['utils/**/*', 'packages/**/CHANGELOG.md', 'packages/**/README.md'],
+  ignore: ['utils/**/*', 'packages/**/CHANGELOG.md', 'packages/**/README.md', 'examples/**/*'],
   typescript: true,
   themeConfig: {
     initialColorMode: 'dark',


### PR DESCRIPTION
## 🔥 Ignore examples 
----------------------------------------------

### Description
The examples were messing around with the readme in the docs page.

### Screenshots

#### Before

#### After
