### PR TITLE
feat(table): adding filter text box

### DIFF
--- a/packages/form/__tests__/ui-input.spec.tsx
+++ b/packages/form/__tests__/ui-input.spec.tsx
@@ -12,6 +12,13 @@ describe('<Component />', () => {
     expect(screen.getByRole('textbox', { name: 'Input' })).toBeVisible();
   });
 
+  it('renders fine with icon', () => {
+    uiRender(<UiInput label="Input" name="MyInput" icon={<span>some icon</span>} />);
+
+    expect(screen.getByRole('textbox', { name: 'Input' })).toBeVisible();
+    expect(screen.getByText('some icon')).toBeVisible();
+  });
+
   it('renders fine with size', () => {
     uiRender(<UiInput label="Input" name="MyInput" size="large" />);
 

--- a/packages/form/docs/ui-input.mdx
+++ b/packages/form/docs/ui-input.mdx
@@ -10,6 +10,9 @@ import Playground from '../../../src/Playground';
 
 import { UiInput } from '../src';
 
+import { UiIcon } from '@uireact/icons';
+import { UiSpacing } from '@uireact/foundation';
+
 # UiInput
 
 <sup>
@@ -51,6 +54,21 @@ import { UiInput } from '../src';
 
 <Playground>
   <UiInput label="Fist Name" labelOnTop />
+</Playground>
+
+## UiInput with icon
+
+<Playground>
+  <UiInput
+    label="Search"
+    placeholder="Type your search"
+    labelOnTop
+    icon={
+      <UiSpacing margin={{ top: 'two', left: 'four' }}>
+        <UiIcon icon="MagnifyingGlass" />
+      </UiSpacing>
+    }
+  />
 </Playground>
 
 ## UiInput disabled

--- a/packages/form/src/types/input.ts
+++ b/packages/form/src/types/input.ts
@@ -5,6 +5,8 @@ export type UiInputProps = {
   disabled?: boolean;
   /** Error label for input field */
   error?: string;
+  /** An icon element to be rendered inside the input */
+  icon?: React.ReactElement;
   /** Input name for form submittion */
   name?: string;
   /** Label for input field */
@@ -54,4 +56,5 @@ export type privateInputProps = {
   value?: HTMLInputElement['value'];
   $size?: SizesProp;
   required?: boolean;
+  $withIcon?: boolean;
 } & UiReactPrivateElementProps;

--- a/packages/form/src/ui-input.tsx
+++ b/packages/form/src/ui-input.tsx
@@ -40,7 +40,7 @@ const Input = styled.input<privateInputProps>`
 
     padding-top: ${getPadding(props.$size || 'regular')};
     padding-bottom: ${getPadding(props.$size || 'regular')};
-    padding-left: ${props.$withIcon ? '30px' : ''};
+    padding-left: ${props.$withIcon ? '30px' : '5px'};
     outline: none;
     width: 100%;
   `}

--- a/packages/form/src/ui-input.tsx
+++ b/packages/form/src/ui-input.tsx
@@ -2,7 +2,13 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { ThemeContext, getColorCategory, getTextSizeFromSizeString, getThemeStyling } from '@uireact/foundation';
+import {
+  SizesProp,
+  ThemeContext,
+  getColorCategory,
+  getTextSizeFromSizeString,
+  getThemeStyling,
+} from '@uireact/foundation';
 import { UiText, UiLabel } from '@uireact/text';
 
 import { UiInputProps, privateInputProps } from './types';
@@ -32,7 +38,9 @@ const Input = styled.input<privateInputProps>`
       cursor: not-allowed;
     }
 
-    padding: ${getPadding(props.$size || 'regular')};
+    padding-top: ${getPadding(props.$size || 'regular')};
+    padding-bottom: ${getPadding(props.$size || 'regular')};
+    padding-left: ${props.$withIcon ? '30px' : ''};
     outline: none;
     width: 100%;
   `}
@@ -45,11 +53,19 @@ const WrapperDiv = styled.div`
 const InputDiv = styled.div`
   display: inline-block;
   flex-grow: 1;
+  position: relative;
+`;
+
+const IconContainer = styled.span<{ $size?: SizesProp }>`
+  position: absolute;
 `;
 
 export const UiInput: React.FC<UiInputProps> = ({
+  className,
+  testId,
   disabled,
   error,
+  icon,
   label,
   labelOnTop,
   name = 'input-name',
@@ -65,7 +81,7 @@ export const UiInput: React.FC<UiInputProps> = ({
   const themeContext = React.useContext(ThemeContext);
 
   return (
-    <>
+    <div className={className} data-testid={testId}>
       {label && labelOnTop && (
         <div>
           <UiLabel htmlFor={name} category={category}>
@@ -82,6 +98,7 @@ export const UiInput: React.FC<UiInputProps> = ({
           </div>
         )}
         <InputDiv>
+          {icon && <IconContainer>{icon}</IconContainer>}
           <Input
             $customTheme={themeContext.theme}
             disabled={disabled}
@@ -96,11 +113,12 @@ export const UiInput: React.FC<UiInputProps> = ({
             value={value}
             $size={size}
             required={required}
+            $withIcon={icon !== undefined}
           />
           {error && <UiText category={category}>{error}</UiText>}
         </InputDiv>
       </WrapperDiv>
-    </>
+    </div>
   );
 };
 

--- a/packages/table/__tests__/ui-table.spec.tsx
+++ b/packages/table/__tests__/ui-table.spec.tsx
@@ -1,6 +1,6 @@
 import React from 'react';
 
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 
 import { uiRender } from '../../../__tests__/utils/render';
 import { UiTable } from '../src';
@@ -21,6 +21,18 @@ describe('<Component />', () => {
     expect(screen.getByRole('table')).toBeVisible();
     expect(screen.getByRole('columnheader', { name: /id/i })).toBeVisible();
     expect(screen.getByRole('cell', { name: /summary 1/i })).toBeVisible();
+
+    expect(screen.getByRole('textbox')).toBeVisible();
+  });
+
+  it('renders fine without filter', () => {
+    uiRender(<UiTable data={data} withFilter={false} />);
+
+    expect(screen.getByRole('table')).toBeVisible();
+    expect(screen.getByRole('columnheader', { name: /id/i })).toBeVisible();
+    expect(screen.getByRole('cell', { name: /summary 1/i })).toBeVisible();
+
+    expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
   });
 
   it('renders fine with category', () => {
@@ -29,5 +41,19 @@ describe('<Component />', () => {
     expect(screen.getByRole('table')).toBeVisible();
     expect(screen.getByRole('columnheader', { name: /id/i })).toBeVisible();
     expect(screen.getByRole('cell', { name: /summary 1/i })).toBeVisible();
+  });
+
+  it('Filters correctly', () => {
+    uiRender(<UiTable data={data} />);
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'summary 1' } });
+
+    expect(screen.getByRole('cell', { name: /summary 1/i })).toBeVisible();
+    expect(screen.queryByRole('cell', { name: /summary 2/i })).not.toBeInTheDocument();
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'summary' } });
+
+    expect(screen.getByRole('cell', { name: /summary 1/i })).toBeVisible();
+    expect(screen.getByRole('cell', { name: /summary 2/i })).toBeVisible();
   });
 });

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -29,6 +29,8 @@
   },
   "peerDependencies": {
     "@uireact/foundation": "^1.3.0",
+    "@uireact/forms": "^1.4.0",
+    "@uireact/icon": "^1.4.0",
     "react": ">= 17 < 19",
     "react-dom": ">= 17 < 19",
     "styled-components": ">= 4 <= 6",

--- a/packages/table/src/ui-table.tsx
+++ b/packages/table/src/ui-table.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { FormEvent, useCallback, useState } from 'react';
 
 import styled from 'styled-components';
 
@@ -7,9 +7,13 @@ import {
   ColorTokens,
   ThemeContext,
   UiReactElementProps,
+  UiSpacing,
+  UiSpacingProps,
   getColorCategory,
   getThemeColor,
 } from '@uireact/foundation';
+import { UiInput } from '@uireact/form';
+import { UiIcon } from '@uireact/icons';
 
 import { UiTableData } from './types';
 import { privateTableProps } from './types/private-table-props';
@@ -17,6 +21,7 @@ import { privateTableProps } from './types/private-table-props';
 export type UiTableProps = {
   data: UiTableData;
   category?: ColorCategory;
+  withFilter?: boolean;
 } & UiReactElementProps;
 
 const Table = styled.table<privateTableProps>`
@@ -43,35 +48,72 @@ const TableCol = styled.td`
   text-align: center;
 `;
 
-export const UiTable: React.FC<UiTableProps> = ({ className, data, category = 'primary', testId }: UiTableProps) => {
+const iconSpacing: UiSpacingProps['margin'] = { top: 'two', left: 'four' };
+
+export const UiTable: React.FC<UiTableProps> = ({
+  className,
+  data,
+  category = 'primary',
+  testId,
+  withFilter = true,
+}: UiTableProps) => {
   const theme = React.useContext(ThemeContext);
+  const [_data, setPrivateData] = useState(data);
+  const [filterPhrase, setFilterPhrase] = useState('');
+
+  const onFilter = useCallback(
+    (e: FormEvent<HTMLInputElement>) => {
+      const newFilterPhrase = e.currentTarget.value;
+      setFilterPhrase(newFilterPhrase);
+
+      const filteredData = data.fields.filter(
+        (field) => field.filter((text) => text.includes(newFilterPhrase)).length > 0
+      );
+
+      setPrivateData({ ...data, fields: filteredData });
+    },
+    [setFilterPhrase]
+  );
 
   return (
-    <Table
-      className={className}
-      data-testid={testId}
-      $customTheme={theme.theme}
-      $selectedTheme={theme.selectedTheme}
-      $category={category}
-      cellSpacing="0"
-    >
-      <thead>
-        <tr>
-          {data.headings.map((heading, index) => (
-            <TableHeadingCol key={`table-heading-${index}`}>{heading}</TableHeadingCol>
-          ))}
-        </tr>
-      </thead>
-      <tbody>
-        {data.fields.map((field, rowIndex) => (
-          <tr key={`table-item-index-${rowIndex}`}>
-            {field.map((text, index) => (
-              <TableCol key={`table-item-${rowIndex}-colum-index-${index}`}>{text}</TableCol>
+    <div>
+      {withFilter && (
+        <UiInput
+          value={filterPhrase}
+          onChange={onFilter}
+          icon={
+            <UiSpacing margin={iconSpacing}>
+              <UiIcon icon="MagnifyingGlass" />
+            </UiSpacing>
+          }
+        />
+      )}
+      <Table
+        className={className}
+        data-testid={testId}
+        $customTheme={theme.theme}
+        $selectedTheme={theme.selectedTheme}
+        $category={category}
+        cellSpacing="0"
+      >
+        <thead>
+          <tr>
+            {_data.headings.map((heading, index) => (
+              <TableHeadingCol key={`table-heading-${index}`}>{heading}</TableHeadingCol>
             ))}
           </tr>
-        ))}
-      </tbody>
-    </Table>
+        </thead>
+        <tbody>
+          {_data.fields.map((field, rowIndex) => (
+            <tr key={`table-item-index-${rowIndex}`}>
+              {field.map((text, index) => (
+                <TableCol key={`table-item-${rowIndex}-colum-index-${index}`}>{text}</TableCol>
+              ))}
+            </tr>
+          ))}
+        </tbody>
+      </Table>
+    </div>
   );
 };
 


### PR DESCRIPTION
## 🔥 Adding filter text box
----------------------------------------------

### Description
Adding a filter text box to table component, this allows the data passed to the table to be filtered out. I also added the option to pass an icon to the text field as I wanted to show the magnifier icon in the text field.

### Screenshots

#### Before
<img width="773" alt="Screenshot 2023-08-29 at 11 54 45 AM" src="https://github.com/inavac182/uireact/assets/16787893/87d21444-3a43-4fe8-9f1e-e2d8dadb9518">

#### Aft
<img width="685" alt="Screenshot 2023-08-29 at 1 36 41 PM" src="https://github.com/inavac182/uireact/assets/16787893/d00216e2-3e30-4ab9-8752-7d1a41ecba0b">
er
