### PR TITLE
feat: range validator numeric and category color for linear chart

### DIFF
--- a/packages/charts/__tests__/private/linear-chart/util/get-color.spec.ts
+++ b/packages/charts/__tests__/private/linear-chart/util/get-color.spec.ts
@@ -1,19 +1,54 @@
-import { ColorCategories, DefaultTheme, ThemeColor } from '@uireact/foundation';
+import { DefaultTheme, ThemeColor } from '@uireact/foundation';
 import { getColor } from '../../../../src/private/linear-chart/util';
 
 describe('getColor', () => {
   it('Should get color string when string is passed', () => {
-    const color = getColor(DefaultTheme, ThemeColor.dark, ColorCategories.primary, '#ffffff');
+    const color = getColor(DefaultTheme, ThemeColor.dark, '#ffffff');
     expect(color).toBe('#ffffff');
   });
 
+  it('Should get correct color when primary category is passed', () => {
+    const color = getColor(DefaultTheme, ThemeColor.dark, 'primary');
+    expect(color).toBe(DefaultTheme.dark.primary.token_100);
+  });
+
+  it('Should get correct color when secondary category is passed', () => {
+    const color = getColor(DefaultTheme, ThemeColor.dark, 'secondary');
+    expect(color).toBe(DefaultTheme.dark.secondary.token_100);
+  });
+
+  it('Should get correct color when tertiary category is passed', () => {
+    const color = getColor(DefaultTheme, ThemeColor.dark, 'tertiary');
+    expect(color).toBe(DefaultTheme.dark.tertiary.token_100);
+  });
+
+  it('Should get correct color when positive category is passed', () => {
+    const color = getColor(DefaultTheme, ThemeColor.dark, 'positive');
+    expect(color).toBe(DefaultTheme.dark.positive.token_100);
+  });
+
+  it('Should get correct color when error category is passed', () => {
+    const color = getColor(DefaultTheme, ThemeColor.dark, 'error');
+    expect(color).toBe(DefaultTheme.dark.error.token_100);
+  });
+
+  it('Should get correct color when negative category is passed', () => {
+    const color = getColor(DefaultTheme, ThemeColor.dark, 'negative');
+    expect(color).toBe(DefaultTheme.dark.negative.token_100);
+  });
+
+  it('Should get correct color when warning category is passed', () => {
+    const color = getColor(DefaultTheme, ThemeColor.dark, 'warning');
+    expect(color).toBe(DefaultTheme.dark.warning.token_100);
+  });
+
   it('Should get color from dark theme when no color is passed and selected theme is dark', () => {
-    const color = getColor(DefaultTheme, ThemeColor.dark, ColorCategories.primary);
+    const color = getColor(DefaultTheme, ThemeColor.dark);
     expect(color).toBe(DefaultTheme.dark.primary.token_100);
   });
 
   it('Should get correct color when themed color is passed and dark theme is selected', () => {
-    const color = getColor(DefaultTheme, ThemeColor.dark, ColorCategories.primary, {
+    const color = getColor(DefaultTheme, ThemeColor.dark, {
       dark: 'darkColor',
       light: 'lightColor',
     });
@@ -21,7 +56,7 @@ describe('getColor', () => {
   });
 
   it('Should get correct color when themed color is passed and light theme is selected', () => {
-    const color = getColor(DefaultTheme, ThemeColor.light, ColorCategories.primary, {
+    const color = getColor(DefaultTheme, ThemeColor.light, {
       dark: 'darkColor',
       light: 'lightColor',
     });

--- a/packages/charts/__tests__/ui-linear-chart.spec.tsx
+++ b/packages/charts/__tests__/ui-linear-chart.spec.tsx
@@ -21,6 +21,21 @@ describe('<UiLinearChart />', () => {
     expect(screen.getByTestId('linear-chart')).toBeVisible();
   });
 
+  it('renders fine if current is 0', () => {
+    const data: UiLinearChartData = {
+      current: {
+        value: 0,
+      },
+      limit: {
+        value: 30,
+      },
+    };
+
+    uiRender(<UiLinearChart data={data} testId="linear-chart" />);
+
+    expect(screen.getByTestId('linear-chart')).toBeVisible();
+  });
+
   it('renders limit label', () => {
     const data: UiLinearChartData = {
       current: {

--- a/packages/charts/docs/docs.mdx
+++ b/packages/charts/docs/docs.mdx
@@ -82,6 +82,29 @@ When static label is used the label for the current value will be static at the 
   />
 </Playground>
 
+## UiLinearChart - with theme colors
+
+We can use the color categories for grabbing a specific theme color for the chart
+
+<Playground>
+  <UiLinearChart
+    data={{
+      current: {
+        color: 'tertiary',
+        label: '60%',
+        value: 60,
+        labelStatic: true,
+      },
+      limit: {
+        color: 'secondary',
+        label: '80% battery',
+        value: 80,
+      },
+      title: 'Demo with color',
+    }}
+  />
+</Playground>
+
 ## UiLinearChart - with custom colors
 
 The custom colors supports hex and rgb colors

--- a/packages/charts/src/private/linear-chart/containers.ts
+++ b/packages/charts/src/private/linear-chart/containers.ts
@@ -1,18 +1,11 @@
 import styled from 'styled-components';
 
-import { ColorCategories } from '@uireact/foundation';
-
 import { privateLinearChartProps } from '../../types';
 import { getAnimation, getColor, getPercentage } from './util';
 
 export const LimitDiv = styled.div<privateLinearChartProps>`
   ${(props) =>
-    `background-color: ${getColor(
-      props.$customTheme,
-      props.$selectedTheme,
-      ColorCategories.secondary,
-      props.$limitColor
-    )};`}
+    `background-color: ${getColor(props.$customTheme, props.$selectedTheme, props.$limitColor || 'primary')};`}
 
   width: 100%;
   padding: 5px;
@@ -21,16 +14,11 @@ export const LimitDiv = styled.div<privateLinearChartProps>`
 
 export const CurrentDiv = styled.div<privateLinearChartProps>`
   ${(props) =>
-    `background-color: ${getColor(
-      props.$customTheme,
-      props.$selectedTheme,
-      ColorCategories.tertiary,
-      props.$currentColor
-    )};`}
+    `background-color: ${getColor(props.$customTheme, props.$selectedTheme, props.$currentColor || 'tertiary')};`}
 
   animation: ${(props) => getAnimation(getPercentage(props.$limitValue, props.$currentValue))} 1s ease-out forwards;
   height: 100%;
-  padding: 5px;
+  padding: ${(props) => (props.$currentValue > 0 ? '5px' : '0')};
   box-sizing: border-box;
   position: absolute;
   top: 0;

--- a/packages/charts/src/private/linear-chart/util/get-color.ts
+++ b/packages/charts/src/private/linear-chart/util/get-color.ts
@@ -1,17 +1,41 @@
-import { ColorCategories, ColorTokens, Theme, ThemeColor, getThemeColor } from '@uireact/foundation';
+import { ColorCategories, ColorCategory, ColorTokens, Theme, ThemeColor, getThemeColor } from '@uireact/foundation';
 import { ThemedColor } from '../../../types';
+
+export const getColorFromThemeIfRecognized = (
+  customTheme: Theme,
+  selectedTheme: ThemeColor,
+  value: ColorCategory | string
+): string => {
+  switch (value) {
+    case 'error':
+      return getThemeColor(customTheme, selectedTheme, ColorCategories.error, ColorTokens.token_100);
+    case 'warning':
+      return getThemeColor(customTheme, selectedTheme, ColorCategories.warning, ColorTokens.token_100);
+    case 'negative':
+      return getThemeColor(customTheme, selectedTheme, ColorCategories.negative, ColorTokens.token_100);
+    case 'positive':
+      return getThemeColor(customTheme, selectedTheme, ColorCategories.positive, ColorTokens.token_100);
+    case 'primary':
+      return getThemeColor(customTheme, selectedTheme, ColorCategories.primary, ColorTokens.token_100);
+    case 'secondary':
+      return getThemeColor(customTheme, selectedTheme, ColorCategories.secondary, ColorTokens.token_100);
+    case 'tertiary':
+      return getThemeColor(customTheme, selectedTheme, ColorCategories.tertiary, ColorTokens.token_100);
+    default:
+      return value;
+  }
+};
 
 export const getColor = (
   customTheme: Theme,
   selectedTheme: ThemeColor,
-  category: ColorCategories,
-  color?: string | ThemedColor
+  color?: string | ThemedColor | ColorCategory
 ): string => {
-  let themeColor = getThemeColor(customTheme, selectedTheme, category, ColorTokens.token_100);
+  let themeColor = getThemeColor(customTheme, selectedTheme, ColorCategories.primary, ColorTokens.token_100);
 
   if (color) {
     if (typeof color === 'string') {
-      themeColor = color;
+      themeColor = getColorFromThemeIfRecognized(customTheme, selectedTheme, color);
     } else {
       themeColor = selectedTheme === ThemeColor.dark ? color.dark : color.light;
     }

--- a/packages/charts/src/types/data-types.ts
+++ b/packages/charts/src/types/data-types.ts
@@ -1,13 +1,14 @@
+import { ColorCategory } from '@uireact/foundation';
 import { ThemedColor } from '.';
 
 export type UiLinearChartLimitData = {
-  color?: string | ThemedColor;
+  color?: string | ThemedColor | ColorCategory;
   label?: string;
   value: number;
 };
 
 export type UiLinearChartCurrentData = {
-  color?: string | ThemedColor;
+  color?: string | ThemedColor | ColorCategory;
   label?: string;
   value: number;
   labelStatic?: boolean;

--- a/packages/charts/src/types/private-props.ts
+++ b/packages/charts/src/types/private-props.ts
@@ -1,4 +1,4 @@
-import { UiReactPrivateElementProps } from '@uireact/foundation';
+import { ColorCategory, UiReactPrivateElementProps } from '@uireact/foundation';
 
 export type ThemedColor = {
   dark: string;
@@ -17,7 +17,7 @@ export type privateLinearChartProps = {
   /** Represents the label for the current value */
   $currentLabel?: string;
   /** Represents the color for the current value */
-  $currentColor?: string | ThemedColor;
+  $currentColor?: string | ThemedColor | ColorCategory;
   /** Represents the chart's title */
   $title?: string;
 } & UiReactPrivateElementProps;

--- a/packages/validator/__tests__/ui-validator.spec.ts
+++ b/packages/validator/__tests__/ui-validator.spec.ts
@@ -758,7 +758,20 @@ describe('UiValidator', () => {
       expect(result.errors?.test[0].code).toBe('E120');
     });
 
-    it('Should error out if value is not a number', () => {
+    it('Should error out if value is not numeric', () => {
+      const schema = {
+        test: validator.ruler().range(10, 100),
+      };
+      const data = {
+        test: '12aa0',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+    });
+
+    it('Should error out if value is numeric and does not pass validation', () => {
       const schema = {
         test: validator.ruler().range(10, 100),
       };
@@ -769,6 +782,19 @@ describe('UiValidator', () => {
       const result = validator.validate(schema, data);
 
       expect(result.passed).toBeFalsy();
+    });
+
+    it('Should validate correctly if value is numeric and passes validation', () => {
+      const schema = {
+        test: validator.ruler().range(10, 100),
+      };
+      const data = {
+        test: '90',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeTruthy();
     });
   });
 

--- a/packages/validator/docs/docs.mdx
+++ b/packages/validator/docs/docs.mdx
@@ -210,7 +210,7 @@ These are the chainable functions that you can use, to set the rules, their poss
     </td>
     <td>
       <UiList>
-        <li>✅ If the NUMBER is bigger or equal than min and smaller or equal than max.</li>
+        <li>✅ If the value is NUMERIC AND is bigger or equal than min and smaller or equal than max.</li>
         <li>❌ Everything else</li>
       </UiList>
     </td>
@@ -239,6 +239,7 @@ These are the chainable functions that you can use, to set the rules, their poss
 The phone validation is pretty extensive so we better have it very clear what values are positive in our validator so you know what to expect:
 
 {' '}
+
 <table>
   <tr>
     <th>Country code</th>

--- a/packages/validator/docs/docs.mdx
+++ b/packages/validator/docs/docs.mdx
@@ -50,7 +50,7 @@ const validator = new UiValidator();
 
 const schema = {
   firstName: validator.ruler().isRequired('First Name is required').length(0, 10, 'First name is not valid'),
-  email: validator.ruler().isRequired('Phone is required').type('phone', 'Phone is not valid'),
+  email: validator.ruler().isRequired('Email is required').type('email', 'The mail is not valid'),
 };
 ```
 
@@ -65,7 +65,7 @@ const validator = new UiValidator();
 
 const schema = {
   firstName: validator.ruler().isRequired('First Name is required').length(0, 10, 'First name is not valid'),
-  email: validator.ruler().isRequired('Phone is required').type('phone', 'Phone is not valid'),
+  email: validator.ruler().isRequired('Email is required').type('email', 'The mail is not valid'),
 };
 
 const data = {

--- a/packages/validator/src/ui-validator.ts
+++ b/packages/validator/src/ui-validator.ts
@@ -72,6 +72,14 @@ export class UiValidator {
   }
 
   private validRangeRule(min: number, max: number, value: unknown): boolean {
+    if (typeof value === 'string' && this.isNumeric(value)) {
+      const numericValue = parseInt(value);
+
+      if (numericValue >= min && numericValue <= max) {
+        return true;
+      }
+    }
+
     if (typeof value === 'number' && value >= min && value <= max) {
       return true;
     }

--- a/packages/validator/tsconfig.json
+++ b/packages/validator/tsconfig.json
@@ -4,11 +4,5 @@
     "outDir": "dist",
     "baseUrl": "./src"
   },
-  "exclude": [
-    "coverage",
-    "node_modules",
-    "dist",
-    "__tests__",
-    "docs"
-  ]
+  "exclude": ["coverage", "node_modules", "dist", "__tests__", "docs"]
 }


### PR DESCRIPTION
## 🔥 Various features
----------------------------------------------

### Description
- Range validator now accepts strings as value when they can be numeric.
- The linear chart accepts color categories so colors from the them can be picked up.

### Screenshots

<img width="786" alt="Screenshot 2023-08-28 at 1 29 29 PM" src="https://github.com/inavac182/uireact/assets/16787893/8a7225d9-e6cc-4594-a137-22a5eb5bdd72">
<img width="854" alt="Screenshot 2023-08-28 at 1 30 31 PM" src="https://github.com/inavac182/uireact/assets/16787893/c976af02-6f83-4ecf-a7e2-42140559e15b">

