### PR TITLE
docs: extend styling docs

### DIFF
--- a/docs/extending-component.mdx
+++ b/docs/extending-component.mdx
@@ -25,6 +25,8 @@ Now, we will import styled components and apply a custom style to the `UiCard`:
 ```jsx
 import styled from 'styled-components';
 
+import { UiCard } from '@uireact/card';
+
 const CustomUiCard = styled(UiCard)`
   border-radius: 20px 50px 20px 50px;
   box-shadow: rgba(50, 50, 93, 0.25) 0px 50px 100px -20px, rgba(0, 0, 0, 0.3) 0px 30px 60px -30px;

--- a/docs/extending-component.mdx
+++ b/docs/extending-component.mdx
@@ -1,0 +1,43 @@
+---
+name: Extend component styling
+menu: Documentation
+route: /extend-component-styling
+---
+
+import { ExtendStyleExpample } from './helpers/extend-styling-example.tsx';
+import { JustACard } from './helpers/just-a-card.tsx';
+
+import { UiCard } from '@uireact/card';
+
+# Extending a component styling 💅🏿
+
+---
+
+We know that there are enless number of use cases and a library for everything is not efficient, so with styled components
+you can extend the styling of a component, this is how you would do it:
+
+First, we render a normal `UiCard` component:
+
+<JustACard />
+
+Now, we will import styled components and apply a custom style to the `UiCard`:
+
+```jsx
+import styled from 'styled-components';
+
+const CustomUiCard = styled(UiCard)`
+  border-radius: 20px 50px 20px 50px;
+  box-shadow: rgba(50, 50, 93, 0.25) 0px 50px 100px -20px, rgba(0, 0, 0, 0.3) 0px 30px 60px -30px;
+`;
+
+export const MyComponent = () => {
+  return <CustomUiCard>Some content<CustomUiCard>;
+}
+```
+
+<ExtendStyleExpample />
+
+<br />
+<br />
+
+You can see the component used in this example [Here](https://github.com/inavac182/uireact/tree/main/docs/helpers/extend-styling-example.tsx)

--- a/docs/extending-component.mdx
+++ b/docs/extending-component.mdx
@@ -13,7 +13,7 @@ import { UiCard } from '@uireact/card';
 
 ---
 
-We know that there are enless number of use cases and a library for everything is not efficient, so with styled components
+We know that there are endless number of use cases and a library to fit them all is not efficient nor possible, so with styled components
 you can extend the styling of a component, this is how you would do it:
 
 First, we render a normal `UiCard` component:

--- a/docs/extending-component.mdx
+++ b/docs/extending-component.mdx
@@ -1,6 +1,6 @@
 ---
 name: Extend component styling
-menu: Documentation
+menu: Advanced
 route: /extend-component-styling
 ---
 

--- a/docs/helpers/extend-styling-example.tsx
+++ b/docs/helpers/extend-styling-example.tsx
@@ -1,0 +1,28 @@
+import React from 'react';
+
+import styled from 'styled-components';
+
+import { UiCard } from '@uireact/card';
+import { UiHeading, UiText } from '@uireact/text';
+import { UiButton } from '@uireact/button';
+import { UiSpacing, UiSpacingProps } from '@uireact/foundation';
+
+const CustomUiCard = styled(UiCard)`
+  border-radius: 20px 50px 20px 50px;
+  box-shadow: rgba(50, 50, 93, 0.25) 0px 50px 100px -20px, rgba(0, 0, 0, 0.3) 0px 30px 60px -30px;
+`;
+
+const cardContentPadding: UiSpacingProps['padding'] = { all: 'six' };
+
+export const ExtendStyleExpample = () => (
+  <>
+    <CustomUiCard>
+      <UiSpacing padding={cardContentPadding}>
+        <UiHeading>Custom card</UiHeading>
+        <UiText>The styling of this card has been extended to have different radius in each corner</UiText>
+        <br />
+        <UiButton> Some element 🫶 </UiButton>
+      </UiSpacing>
+    </CustomUiCard>
+  </>
+);

--- a/docs/helpers/just-a-card.tsx
+++ b/docs/helpers/just-a-card.tsx
@@ -1,0 +1,21 @@
+import React from 'react';
+
+import { UiCard } from '@uireact/card';
+import { UiHeading, UiText } from '@uireact/text';
+import { UiButton } from '@uireact/button';
+import { UiSpacing, UiSpacingProps } from '@uireact/foundation';
+
+const cardContentPadding: UiSpacingProps['padding'] = { all: 'six' };
+
+export const JustACard = () => (
+  <>
+    <UiCard>
+      <UiSpacing padding={cardContentPadding}>
+        <UiHeading>Custom card</UiHeading>
+        <UiText>The styling of this card has been extended to have different radius in each corner</UiText>
+        <br />
+        <UiButton> Some element 🫶 </UiButton>
+      </UiSpacing>
+    </UiCard>
+  </>
+);


### PR DESCRIPTION
## 🔥 Extend styling docs
----------------------------------------------

### Description
Adding a doc to showcase how we can extend the styling of a component in a client app

### Screenshots
![Screenshot 2023-08-20 at 4 00 00 PM](https://github.com/inavac182/uireact/assets/16787893/5be282eb-691a-4ec3-ae0e-9f05601dc247)
