### PR TITLE
feat(navbar): adding styling props

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -69,7 +69,7 @@
         "jest": "^26.6.3",
         "jest-environment-enzyme": "^7.1.2",
         "jest-enzyme": "^7.1.2",
-        "jest-styled-components": "^7.0.8",
+        "jest-styled-components": "^7.1.1",
         "lerna": "^4.0.0",
         "lint": "^0.7.0",
         "lint-staged": "^10.5.4",
@@ -84,6 +84,12 @@
         "tslint-react": "^5.0.0",
         "typescript": "^4.2.3"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.0.tgz",
+      "integrity": "sha512-+RNNcQvw2V1bmnBTPAtOLfW/9mhH2vC67+rUSi5T8EtEWt6lEnGNY2GuhZ1/YwbgikT1TkhvidCDmN5Q5YCo/w==",
+      "dev": true
     },
     "node_modules/@ampproject/remapping": {
       "version": "2.2.1",
@@ -25569,36 +25575,18 @@
       }
     },
     "node_modules/jest-styled-components": {
-      "version": "7.0.8",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/jest-styled-components/-/jest-styled-components-7.1.1.tgz",
+      "integrity": "sha512-OUq31R5CivBF8oy81dnegNQrRW13TugMol/Dz6ZnFfEyo03exLASod7YGwyHGuayYlKmCstPtz0RQ1+NrAbIIA==",
       "dev": true,
-      "license": "MIT",
       "dependencies": {
-        "css": "^3.0.0"
+        "@adobe/css-tools": "^4.0.1"
       },
       "engines": {
         "node": ">= 12"
       },
       "peerDependencies": {
         "styled-components": ">= 5"
-      }
-    },
-    "node_modules/jest-styled-components/node_modules/css": {
-      "version": "3.0.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "inherits": "^2.0.4",
-        "source-map": "^0.6.1",
-        "source-map-resolve": "^0.6.0"
-      }
-    },
-    "node_modules/jest-styled-components/node_modules/source-map-resolve": {
-      "version": "0.6.0",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "atob": "^2.1.2",
-        "decode-uri-component": "^0.2.0"
       }
     },
     "node_modules/jest-util": {
@@ -40581,6 +40569,12 @@
     }
   },
   "dependencies": {
+    "@adobe/css-tools": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.3.0.tgz",
+      "integrity": "sha512-+RNNcQvw2V1bmnBTPAtOLfW/9mhH2vC67+rUSi5T8EtEWt6lEnGNY2GuhZ1/YwbgikT1TkhvidCDmN5Q5YCo/w==",
+      "dev": true
+    },
     "@ampproject/remapping": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/@ampproject/remapping/-/remapping-2.2.1.tgz",
@@ -58307,29 +58301,12 @@
       }
     },
     "jest-styled-components": {
-      "version": "7.0.8",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/jest-styled-components/-/jest-styled-components-7.1.1.tgz",
+      "integrity": "sha512-OUq31R5CivBF8oy81dnegNQrRW13TugMol/Dz6ZnFfEyo03exLASod7YGwyHGuayYlKmCstPtz0RQ1+NrAbIIA==",
       "dev": true,
       "requires": {
-        "css": "^3.0.0"
-      },
-      "dependencies": {
-        "css": {
-          "version": "3.0.0",
-          "dev": true,
-          "requires": {
-            "inherits": "^2.0.4",
-            "source-map": "^0.6.1",
-            "source-map-resolve": "^0.6.0"
-          }
-        },
-        "source-map-resolve": {
-          "version": "0.6.0",
-          "dev": true,
-          "requires": {
-            "atob": "^2.1.2",
-            "decode-uri-component": "^0.2.0"
-          }
-        }
+        "@adobe/css-tools": "^4.0.1"
       }
     },
     "jest-util": {

--- a/package.json
+++ b/package.json
@@ -78,7 +78,7 @@
     "jest": "^26.6.3",
     "jest-environment-enzyme": "^7.1.2",
     "jest-enzyme": "^7.1.2",
-    "jest-styled-components": "^7.0.8",
+    "jest-styled-components": "^7.1.1",
     "lerna": "^4.0.0",
     "lint": "^0.7.0",
     "lint-staged": "^10.5.4",

--- a/packages/navbar/__tests__/navbar.spec.tsx
+++ b/packages/navbar/__tests__/navbar.spec.tsx
@@ -145,4 +145,32 @@ describe('<UiNavbar />', () => {
     expect(screen.getByText('Option 2')).toBeVisible();
     expect(screen.getByText('Option 3')).toBeVisible();
   });
+
+  it('Should render with bordered styling', () => {
+    render(
+      <UiNavbar category="secondary" styling="bordered">
+        {`Option 1`}
+        <UiNavbarItem active>Option 2</UiNavbarItem>
+        <UiNavbarItem>Option 3</UiNavbarItem>
+      </UiNavbar>
+    );
+
+    expect(screen.queryByText('Option 1')).not.toBeInTheDocument();
+    expect(screen.getByText('Option 2')).toBeVisible();
+    expect(screen.getByText('Option 3')).toBeVisible();
+  });
+
+  it('Should render with filled styling', () => {
+    render(
+      <UiNavbar category="secondary" styling="filled">
+        {`Option 1`}
+        <UiNavbarItem active>Option 2</UiNavbarItem>
+        <UiNavbarItem>Option 3</UiNavbarItem>
+      </UiNavbar>
+    );
+
+    expect(screen.queryByText('Option 1')).not.toBeInTheDocument();
+    expect(screen.getByText('Option 2')).toBeVisible();
+    expect(screen.getByText('Option 3')).toBeVisible();
+  });
 });

--- a/packages/navbar/src/navbar-item.tsx
+++ b/packages/navbar/src/navbar-item.tsx
@@ -1,25 +1,9 @@
 import React from 'react';
 
-import { ThemeContext } from '@uireact/foundation';
+import { UiNavbarItemProps } from './types';
 
-import styled from 'styled-components';
-
-import { UiNavbarItemProps, privateNavbarItemProps } from './types';
-
-const Div = styled.div<privateNavbarItemProps>`
-  ${(props) => `
-    ${!props.$active ? 'background: transparent !important;' : ''}
-  `}
-`;
-
-export const UiNavbarItem: React.FC<UiNavbarItemProps> = ({ active, children }: UiNavbarItemProps) => {
-  const themeContext = React.useContext(ThemeContext);
-
-  return (
-    <Div $active={active} $customTheme={themeContext.theme} $selectedTheme={themeContext.selectedTheme}>
-      {children}
-    </Div>
-  );
+export const UiNavbarItem: React.FC<UiNavbarItemProps> = ({ children }: UiNavbarItemProps) => {
+  return <>{children}</>;
 };
 
 UiNavbarItem.displayName = 'UiNavbarItem';

--- a/packages/navbar/src/navbar.tsx
+++ b/packages/navbar/src/navbar.tsx
@@ -31,6 +31,7 @@ export const UiNavbar: React.FC<UiNavbarProps> = ({
   orientation = 'inline',
   roundedCorners,
   stretchItems,
+  styling,
   testId,
 }: UiNavbarProps) => {
   const themeContext = React.useContext(ThemeContext);
@@ -52,6 +53,7 @@ export const UiNavbar: React.FC<UiNavbarProps> = ({
           $isLast={index === numberOfItems - 1}
           $roundedCorners={roundedCorners}
           $stretchItems={stretchItems}
+          $styling={styling}
         >
           {child}
         </NavbarItemWrapper>

--- a/packages/navbar/src/private/navbar-item-wrapper.tsx
+++ b/packages/navbar/src/private/navbar-item-wrapper.tsx
@@ -11,7 +11,7 @@ import {
   getThemeStyling,
 } from '@uireact/foundation';
 
-import { Alignment, Orientation } from '../types';
+import { Alignment, NavbarStyling, Orientation } from '../types';
 import { getNavbarItemMapper } from '../theme';
 import { getBorderRadiusStyling } from '../utils';
 
@@ -28,12 +28,13 @@ type NavbarItemWrapperProps = {
   $category: ColorCategory;
   $isFirst?: boolean;
   $isLast?: boolean;
+  $active?: boolean;
+  $styling?: NavbarStyling;
 } & UiReactPrivateElementProps;
 
 const Div = styled.div<NavbarItemWrapperProps>`
   ${(props) => `
     ${props.$orientation === 'stacked' ? 'width: 100%;' : ''}
-    ${getThemeStyling(props.$customTheme, props.$selectedTheme, getNavbarItemMapper(props.$category))}
     ${props.$roundedCorners ? getBorderRadiusStyling(props.$orientation, props.$isFirst, props.$isLast) : ''}
     ${props.$stretchItems ? 'flex-grow: 1; text-align: center;' : ''}
   `}
@@ -41,17 +42,44 @@ const Div = styled.div<NavbarItemWrapperProps>`
   > div {
     ${(props) => `
       ${props.$roundedCorners ? getBorderRadiusStyling(props.$orientation, props.$isFirst, props.$isLast) : ''}
-      background: ${getThemeColor(
-        props.$customTheme,
-        props.$selectedTheme,
-        getColorCategory(props.$category),
-        ColorTokens.token_150,
-        false
-      )};
     `}
   }
 
-  transition: background 0.2s;
+  > div > :first-child {
+    transition: background 0.2s, border-left 0.2s;
+    border-left: 2px solid transparent;
+    padding-left: 5px;
+
+    ${(props) => `
+      ${
+        props.$styling === 'bordered'
+          ? `
+            &:hover {
+              border-left: 2px solid ${getThemeColor(
+                props.$customTheme,
+                props.$selectedTheme,
+                getColorCategory(props.$category),
+                ColorTokens.token_150,
+                false
+              )};
+            }`
+          : getThemeStyling(props.$customTheme, props.$selectedTheme, getNavbarItemMapper(props.$category))
+      }
+      ${
+        props.$active
+          ? `
+            border-left: 2px solid ${getThemeColor(
+              props.$customTheme,
+              props.$selectedTheme,
+              getColorCategory(props.$category),
+              ColorTokens.token_150,
+              false
+            )};
+          `
+          : ''
+      }
+    `}
+  }
 `;
 
 export const NavbarItemWrapper: React.FC<NavbarItemWrapperProps> = ({
@@ -65,8 +93,11 @@ export const NavbarItemWrapper: React.FC<NavbarItemWrapperProps> = ({
   $roundedCorners,
   $selectedTheme,
   $stretchItems,
+  $styling,
 }: NavbarItemWrapperProps) => {
   if (React.isValidElement(children)) {
+    const props = children.props;
+
     return (
       <Div
         $align={$align}
@@ -78,6 +109,8 @@ export const NavbarItemWrapper: React.FC<NavbarItemWrapperProps> = ({
         $isFirst={$isFirst}
         $isLast={$isLast}
         $stretchItems={$stretchItems}
+        $styling={$styling}
+        $active={props.active}
       >
         {children}
       </Div>

--- a/packages/navbar/src/types/navbar-props.ts
+++ b/packages/navbar/src/types/navbar-props.ts
@@ -4,6 +4,8 @@ export type Alignment = 'start' | 'center' | 'end';
 
 export type Orientation = 'stacked' | 'inline';
 
+export type NavbarStyling = 'bordered' | 'filled';
+
 export type UiNavbarProps = {
   children: React.ReactNode;
   /**  Stacked will render all options vertically - INLINE Default */
@@ -16,6 +18,8 @@ export type UiNavbarProps = {
   roundedCorners?: boolean;
   /** If items should be stretched, useful when navbar is rendered to cover whole width */
   stretchItems?: boolean;
+  /** The hover effect for the navbar*/
+  styling?: NavbarStyling;
 } & Omit<UiReactElementProps, 'children'>;
 
 export type privateNavbarProps = {
@@ -28,4 +32,5 @@ export type privateNavbarProps = {
   $stretchItems?: boolean;
   $orientation: Orientation;
   $align: Alignment;
+  $styling?: NavbarStyling;
 } & UiReactPrivateElementProps;

--- a/packages/text/__tests__/ui-link.spec.tsx
+++ b/packages/text/__tests__/ui-link.spec.tsx
@@ -157,5 +157,18 @@ describe('<UiLink />', () => {
 
       expect(screen.getByRole('link', { name: 'Link' })).toBeVisible();
     });
+
+    it('renders fine with wrap', () => {
+      uiRender(
+        <UiLink theme="positive" wrap>
+          Link
+        </UiLink>
+      );
+
+      expect(screen.getByRole('link', { name: 'Link' })).toBeVisible();
+      expect(screen.getByRole('link', { name: 'Link' })).toHaveStyleRule('text-overflow', 'ellipsis');
+      expect(screen.getByRole('link', { name: 'Link' })).toHaveStyleRule('white-space', 'nowrap');
+      expect(screen.getByRole('link', { name: 'Link' })).toHaveStyleRule('overflow', 'hidden!important');
+    });
   });
 });

--- a/packages/text/src/types/ui-link-props.ts
+++ b/packages/text/src/types/ui-link-props.ts
@@ -25,6 +25,8 @@ export type UiLinkProps = {
   fullWidth?: boolean;
   /** Font style */
   fontStyle?: FontStyle;
+  /** If text should wrap */
+  wrap?: boolean;
 } & UiReactElementProps;
 
 export type privateLinkProps = {
@@ -48,4 +50,5 @@ export type privateLinkProps = {
   $fontStyle?: FontStyle;
   $category: ColorCategory;
   to?: string;
+  $wrap?: boolean;
 } & UiReactPrivateElementProps;

--- a/packages/text/src/ui-link.tsx
+++ b/packages/text/src/ui-link.tsx
@@ -22,6 +22,7 @@ const Anchor = styled.a<privateLinkProps>`
     ${props.$fontStyle === 'bold' ? `font-weight: bold;` : ''}
     ${props.$fontStyle === 'light' ? `font-weight: 300;` : ''}
     ${props.$fontStyle === 'regular' ? `font-weight: normal;` : ''}
+    ${props.$wrap ? `text-overflow: ellipsis;white-space: nowrap;overflow: hidden !important;` : ''}
   `}
 
   cursor: pointer;
@@ -69,6 +70,7 @@ export const UiLink: React.FC<UiLinkProps> = ({
   target,
   useReactLink,
   testId,
+  wrap,
 }: UiLinkProps) => {
   const themeContext = React.useContext(ThemeContext);
 
@@ -82,6 +84,7 @@ export const UiLink: React.FC<UiLinkProps> = ({
         onClick={handleClick}
         $selectedTheme={themeContext.selectedTheme}
         $size={size}
+        $wrap={wrap}
       >
         <Link
           to={href}
@@ -112,6 +115,7 @@ export const UiLink: React.FC<UiLinkProps> = ({
       target={target}
       role="link"
       data-testid={testId}
+      $wrap={wrap}
     >
       {children}
     </Anchor>

--- a/src/gatsby-theme-docz/components/Sidebar/sidebar-group.tsx
+++ b/src/gatsby-theme-docz/components/Sidebar/sidebar-group.tsx
@@ -30,16 +30,17 @@ const nestedItemSpacing: UiSpacingProps['padding'] = { all: 'three' };
 const sidebarGroupSpacing: UiSpacingProps['margin'] = { block: 'three' };
 const nestedHeadingSpacing: UiSpacingProps['padding'] = { left: 'four' };
 
+const getCurrentHash = () => {
+  if (typeof window === 'undefined') {
+    return '';
+  }
+  return window.location ? decodeURI(window.location.hash) : '';
+};
+
 export const SidebarGroup = ({ menuItem }: SidebarGroupProps): React.ReactElement => {
   const currentDoc = useCurrentDoc();
   const [isExpanded, setIsExpanded] = useState(false);
-  const [currentHash, setCurrentHash] = useState('');
-
-  useEffect(() => {
-    if (window !== undefined && window.location.hash) {
-      setCurrentHash(window.location.hash);
-    }
-  }, [window?.location?.hash, setCurrentHash]);
+  const currentHash = getCurrentHash();
 
   useEffect(() => {
     let isSelected = false;
@@ -97,7 +98,7 @@ export const SidebarGroup = ({ menuItem }: SidebarGroupProps): React.ReactElemen
                           return (
                             <UiNavbarItem
                               key={`sidebar-submenu-nested-item-${index}`}
-                              active={currentHash.includes(heading.slug?.slice(0, -1))}
+                              active={currentHash === `#${heading.slug}`}
                             >
                               <UiSpacing padding={nestedHeadingSpacing}>
                                 <UiLink href={`#${heading?.slug}`} fullWidth wrap>

--- a/src/gatsby-theme-docz/components/Sidebar/sidebar-group.tsx
+++ b/src/gatsby-theme-docz/components/Sidebar/sidebar-group.tsx
@@ -5,7 +5,7 @@ import styled from 'styled-components';
 
 import { UiLink, UiText } from '@uireact/text';
 import { UiNavbar, UiNavbarItem } from '@uireact/navbar';
-import { UiSpacing, UiSpacingProps } from '@uireact/foundation';
+import { TextSize, UiSpacing, UiSpacingProps } from '@uireact/foundation';
 
 type SidebarGroupProps = {
   menuItem: MenuItem;
@@ -62,9 +62,11 @@ export const SidebarGroup = ({ menuItem }: SidebarGroupProps): React.ReactElemen
     <UiSpacing margin={sidebarGroupSpacing}>
       <GroupHeadingDiv onClick={onClick}>
         {menuItem.menu && menuItem.menu.length > 0 ? (
-          <UiText theme={isExpanded ? 'tertiary' : undefined}>{menuItem.name}</UiText>
+          <UiText theme={isExpanded ? 'tertiary' : undefined} size={TextSize.large}>
+            {menuItem.name}
+          </UiText>
         ) : (
-          <UiLink href={menuItem.route}>
+          <UiLink href={menuItem.route} size={TextSize.large}>
             <UiText>{menuItem.name}</UiText>
           </UiLink>
         )}
@@ -83,6 +85,7 @@ export const SidebarGroup = ({ menuItem }: SidebarGroupProps): React.ReactElemen
                       href={item.route}
                       fullWidth
                       theme={item.route !== undefined && item.route === currentDoc?.route ? 'tertiary' : undefined}
+                      size={TextSize.large}
                     >
                       {item.name}
                     </UiLink>

--- a/src/gatsby-theme-docz/components/Sidebar/sidebar-group.tsx
+++ b/src/gatsby-theme-docz/components/Sidebar/sidebar-group.tsx
@@ -33,6 +33,13 @@ const nestedHeadingSpacing: UiSpacingProps['padding'] = { left: 'four' };
 export const SidebarGroup = ({ menuItem }: SidebarGroupProps): React.ReactElement => {
   const currentDoc = useCurrentDoc();
   const [isExpanded, setIsExpanded] = useState(false);
+  const [currentHash, setCurrentHash] = useState('');
+
+  useEffect(() => {
+    if (window !== undefined && window.location.hash) {
+      setCurrentHash(window.location.hash);
+    }
+  }, [window?.location?.hash, setCurrentHash]);
 
   useEffect(() => {
     let isSelected = false;
@@ -71,11 +78,15 @@ export const SidebarGroup = ({ menuItem }: SidebarGroupProps): React.ReactElemen
               >
                 <UiSpacing padding={nestedItemSpacing}>
                   <>
-                    <UiLink href={item.route} fullWidth theme="tertiary">
+                    <UiLink
+                      href={item.route}
+                      fullWidth
+                      theme={item.route !== undefined && item.route === currentDoc?.route ? 'tertiary' : undefined}
+                    >
                       {item.name}
                     </UiLink>
                     {item.route !== undefined && item.route === currentDoc.route && (
-                      <UiNavbar category="secondary" orientation="stacked">
+                      <UiNavbar category="secondary" orientation="stacked" styling="bordered">
                         {/* eslint-disable-next-line @typescript-eslint/ban-ts-comment */}
                         {/*@ts-ignore-next */}
                         {item.headings?.map((heading, index) => {
@@ -84,9 +95,12 @@ export const SidebarGroup = ({ menuItem }: SidebarGroupProps): React.ReactElemen
                           }
 
                           return (
-                            <UiNavbarItem key={`sidebar-submenu-nested-item-${index}`}>
+                            <UiNavbarItem
+                              key={`sidebar-submenu-nested-item-${index}`}
+                              active={currentHash.includes(heading.slug?.slice(0, -1))}
+                            >
                               <UiSpacing padding={nestedHeadingSpacing}>
-                                <UiLink href={`#${heading?.slug}`} fullWidth theme="tertiary">
+                                <UiLink href={`#${heading?.slug}`} fullWidth wrap>
                                   {heading?.value}
                                 </UiLink>
                               </UiSpacing>


### PR DESCRIPTION
## 🔥 Adding styling prop to navbar
----------------------------------------------

### Description
As there might be different use cases with different styling I'm adding a styling prop so we can handle the different css properties that will take use based on the selected styling.

Currently there are 2 options:

 - Bordered
  - Renders only a border in the left side when navbar is stacked to show which item has the hover and active state
  - Future PR will render the border in the bottom when navbar is rendered inline.
 - Filled
  - Renders a background to show the hover and active state. 

### Screenshots

#### Before
<img width="719" alt="Screenshot 2023-08-12 at 12 31 24 PM" src="https://github.com/inavac182/uireact/assets/16787893/35f3cf95-805c-4fcb-8d36-e57dc5f03db5">


#### After
![Aug-12-2023 12-31-06](https://github.com/inavac182/uireact/assets/16787893/ae266bee-4e79-4a8e-85a3-f72dbe7c4076)
