### PR TITLE
feat(navbar): render border bottom in inline navbar

### DIFF
--- a/packages/navbar/__tests__/navbar.spec.tsx
+++ b/packages/navbar/__tests__/navbar.spec.tsx
@@ -160,6 +160,20 @@ describe('<UiNavbar />', () => {
     expect(screen.getByText('Option 3')).toBeVisible();
   });
 
+  it('Should render with bordered styling when is stacked', () => {
+    render(
+      <UiNavbar category="secondary" styling="bordered" orientation="stacked">
+        {`Option 1`}
+        <UiNavbarItem active>Option 2</UiNavbarItem>
+        <UiNavbarItem>Option 3</UiNavbarItem>
+      </UiNavbar>
+    );
+
+    expect(screen.queryByText('Option 1')).not.toBeInTheDocument();
+    expect(screen.getByText('Option 2')).toBeVisible();
+    expect(screen.getByText('Option 3')).toBeVisible();
+  });
+
   it('Should render with filled styling', () => {
     render(
       <UiNavbar category="secondary" styling="filled">

--- a/packages/navbar/src/private/navbar-item-wrapper.tsx
+++ b/packages/navbar/src/private/navbar-item-wrapper.tsx
@@ -55,31 +55,27 @@ const Div = styled.div<NavbarItemWrapperProps>`
         props.$styling === 'bordered'
           ? `
             &:hover {
-              border-left: 2px solid ${getThemeColor(
-                props.$customTheme,
-                props.$selectedTheme,
-                getColorCategory(props.$category),
-                ColorTokens.token_150,
-                false
-              )};
-            }`
-          : `&:hover { ${getThemeStyling(
-              props.$customTheme,
-              props.$selectedTheme,
-              getNavbarItemMapper(props.$category)
-            )} }`
-      }
-      ${
-        props.$active
-          ? props.$styling === 'bordered'
-            ? `
-            border-left: 2px solid ${getThemeColor(
+              border-${props.$orientation === 'inline' ? 'bottom' : 'left'}: 2px solid ${getThemeColor(
               props.$customTheme,
               props.$selectedTheme,
               getColorCategory(props.$category),
               ColorTokens.token_150,
               false
             )};
+            }`
+          : getThemeStyling(props.$customTheme, props.$selectedTheme, getNavbarItemMapper(props.$category))
+      }
+      ${
+        props.$active
+          ? props.$styling === 'bordered'
+            ? `
+            border-${props.$orientation === 'inline' ? 'bottom' : 'left'}: 2px solid ${getThemeColor(
+                props.$customTheme,
+                props.$selectedTheme,
+                getColorCategory(props.$category),
+                ColorTokens.token_150,
+                false
+              )};
             `
             : `
             background-color: ${getThemeColor(


### PR DESCRIPTION
## 🔥 Navbar border on inline orientation
----------------------------------------------

### Description
The border should render at the bottom when is oriented inline/

### Screenshots

#### Before

#### After
<img width="889" alt="Screenshot 2023-08-14 at 10 53 44 AM" src="https://github.com/inavac182/uireact/assets/16787893/336e857d-2af5-45ad-b875-deef3c7fd182">
