### PR TITLE
refactor(grid): default to large state when using breakpoints prop

### DIFF
--- a/packages/grid/src/grid.tsx
+++ b/packages/grid/src/grid.tsx
@@ -46,23 +46,23 @@ const getSpanValueFromBreakpoint = (
   return 1;
 };
 
+const getSsrValue = (value: number | GridBreakpointsDistribution): number => {
+  if (typeof value === 'number') {
+    return value;
+  }
+
+  if (typeof value === 'object') {
+    return value.large;
+  }
+
+  return 1;
+};
+
 export const UiGrid: React.FC<UiGridProps> = (props: UiGridProps) => {
   const viewport = useViewport();
-  const [cols, setCols] = useState<number>(
-    props.cols && typeof props.cols === 'number'
-      ? props.cols
-      : typeof props.cols === 'object'
-      ? getSpanValueFromBreakpoint(viewport, props.cols)
-      : 1
-  );
+  const [cols, setCols] = useState<number>(getSsrValue(props.cols || 1));
 
-  const [rows, setRows] = useState<number>(
-    props.rows && typeof props.rows === 'number'
-      ? props.rows
-      : typeof props.rows === 'object'
-      ? getSpanValueFromBreakpoint(viewport, props.rows)
-      : 1
-  );
+  const [rows, setRows] = useState<number>(getSsrValue(props.rows || 1));
 
   useEffect(() => {
     if (props.cols && typeof props.cols === 'object') {

--- a/packages/view/src/types/ui-view-props.ts
+++ b/packages/view/src/types/ui-view-props.ts
@@ -25,4 +25,7 @@ export type UiViewRowProps = {
 
 export type privateViewProps = Omit<Omit<Omit<UiViewProps, 'selectedTheme'>, 'theme'>, 'dialogController'> &
   UiReactPrivateElementProps;
-export type privateViewRowProps = UiViewRowProps & UiReactPrivateElementProps;
+export type privateViewRowProps = {
+  $centeredContent?: boolean;
+  $weight?: '10' | '50' | '100' | '150' | '200';
+} & UiReactPrivateElementProps;

--- a/packages/view/src/ui-view-row.tsx
+++ b/packages/view/src/ui-view-row.tsx
@@ -10,7 +10,7 @@ import { CenteredDiv } from './__private';
 
 const Div = styled.div<privateViewRowProps>`
   ${(props) => {
-    const mapper = dynamicViewRowMapper(props.weight);
+    const mapper = dynamicViewRowMapper(props.$weight);
     return getThemeStyling(props.$customTheme, props.$selectedTheme, mapper);
   }}
 `;
@@ -27,7 +27,7 @@ export const UiViewRow: React.FC<UiViewRowProps> = ({
     <Div
       $customTheme={themeContext.theme}
       $selectedTheme={themeContext.selectedTheme}
-      weight={weight}
+      $weight={weight}
       className={className}
     >
       {centeredContent ? (

--- a/packages/view/src/ui-view.tsx
+++ b/packages/view/src/ui-view.tsx
@@ -26,6 +26,10 @@ const GlobalStyle = createGlobalStyle<privateViewProps>`
     padding: 0;
   }
 
+  a {
+    text-decoration: none;
+  }
+
   body {
     ${(props) => `
       ${`font-family: ${props.$customTheme.texts.font};`}


### PR DESCRIPTION
## 🔥 Default to large in grid ssr
----------------------------------------------

### Description
I'm seeing a weird issue in SSR when the grid is using the breakpoints distribution prop. It's making react to fail on hydration with different classes when using in Next.JS, so in order to fix this I'm defaulting to large.

### Screenshots

#### Before
<img width="1073" alt="Screenshot 2023-08-15 at 2 04 22 PM" src="https://github.com/inavac182/uireact/assets/16787893/15bf6edc-8047-42aa-a162-28773ab120f7">

#### After

No error I hope 🤞