### PR TITLE
fix: tab item custom typing for callback

### DIFF
--- a/packages/tabs/docs/docs.mdx
+++ b/packages/tabs/docs/docs.mdx
@@ -22,7 +22,8 @@ import { UiTabs, UiTabItem } from '../src/';
   </a>
 </sup>
 
-> Component to render tabs for selection
+> Component that renders a tabs for an options selection experience. When a tab is clicked it executes a callback and it passes an identifier that
+> to identify what tab was clicked. The UiTabItem allows for any custom type to be passed so the callback function is correctly typed.
 
 ## Installation
 
@@ -30,25 +31,11 @@ import { UiTabs, UiTabItem } from '../src/';
 
 ## UiTabs
 
-<Playground>
-  <UiTabs>
-    <UiTabItem>
-      <UiText>Item 1</UiText>
-    </UiTabItem>
-    <UiTabItem selected>
-      <UiText>Item 2</UiText>
-    </UiTabItem>
-    <UiTabItem>
-      <UiText>Item 3</UiText>
-    </UiTabItem>
-  </UiTabs>
-</Playground>
-
-## UiTabs with state management
-
 <Playground hideThemeSelector>
   <TabsExample />
 </Playground>
+
+<br />
 
 TabsExample:
 
@@ -57,7 +44,7 @@ export const TabsExample: React.FC = () => {
   const [selectedTab, setSelectedTab] = React.useState(1);
 
   const handleTabClick = React.useCallback(
-    (identifier) => {
+    (identifier: number) => {
       setSelectedTab(identifier);
     },
     [setSelectedTab]
@@ -66,13 +53,13 @@ export const TabsExample: React.FC = () => {
   return (
     <UiCard noPadding>
       <UiTabs rounded>
-        <UiTabItem selected={selectedTab === 1} identifier={1} handleClick={handleTabClick}>
+        <UiTabItem<number> selected={selectedTab === 1} identifier={1} handleClick={handleTabClick}>
           <UiText>Fruits</UiText>
         </UiTabItem>
-        <UiTabItem selected={selectedTab === 2} identifier={2} handleClick={handleTabClick}>
+        <UiTabItem<number> selected={selectedTab === 2} identifier={2} handleClick={handleTabClick}>
           <UiText>Vegetables</UiText>
         </UiTabItem>
-        <UiTabItem selected={selectedTab === 3} identifier={3} handleClick={handleTabClick}>
+        <UiTabItem<number> selected={selectedTab === 3} identifier={3} handleClick={handleTabClick}>
           <UiText>Meats</UiText>
         </UiTabItem>
       </UiTabs>

--- a/packages/tabs/docs/utils/tabs-example.tsx
+++ b/packages/tabs/docs/utils/tabs-example.tsx
@@ -76,7 +76,7 @@ export const TabsExample: React.FC = () => {
   const [selectedTab, setSelectedTab] = React.useState(1);
 
   const handleTabClick = React.useCallback(
-    (identifier) => {
+    (identifier: number) => {
       setSelectedTab(identifier);
     },
     [setSelectedTab]
@@ -85,13 +85,13 @@ export const TabsExample: React.FC = () => {
   return (
     <UiCard noPadding>
       <UiTabs rounded>
-        <UiTabItem selected={selectedTab === 1} identifier={1} handleClick={handleTabClick}>
+        <UiTabItem<number> selected={selectedTab === 1} identifier={1} handleClick={handleTabClick}>
           <UiText>Fruits</UiText>
         </UiTabItem>
-        <UiTabItem selected={selectedTab === 2} identifier={2} handleClick={handleTabClick}>
+        <UiTabItem<number> selected={selectedTab === 2} identifier={2} handleClick={handleTabClick}>
           <UiText>Vegetables</UiText>
         </UiTabItem>
-        <UiTabItem selected={selectedTab === 3} identifier={3} handleClick={handleTabClick}>
+        <UiTabItem<number> selected={selectedTab === 3} identifier={3} handleClick={handleTabClick}>
           <UiText>Meats</UiText>
         </UiTabItem>
       </UiTabs>

--- a/packages/tabs/src/types/tab-item-props.ts
+++ b/packages/tabs/src/types/tab-item-props.ts
@@ -1,18 +1,15 @@
 import { UiReactElementProps, UiReactPrivateElementProps } from '@uireact/foundation';
 
-export type UiTabItemProps = {
+export type UiTabItemProps<T> = {
   /** Tab identifier to be shared when clicked */
-  identifier: string | number;
+  identifier: T;
   /** Selected state for tab item */
   selected?: boolean;
   /** On click CB for tab item */
-  handleClick: (identifier: string | number) => void;
+  handleClick: (identifier: T) => void;
 } & UiReactElementProps;
 
 export type privateTabItemProps = {
-  /** Tab identifier to be shared when clicked */
-  $identifier: string | number;
   /** Selected state for tab item */
   $selected?: boolean;
-  /** On click CB for tab item */
 } & UiReactPrivateElementProps;

--- a/packages/tabs/src/ui-tab-item.tsx
+++ b/packages/tabs/src/ui-tab-item.tsx
@@ -33,13 +33,13 @@ const TabItem = styled.div<privateTabItemProps>`
   padding: 5px 0px 5px 0px;
 `;
 
-export const UiTabItem: React.FC<UiTabItemProps> = ({
+export function UiTabItem<T>({
   className,
   children,
   handleClick,
   identifier,
   selected,
-}: UiTabItemProps) => {
+}: UiTabItemProps<T>): JSX.Element {
   const theme = React.useContext(ThemeContext);
 
   const handleTabClick = React.useCallback(() => {
@@ -52,12 +52,11 @@ export const UiTabItem: React.FC<UiTabItemProps> = ({
       $selectedTheme={theme.selectedTheme}
       className={className}
       onClick={handleTabClick}
-      $identifier={identifier}
       $selected={selected}
     >
       {children}
     </TabItem>
   );
-};
+}
 
 UiTabItem.displayName = 'UiTabItem';


### PR DESCRIPTION
## 🔥 Custom type for UiTabItem
----------------------------------------------

### Description
Allow for a custom type passed to the UiTabItem element so the callback can be typed correctly

### Screenshots

#### Before

#### After
