### PR TITLE
feat(text): wrap heading and text align

### DIFF
--- a/packages/text/__tests__/ui-heading.spec.tsx
+++ b/packages/text/__tests__/ui-heading.spec.tsx
@@ -12,6 +12,12 @@ describe('<UiHeading />', () => {
     expect(screen.getByRole('heading', { name: 'Heading', level: 3 })).toBeVisible();
   });
 
+  it('renders fine when is wrapped', () => {
+    uiRender(<UiHeading wrap>Heading</UiHeading>);
+
+    expect(screen.getByRole('heading', { name: 'Heading', level: 3 })).toBeVisible();
+  });
+
   it('renders fine when level is unrecognized', () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     //@ts-ignore
@@ -42,6 +48,16 @@ describe('<UiHeading />', () => {
     expect(screen.getByRole('heading', { name: 'Heading', level: 1 })).toBeVisible();
   });
 
+  it('renders fine with level 1 and wrapped', () => {
+    uiRender(
+      <UiHeading level={1} wrap>
+        Heading
+      </UiHeading>
+    );
+
+    expect(screen.getByRole('heading', { name: 'Heading', level: 1 })).toBeVisible();
+  });
+
   it('renders fine with level 2', () => {
     uiRender(<UiHeading level={2}>Heading</UiHeading>);
 
@@ -51,6 +67,16 @@ describe('<UiHeading />', () => {
   it('renders fine with level 2 and centered', () => {
     uiRender(
       <UiHeading level={2} centered>
+        Heading
+      </UiHeading>
+    );
+
+    expect(screen.getByRole('heading', { name: 'Heading', level: 2 })).toBeVisible();
+  });
+
+  it('renders fine with level 2 and wrapped', () => {
+    uiRender(
+      <UiHeading level={2} wrap>
         Heading
       </UiHeading>
     );
@@ -74,6 +100,16 @@ describe('<UiHeading />', () => {
     expect(screen.getByRole('heading', { name: 'Heading', level: 3 })).toBeVisible();
   });
 
+  it('renders fine with level 3 and wrap', () => {
+    uiRender(
+      <UiHeading level={3} wrap>
+        Heading
+      </UiHeading>
+    );
+
+    expect(screen.getByRole('heading', { name: 'Heading', level: 3 })).toBeVisible();
+  });
+
   it('renders fine with level 4', () => {
     uiRender(<UiHeading level={4}>Heading</UiHeading>);
 
@@ -83,6 +119,16 @@ describe('<UiHeading />', () => {
   it('renders fine with level 4 and centered', () => {
     uiRender(
       <UiHeading level={4} centered>
+        Heading
+      </UiHeading>
+    );
+
+    expect(screen.getByRole('heading', { name: 'Heading', level: 4 })).toBeVisible();
+  });
+
+  it('renders fine with level 4 and wrap', () => {
+    uiRender(
+      <UiHeading level={4} wrap>
         Heading
       </UiHeading>
     );
@@ -106,6 +152,16 @@ describe('<UiHeading />', () => {
     expect(screen.getByRole('heading', { name: 'Heading', level: 5 })).toBeVisible();
   });
 
+  it('renders fine with level 5 and wrap', () => {
+    uiRender(
+      <UiHeading level={5} wrap>
+        Heading
+      </UiHeading>
+    );
+
+    expect(screen.getByRole('heading', { name: 'Heading', level: 5 })).toBeVisible();
+  });
+
   it('renders fine with level 6', () => {
     uiRender(<UiHeading level={6}>Heading</UiHeading>);
 
@@ -115,6 +171,16 @@ describe('<UiHeading />', () => {
   it('renders fine with level 6 and centered', () => {
     uiRender(
       <UiHeading level={6} centered>
+        Heading
+      </UiHeading>
+    );
+
+    expect(screen.getByRole('heading', { name: 'Heading', level: 6 })).toBeVisible();
+  });
+
+  it('renders fine with level 6 and wrap', () => {
+    uiRender(
+      <UiHeading level={6} wrap>
         Heading
       </UiHeading>
     );

--- a/packages/text/__tests__/ui-text.spec.tsx
+++ b/packages/text/__tests__/ui-text.spec.tsx
@@ -13,6 +13,12 @@ describe('<UiText />', () => {
     expect(screen.getByText('Text')).toBeVisible();
   });
 
+  it('renders fine aligned right', () => {
+    uiRender(<UiText align="right">Text</UiText>);
+
+    expect(screen.getByText('Text')).toBeVisible();
+  });
+
   it('renders fine with inverse coloration', () => {
     uiRender(<UiText inverseColoration>Text</UiText>);
 

--- a/packages/text/docs/heading-docs.mdx
+++ b/packages/text/docs/heading-docs.mdx
@@ -30,6 +30,22 @@ import { UiHeading } from '../src';
   <UiHeading level={1}>Some heading</UiHeading>
 </Playground>
 
+## UiHeading centered
+
+<Playground>
+  <UiHeading level={1} centered>
+    Some heading
+  </UiHeading>
+</Playground>
+
+## UiHeading wrapped
+
+<Playground>
+  <UiHeading level={1} wrap>
+    This is a very very very very very loooooong heading so it can be wrapped
+  </UiHeading>
+</Playground>
+
 ### Props
 
 <Props of={UiHeading} />

--- a/packages/text/docs/text-docs.mdx
+++ b/packages/text/docs/text-docs.mdx
@@ -30,6 +30,18 @@ import { UiText } from '../src';
   <UiText>Some text</UiText>
 </Playground>
 
+## UiText centered
+
+<Playground>
+  <UiText centered>Some text</UiText>
+</Playground>
+
+## UiText aligned right
+
+<Playground>
+  <UiText align="right">Some text</UiText>
+</Playground>
+
 ## UiText with color category
 
 <Playground>

--- a/packages/text/src/types/ui-heading-props.ts
+++ b/packages/text/src/types/ui-heading-props.ts
@@ -5,9 +5,12 @@ export type UiHeadingProps = {
   level?: 1 | 2 | 3 | 4 | 5 | 6;
   /* Heading centered */
   centered?: boolean;
+  /* Wrap text with 3 dots at the end */
+  wrap?: boolean;
 } & UiReactElementProps;
 
 export type privateHeadingProps = {
   $centered?: boolean;
   $level: 1 | 2 | 3 | 4 | 5 | 6;
+  $wrap?: boolean;
 } & UiReactPrivateElementProps;

--- a/packages/text/src/types/ui-text-props.ts
+++ b/packages/text/src/types/ui-text-props.ts
@@ -20,6 +20,8 @@ export type UiTextProps = {
   category?: ColorCategory;
   /** If the font color should be inversed to use its counter part coloration. */
   inverseColoration?: boolean | InverseColorationProp;
+  /** Align text left or right, default LEFT */
+  align?: 'left' | 'right';
 } & UiReactElementProps;
 
 export type privateTextProps = {
@@ -33,4 +35,5 @@ export type privateTextProps = {
   $inline?: boolean;
   $category?: ColorCategory;
   $inverseColoration?: boolean | InverseColorationProp;
+  $align?: 'left' | 'right';
 } & UiReactPrivateElementProps;

--- a/packages/text/src/ui-heading.tsx
+++ b/packages/text/src/ui-heading.tsx
@@ -19,6 +19,14 @@ const H1 = styled.h1<privateHeadingProps>`
   ${(props) => `font-size: ${getHeadingSize(props.$customTheme, props.$level)};`}
   ${(props) => `
     ${props.$centered ? `text-align: center;` : ``}
+    ${
+      props.$wrap
+        ? `
+      overflow:hidden; 
+      white-space:nowrap; 
+      text-overflow: ellipsis;`
+        : ``
+    }
   `}
 
   ${commonStyles}
@@ -28,6 +36,14 @@ const H2 = styled.h2<privateHeadingProps>`
   ${(props) => `font-size: ${getHeadingSize(props.$customTheme, props.$level)};`}
   ${(props) => `
     ${props.$centered ? `text-align: center;` : ``}
+        ${
+          props.$wrap
+            ? `
+      overflow:hidden; 
+      white-space:nowrap; 
+      text-overflow: ellipsis;`
+            : ``
+        }
   `}
 
   ${commonStyles}
@@ -37,6 +53,14 @@ const H3 = styled.h3<privateHeadingProps>`
   ${(props) => `font-size: ${getHeadingSize(props.$customTheme, props.$level)};`}
   ${(props) => `
     ${props.$centered ? `text-align: center;` : ``}
+        ${
+          props.$wrap
+            ? `
+      overflow:hidden; 
+      white-space:nowrap; 
+      text-overflow: ellipsis;`
+            : ``
+        }
   `}
 
   ${commonStyles}
@@ -46,6 +70,14 @@ const H4 = styled.h4<privateHeadingProps>`
   ${(props) => `font-size: ${getHeadingSize(props.$customTheme, props.$level)};`}
   ${(props) => `
     ${props.$centered ? `text-align: center;` : ``}
+        ${
+          props.$wrap
+            ? `
+      overflow:hidden; 
+      white-space:nowrap; 
+      text-overflow: ellipsis;`
+            : ``
+        }
   `}
 
   ${commonStyles}
@@ -55,6 +87,14 @@ const H5 = styled.h5<privateHeadingProps>`
   ${(props) => `font-size: ${getHeadingSize(props.$customTheme, props.$level)};`}
   ${(props) => `
     ${props.$centered ? `text-align: center;` : ``}
+        ${
+          props.$wrap
+            ? `
+      overflow:hidden; 
+      white-space:nowrap; 
+      text-overflow: ellipsis;`
+            : ``
+        }
   `}
 
   ${commonStyles}
@@ -64,54 +104,104 @@ const H6 = styled.h6<privateHeadingProps>`
   ${(props) => `font-size: ${getHeadingSize(props.$customTheme, props.$level)};`}
   ${(props) => `
     ${props.$centered ? `text-align: center;` : ``}
+        ${
+          props.$wrap
+            ? `
+      overflow:hidden; 
+      white-space:nowrap; 
+      text-overflow: ellipsis;`
+            : ``
+        }
   `}
 
   ${commonStyles}
 `;
 
-export const UiHeading: React.FC<UiHeadingProps> = ({ level = 3, centered, children }: UiHeadingProps) => {
+export const UiHeading: React.FC<UiHeadingProps> = ({ level = 3, centered, children, wrap }: UiHeadingProps) => {
   const theme = React.useContext(ThemeContext);
 
   switch (level) {
     case 1:
       return (
-        <H1 $customTheme={theme.theme} $selectedTheme={theme.selectedTheme} $centered={centered} $level={level}>
+        <H1
+          $customTheme={theme.theme}
+          $selectedTheme={theme.selectedTheme}
+          $centered={centered}
+          $level={level}
+          $wrap={wrap}
+        >
           {children}
         </H1>
       );
     case 2:
       return (
-        <H2 $customTheme={theme.theme} $selectedTheme={theme.selectedTheme} $centered={centered} $level={level}>
+        <H2
+          $customTheme={theme.theme}
+          $selectedTheme={theme.selectedTheme}
+          $centered={centered}
+          $level={level}
+          $wrap={wrap}
+        >
           {children}
         </H2>
       );
     case 3:
       return (
-        <H3 $customTheme={theme.theme} $selectedTheme={theme.selectedTheme} $centered={centered} $level={level}>
+        <H3
+          $customTheme={theme.theme}
+          $selectedTheme={theme.selectedTheme}
+          $centered={centered}
+          $level={level}
+          $wrap={wrap}
+        >
           {children}
         </H3>
       );
     case 4:
       return (
-        <H4 $customTheme={theme.theme} $selectedTheme={theme.selectedTheme} $centered={centered} $level={level}>
+        <H4
+          $customTheme={theme.theme}
+          $selectedTheme={theme.selectedTheme}
+          $centered={centered}
+          $level={level}
+          $wrap={wrap}
+        >
           {children}
         </H4>
       );
     case 5:
       return (
-        <H5 $customTheme={theme.theme} $selectedTheme={theme.selectedTheme} $centered={centered} $level={level}>
+        <H5
+          $customTheme={theme.theme}
+          $selectedTheme={theme.selectedTheme}
+          $centered={centered}
+          $level={level}
+          $wrap={wrap}
+        >
           {children}
         </H5>
       );
     case 6:
       return (
-        <H6 $customTheme={theme.theme} $selectedTheme={theme.selectedTheme} $centered={centered} $level={level}>
+        <H6
+          $customTheme={theme.theme}
+          $selectedTheme={theme.selectedTheme}
+          $centered={centered}
+          $level={level}
+          $wrap={wrap}
+        >
           {children}
         </H6>
       );
     default:
       return (
-        <H3 $customTheme={theme.theme} $selectedTheme={theme.selectedTheme} $centered={centered} $level={level}>
+        <H3
+          $customTheme={theme.theme}
+          $selectedTheme={theme.selectedTheme}
+          $centered={centered}
+          $level={level}
+          $wrap={wrap}
+        >
           {children}
         </H3>
       );

--- a/packages/text/src/ui-text.tsx
+++ b/packages/text/src/ui-text.tsx
@@ -28,6 +28,7 @@ const Text = styled.p<privateTextProps>`
         : TextMapper
     )}
     ${props.$centered ? `text-align: center;` : ``}
+    ${props.$align ? `text-align: ${props.$align};` : ``}
     ${props.$inline ? `display: inline;` : ``}
     ${`font-size: ${getTextSize(props.$customTheme, props.$size)};`}
     ${props.$fontStyle === 'italic' ? `font-style: ${props.$fontStyle};` : ''}
@@ -41,6 +42,7 @@ const Text = styled.p<privateTextProps>`
 `;
 
 export const UiText: React.FC<UiTextProps> = ({
+  align,
   children,
   centered,
   inline,
@@ -58,6 +60,7 @@ export const UiText: React.FC<UiTextProps> = ({
       $fontStyle={fontStyle}
       $selectedTheme={themeContext.selectedTheme}
       $size={size}
+      $align={align}
       $centered={centered}
       $inline={inline}
       $inverseColoration={inverseColoration}


### PR DESCRIPTION
## 🔥 Adding wrap for heading and align for texts
----------------------------------------------

### Description
Some use cases where the heading should be wrapped and the texts we might want to have them aligned to the right or left, depending on our browser orientation.

### Screenshots

<img width="960" alt="Screenshot 2023-08-22 at 9 48 18 AM" src="https://github.com/inavac182/uireact/assets/16787893/bd656923-3937-41cc-8702-e687e210aab4">
<img width="982" alt="Screenshot 2023-08-22 at 9 48 11 AM" src="https://github.com/inavac182/uireact/assets/16787893/d2242f7b-247b-49c9-8acb-2360d58397e2">

