### PR TITLE
feat: adding box-sizing to input

### DIFF
--- a/packages/form/src/ui-input.tsx
+++ b/packages/form/src/ui-input.tsx
@@ -20,6 +20,7 @@ const Input = styled.input<privateInputProps>`
     border-style: solid;
     border-width: 2px;
     border-radius: 2px;
+    box-sizing: border-box;
 
     :focus {
       border-style: solid;


### PR DESCRIPTION
## 🔥 Adding box-sizing to input
----------------------------------------------

### Description
Box-Sizing is needed when using width:100% with padding which is commonly used in inpust

### Screenshots

#### Before
<img width="482" alt="Screenshot 2023-08-08 at 11 35 17 PM" src="https://github.com/inavac182/uireact/assets/16787893/d94893f3-c849-4061-997a-3611a669673a">

#### After
<img width="1326" alt="Screenshot 2023-08-08 at 11 35 52 PM" src="https://github.com/inavac182/uireact/assets/16787893/c4c14d8c-e771-4882-9008-c83c707c22bc">
