### PR TITLE
fix(tabs): rounded corners

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ We are too busy <span style="font-size:10px">(or too lazy? 😅)</span> to have 
 
 ## What? 😲
 
-@UiReact is a React library of Themed UI components that are ready to be used to speed up react web development. The themes allows for a bunch of customization and the components are very flexible as well to cover a bunch of the most common use cases.
+@UiReact is a React library of Themed UI components that are ready to be used to speed up react web development. The themes allows for a lot of customization and the components are very flexible as well to cover a wide variety of the use cases.
 
 ## Why? 🤓
 

--- a/packages/tabs/__tests__/ui-tabs.spec.tsx
+++ b/packages/tabs/__tests__/ui-tabs.spec.tsx
@@ -30,6 +30,14 @@ describe('<UiTabs />', () => {
     expect(screen.getByText('Item 3')).toBeVisible();
   });
 
+  it('renders fine when rounded', () => {
+    uiRender(<MockedComponent rounded />);
+
+    expect(screen.getByText('Item 1')).toBeVisible();
+    expect(screen.getByText('Item 2')).toBeVisible();
+    expect(screen.getByText('Item 3')).toBeVisible();
+  });
+
   it('Triggers CB when tab item is clicked', () => {
     uiRender(<MockedComponent />);
 

--- a/packages/tabs/__tests__/ui-tabs.spec.tsx
+++ b/packages/tabs/__tests__/ui-tabs.spec.tsx
@@ -7,8 +7,12 @@ import { UiTabs, UiTabItem } from '../src';
 
 const onClick = jest.fn();
 
-const MockedComponent = () => (
-  <UiTabs>
+type MockedComponentProps = {
+  rounded?: boolean;
+};
+
+const MockedComponent = ({ rounded }: MockedComponentProps) => (
+  <UiTabs rounded={rounded}>
     <UiTabItem identifier="1" handleClick={onClick} selected>
       Item 1
     </UiTabItem>
@@ -23,7 +27,7 @@ const MockedComponent = () => (
 
 describe('<UiTabs />', () => {
   it('renders fine', () => {
-    uiRender(<MockedComponent />);
+    uiRender(<MockedComponent rounded />);
 
     expect(screen.getByText('Item 1')).toBeVisible();
     expect(screen.getByText('Item 2')).toBeVisible();
@@ -31,7 +35,7 @@ describe('<UiTabs />', () => {
   });
 
   it('renders fine when rounded', () => {
-    uiRender(<MockedComponent rounded />);
+    uiRender(<MockedComponent />);
 
     expect(screen.getByText('Item 1')).toBeVisible();
     expect(screen.getByText('Item 2')).toBeVisible();

--- a/packages/tabs/docs/docs.mdx
+++ b/packages/tabs/docs/docs.mdx
@@ -50,6 +50,40 @@ import { UiTabs, UiTabItem } from '../src/';
   <TabsExample />
 </Playground>
 
+TabsExample:
+
+```
+export const TabsExample: React.FC = () => {
+  const [selectedTab, setSelectedTab] = React.useState(1);
+
+  const handleTabClick = React.useCallback(
+    (identifier) => {
+      setSelectedTab(identifier);
+    },
+    [setSelectedTab]
+  );
+
+  return (
+    <UiCard noPadding>
+      <UiTabs rounded>
+        <UiTabItem selected={selectedTab === 1} identifier={1} handleClick={handleTabClick}>
+          <UiText>Fruits</UiText>
+        </UiTabItem>
+        <UiTabItem selected={selectedTab === 2} identifier={2} handleClick={handleTabClick}>
+          <UiText>Vegetables</UiText>
+        </UiTabItem>
+        <UiTabItem selected={selectedTab === 3} identifier={3} handleClick={handleTabClick}>
+          <UiText>Meats</UiText>
+        </UiTabItem>
+      </UiTabs>
+      {selectedTab === 1 && <Fruits />}
+      {selectedTab === 2 && <Veggies />}
+      {selectedTab === 3 && <Meats />}
+    </UiCard>
+  );
+};
+```
+
 ### UiTabs Props
 
 <Props of={UiTabs} />

--- a/packages/tabs/docs/utils/tabs-example.tsx
+++ b/packages/tabs/docs/utils/tabs-example.tsx
@@ -6,6 +6,72 @@ import { UiText } from '@uireact/text';
 
 import { UiTabs, UiTabItem } from '../../src/';
 
+const Fruits = () => (
+  <div>
+    <UiList>
+      <UiListItem>
+        <UiText>🍎 Apple</UiText>
+      </UiListItem>
+      <UiListItem>
+        <UiText>🍐 Pear</UiText>
+      </UiListItem>
+      <UiListItem>
+        <UiText>🍊 Orange</UiText>
+      </UiListItem>
+      <UiListItem>
+        <UiText>🍌 Banana</UiText>
+      </UiListItem>
+      <UiListItem>
+        <UiText>🍉 Watermelon</UiText>
+      </UiListItem>
+    </UiList>
+  </div>
+);
+
+const Veggies = () => (
+  <div>
+    <UiList>
+      <UiListItem>
+        <UiText>🥑 Avocado</UiText>
+      </UiListItem>
+      <UiListItem>
+        <UiText>🥦 Brocolli</UiText>
+      </UiListItem>
+      <UiListItem>
+        <UiText>🍅 Tomato</UiText>
+      </UiListItem>
+      <UiListItem>
+        <UiText>🌶️ Jalapeño</UiText>
+      </UiListItem>
+      <UiListItem>
+        <UiText>🫑 Pepper</UiText>
+      </UiListItem>
+    </UiList>
+  </div>
+);
+
+const Meats = () => (
+  <div>
+    <UiList>
+      <UiListItem>
+        <UiText>🥩 T-bone</UiText>
+      </UiListItem>
+      <UiListItem>
+        <UiText>🍗 Drums</UiText>
+      </UiListItem>
+      <UiListItem>
+        <UiText>🍖 Ribs</UiText>
+      </UiListItem>
+      <UiListItem>
+        <UiText>🥓 Bacon</UiText>
+      </UiListItem>
+      <UiListItem>
+        <UiText>🦴 Bone Marrow</UiText>
+      </UiListItem>
+    </UiList>
+  </div>
+);
+
 export const TabsExample: React.FC = () => {
   const [selectedTab, setSelectedTab] = React.useState(1);
 
@@ -18,7 +84,7 @@ export const TabsExample: React.FC = () => {
 
   return (
     <UiCard noPadding>
-      <UiTabs>
+      <UiTabs rounded>
         <UiTabItem selected={selectedTab === 1} identifier={1} handleClick={handleTabClick}>
           <UiText>Fruits</UiText>
         </UiTabItem>
@@ -29,69 +95,9 @@ export const TabsExample: React.FC = () => {
           <UiText>Meats</UiText>
         </UiTabItem>
       </UiTabs>
-      {selectedTab === 1 && (
-        <div>
-          <UiList>
-            <UiListItem>
-              <UiText>🍎 Apple</UiText>
-            </UiListItem>
-            <UiListItem>
-              <UiText>🍐 Pear</UiText>
-            </UiListItem>
-            <UiListItem>
-              <UiText>🍊 Orange</UiText>
-            </UiListItem>
-            <UiListItem>
-              <UiText>🍌 Banana</UiText>
-            </UiListItem>
-            <UiListItem>
-              <UiText>🍉 Watermelon</UiText>
-            </UiListItem>
-          </UiList>
-        </div>
-      )}
-      {selectedTab === 2 && (
-        <div>
-          <UiList>
-            <UiListItem>
-              <UiText>🥑 Avocado</UiText>
-            </UiListItem>
-            <UiListItem>
-              <UiText>🥦 Brocolli</UiText>
-            </UiListItem>
-            <UiListItem>
-              <UiText>🍅 Tomato</UiText>
-            </UiListItem>
-            <UiListItem>
-              <UiText>🌶️ Jalapeño</UiText>
-            </UiListItem>
-            <UiListItem>
-              <UiText>🫑 Pepper</UiText>
-            </UiListItem>
-          </UiList>
-        </div>
-      )}
-      {selectedTab === 3 && (
-        <div>
-          <UiList>
-            <UiListItem>
-              <UiText>🥩 T-bone</UiText>
-            </UiListItem>
-            <UiListItem>
-              <UiText>🍗 Drums</UiText>
-            </UiListItem>
-            <UiListItem>
-              <UiText>🍖 Ribs</UiText>
-            </UiListItem>
-            <UiListItem>
-              <UiText>🥓 Bacon</UiText>
-            </UiListItem>
-            <UiListItem>
-              <UiText>🦴 Bone Marrow</UiText>
-            </UiListItem>
-          </UiList>
-        </div>
-      )}
+      {selectedTab === 1 && <Fruits />}
+      {selectedTab === 2 && <Veggies />}
+      {selectedTab === 3 && <Meats />}
     </UiCard>
   );
 };

--- a/packages/tabs/src/types/tab-item-props.ts
+++ b/packages/tabs/src/types/tab-item-props.ts
@@ -9,4 +9,10 @@ export type UiTabItemProps = {
   handleClick: (identifier: string | number) => void;
 } & UiReactElementProps;
 
-export type privateTabItemProps = Omit<UiTabItemProps, 'handleClick'> & UiReactPrivateElementProps;
+export type privateTabItemProps = {
+  /** Tab identifier to be shared when clicked */
+  $identifier: string | number;
+  /** Selected state for tab item */
+  $selected?: boolean;
+  /** On click CB for tab item */
+} & UiReactPrivateElementProps;

--- a/packages/tabs/src/types/tabs-props.ts
+++ b/packages/tabs/src/types/tabs-props.ts
@@ -5,4 +5,7 @@ export type UiTabsProps = {
   rounded?: boolean;
 } & UiReactElementProps;
 
-export type privateTabsProps = UiTabsProps & UiReactPrivateElementProps;
+export type privateTabsProps = {
+  /** For rounded corners */
+  $rounded?: boolean;
+} & UiReactPrivateElementProps;

--- a/packages/tabs/src/ui-tab-item.tsx
+++ b/packages/tabs/src/ui-tab-item.tsx
@@ -11,7 +11,7 @@ const TabItem = styled.div<privateTabItemProps>`
   ${(props) => `
     ${getThemeStyling(props.$customTheme, props.$selectedTheme, TabsMapper)}
     ${
-      props.selected
+      props.$selected
         ? `border-color: ${getThemeColor(
             props.$customTheme,
             props.$selectedTheme,
@@ -52,8 +52,8 @@ export const UiTabItem: React.FC<UiTabItemProps> = ({
       $selectedTheme={theme.selectedTheme}
       className={className}
       onClick={handleTabClick}
-      identifier={identifier}
-      selected={selected}
+      $identifier={identifier}
+      $selected={selected}
     >
       {children}
     </TabItem>

--- a/packages/tabs/src/ui-tabs.tsx
+++ b/packages/tabs/src/ui-tabs.tsx
@@ -8,13 +8,23 @@ import { UiTabsProps, privateTabsProps } from './types';
 
 const TabDiv = styled.div<privateTabsProps>`
   display: flex;
+
+  ${(props) => `
+    ${
+      props.$rounded
+        ? ` 
+          > :first-child { border-radius: 3px 0px 0px 0px; }
+          > :last-child { border-radius: 0px 3px 0px 0px; }`
+        : ''
+    }
+  `}
 `;
 
-export const UiTabs: React.FC<UiTabsProps> = ({ children, className }: UiTabsProps) => {
+export const UiTabs: React.FC<UiTabsProps> = ({ children, className, rounded }: UiTabsProps) => {
   const theme = React.useContext(ThemeContext);
 
   return (
-    <TabDiv $customTheme={theme.theme} $selectedTheme={theme.selectedTheme} className={className}>
+    <TabDiv $customTheme={theme.theme} $selectedTheme={theme.selectedTheme} className={className} $rounded={rounded}>
       {children}
     </TabDiv>
   );


### PR DESCRIPTION
## 🔥 Tabs rounded corners
----------------------------------------------

### Description
I noticed that the tabs were not rendering rounded corners so I'm updating the styling to show it correctly.

### Screenshots

#### Before
<img width="130" alt="Screenshot 2023-08-14 at 12 18 19 PM" src="https://github.com/inavac182/uireact/assets/16787893/9d02afb3-4f2a-4af1-838f-5ea2ab42d3fa">

#### After
<img width="285" alt="Screenshot 2023-08-14 at 12 10 10 PM" src="https://github.com/inavac182/uireact/assets/16787893/2e3369c1-a560-497a-8461-e8c0a62cef77">

