### PR TITLE
feat(dialog): adding gradient animated border to dialog

### DIFF
--- a/packages/dialog/__tests__/__private/border-helpers/border-radius.spec.ts
+++ b/packages/dialog/__tests__/__private/border-helpers/border-radius.spec.ts
@@ -1,0 +1,34 @@
+import { getBorderRadius } from '../../../src/__private/border-helpers/border-radius';
+import { UiDialogType } from '../../../src/types';
+
+describe('getBorderRadius', () => {
+  it('Should get correct radius when is centered', () => {
+    const value = getBorderRadius(UiDialogType.CENTERED);
+    expect(value).toBe('5px');
+  });
+
+  it('Should get correct radius when is fullscreen', () => {
+    const value = getBorderRadius(UiDialogType.FULLSCREEN);
+    expect(value).toBe('0');
+  });
+
+  it('Should get correct radius when is left', () => {
+    const value = getBorderRadius(UiDialogType.LEFT);
+    expect(value).toBe('0');
+  });
+
+  it('Should get correct radius when is right', () => {
+    const value = getBorderRadius(UiDialogType.RIGHT);
+    expect(value).toBe('0');
+  });
+
+  it('Should get correct radius when is bottom', () => {
+    const value = getBorderRadius(UiDialogType.BOTTOM);
+    expect(value).toBe('5px 5px 0 0');
+  });
+
+  it('Should get correct radius when is undefined', () => {
+    const value = getBorderRadius();
+    expect(value).toBe('5px');
+  });
+});

--- a/packages/dialog/__tests__/__private/border-helpers/padding.spec.ts
+++ b/packages/dialog/__tests__/__private/border-helpers/padding.spec.ts
@@ -1,0 +1,34 @@
+import { getPadding } from '../../../src/__private/border-helpers/padding';
+import { UiDialogType } from '../../../src/types';
+
+describe('getPadding', () => {
+  it('Should get correct padding when is centered', () => {
+    const value = getPadding(UiDialogType.CENTERED);
+    expect(value).toBe('2px');
+  });
+
+  it('Should get correct padding when is fullscreen', () => {
+    const value = getPadding(UiDialogType.FULLSCREEN);
+    expect(value).toBe('0');
+  });
+
+  it('Should get correct padding when is left', () => {
+    const value = getPadding(UiDialogType.LEFT);
+    expect(value).toBe('0 2px 0 0');
+  });
+
+  it('Should get correct padding when is right', () => {
+    const value = getPadding(UiDialogType.RIGHT);
+    expect(value).toBe('0 0 0 2px');
+  });
+
+  it('Should get correct padding when is bottom', () => {
+    const value = getPadding(UiDialogType.BOTTOM);
+    expect(value).toBe('2px 2px 0px 2px');
+  });
+
+  it('Should get correct padding when is undefined', () => {
+    const value = getPadding();
+    expect(value).toBe('2px');
+  });
+});

--- a/packages/dialog/__tests__/ui-dialog.spec.tsx
+++ b/packages/dialog/__tests__/ui-dialog.spec.tsx
@@ -246,4 +246,17 @@ describe('<UiDialog />', () => {
       expect(screen.queryByRole('button', { name: 'Close button' })).not.toBeInTheDocument();
     });
   });
+
+  it('opens and closes dialog when using light theme', () => {
+    uiRender(<MockedComponent handleDialogClose={handleDialogClose} />, ThemeColor.light);
+
+    expect(screen.queryByText('Dialog content')).not.toBeInTheDocument();
+    fireEvent.click(screen.getByText('Open Dialog'));
+
+    expect(screen.getByText('Dialog content')).toBeVisible();
+    fireEvent.click(screen.getByRole('button', { name: 'Close button' }));
+
+    expect(screen.queryByText('Dialog content')).not.toBeInTheDocument();
+    expect(handleDialogClose).toHaveBeenCalledTimes(1);
+  });
 });

--- a/packages/dialog/docs/docs.mdx
+++ b/packages/dialog/docs/docs.mdx
@@ -34,7 +34,7 @@ you can follow up this [doc](./custom-dialog-controller) to create you own custo
 
 The `useDialog` hook is used to instantiate a dialog and be able to communicate with the dialogs controller. The [UseDialog response](https://github.com/inavac182/uireact/blob/main/packages/dialog/src/provider/use-dialog-hook.ts#LL10C6-L10C19) will bring a few properties that we will use to manipulate our dialogs:
 
-```
+```ts
 {
   isOpen, // boolean, will give us if a dialogs is opened or not.
   actions: {
@@ -54,7 +54,7 @@ By default, the dialog renders centered on top of the content and with a grayed 
 
 The [DialogsExample](https://github.com/inavac182/uireact/blob/main/packages/dialog/docs/utils/DialogsExample.tsx#L15) that we use throughout this doc. This is an example of the code of a component using a dialog:
 
-```
+```tsx
 import React from 'react';
 
 import { UiButton } from '@uireact/button';

--- a/packages/dialog/docs/docs.mdx
+++ b/packages/dialog/docs/docs.mdx
@@ -49,7 +49,7 @@ The `useDialog` hook is used to instantiate a dialog and be able to communicate 
 By default, the dialog renders centered on top of the content and with a grayed out background that if clicked will close the dialog.
 
 <Playground hideThemeSelector>
-  <DialogsExample title="Dialog title" dialogId="first-example" />
+  <DialogsExample title="Dialog title" dialogId="first-dialog-example" />
 </Playground>
 
 The [DialogsExample](https://github.com/inavac182/uireact/blob/main/packages/dialog/docs/utils/DialogsExample.tsx#L15) that we use throughout this doc. This is an example of the code of a component using a dialog:

--- a/packages/dialog/src/__private/border-helpers/animation.ts
+++ b/packages/dialog/src/__private/border-helpers/animation.ts
@@ -1,0 +1,13 @@
+import { keyframes } from 'styled-components';
+
+export const animateGradient = keyframes`
+  0% {
+		background-position: 0% 50%;
+	}
+	50% {
+		background-position: 100% 50%;
+	}
+	100% {
+		background-position: 0% 50%;
+	}
+`;

--- a/packages/dialog/src/__private/border-helpers/border-radius.ts
+++ b/packages/dialog/src/__private/border-helpers/border-radius.ts
@@ -1,0 +1,18 @@
+import { UiDialogType } from '../../types';
+
+export const getBorderRadius = (type?: UiDialogType): string => {
+  switch (type) {
+    case UiDialogType.BOTTOM:
+      return '5px 5px 0 0';
+    case UiDialogType.CENTERED:
+      return '5px';
+    case UiDialogType.LEFT:
+      return '0';
+    case UiDialogType.RIGHT:
+      return '0';
+    case UiDialogType.FULLSCREEN:
+      return '0';
+    default:
+      return '5px';
+  }
+};

--- a/packages/dialog/src/__private/border-helpers/bordered-wrapper-div.ts
+++ b/packages/dialog/src/__private/border-helpers/bordered-wrapper-div.ts
@@ -1,0 +1,29 @@
+import styled from 'styled-components';
+
+import { ThemeColor, getThemeColor, ColorCategories, ColorTokens } from '@uireact/foundation';
+
+import { privateUiDialogProps } from '../../types';
+import { animateGradient } from './animation';
+import { getBorderRadius } from './border-radius';
+import { getPadding } from './padding';
+
+export const BorderedWrappedDiv = styled.div<privateUiDialogProps>`
+  border-radius: ${(props) => getBorderRadius(props.$type)};
+  padding: ${(props) => `${props.$selectedTheme === ThemeColor.dark ? getPadding(props.$type) : '0'}`};
+  height: 100%;
+
+  ${(props) => `
+  background: linear-gradient(-45deg,
+    ${getThemeColor(props.$customTheme, props.$selectedTheme, ColorCategories.primary, ColorTokens.token_100)}, 
+    ${getThemeColor(props.$customTheme, props.$selectedTheme, ColorCategories.secondary, ColorTokens.token_100)},
+    ${getThemeColor(props.$customTheme, props.$selectedTheme, ColorCategories.tertiary, ColorTokens.token_100)},
+    ${getThemeColor(props.$customTheme, props.$selectedTheme, ColorCategories.primary, ColorTokens.token_10)},
+    ${getThemeColor(props.$customTheme, props.$selectedTheme, ColorCategories.secondary, ColorTokens.token_10)},
+    ${getThemeColor(props.$customTheme, props.$selectedTheme, ColorCategories.tertiary, ColorTokens.token_10)},
+    ${getThemeColor(props.$customTheme, props.$selectedTheme, ColorCategories.primary, ColorTokens.token_200)},
+    ${getThemeColor(props.$customTheme, props.$selectedTheme, ColorCategories.secondary, ColorTokens.token_200)},
+    ${getThemeColor(props.$customTheme, props.$selectedTheme, ColorCategories.tertiary, ColorTokens.token_200)});
+  `}
+  animation: ${animateGradient} 15s ease infinite;
+  background-size: 400% 400%;
+`;

--- a/packages/dialog/src/__private/border-helpers/padding.ts
+++ b/packages/dialog/src/__private/border-helpers/padding.ts
@@ -1,0 +1,18 @@
+import { UiDialogType } from '../../types';
+
+export const getPadding = (type?: UiDialogType): string => {
+  switch (type) {
+    case UiDialogType.BOTTOM:
+      return '2px 2px 0px 2px';
+    case UiDialogType.CENTERED:
+      return '2px';
+    case UiDialogType.LEFT:
+      return '0 2px 0 0';
+    case UiDialogType.RIGHT:
+      return '0 0 0 2px';
+    case UiDialogType.FULLSCREEN:
+      return '0';
+    default:
+      return '2px';
+  }
+};

--- a/packages/dialog/src/__private/dialog-content.tsx
+++ b/packages/dialog/src/__private/dialog-content.tsx
@@ -2,20 +2,29 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { getThemeStyling } from '@uireact/foundation';
+import { ColorCategories, ColorTokens, getThemeColor, getThemeStyling } from '@uireact/foundation';
 
 import { UiDialogType, privateUiDialogProps } from '../types';
 import { mapper } from '../theme';
+import { BorderedWrappedDiv } from './border-helpers/bordered-wrapper-div';
+import { getBorderRadius } from './border-helpers/border-radius';
 
 const Div = styled.div<privateUiDialogProps>`
   ${(props) => getThemeStyling(props.$customTheme, props.$selectedTheme, mapper)}
-
   z-index: 100;
   min-width: 200px;
-  box-shadow: 0px 0 5px #000000;
+
+  ${(props) =>
+    `box-shadow: 0px 0 5px ${getThemeColor(
+      props.$customTheme,
+      props.$selectedTheme,
+      ColorCategories.primary,
+      ColorTokens.token_200
+    )};
+    `}
 
   ${(props) => {
-    if (props.type === UiDialogType.CENTERED) {
+    if (props.$type === UiDialogType.CENTERED) {
       return `
       top: 50%;
       left: 50%;
@@ -25,7 +34,7 @@ const Div = styled.div<privateUiDialogProps>`
     `;
     }
 
-    if (props.type === UiDialogType.BOTTOM) {
+    if (props.$type === UiDialogType.BOTTOM) {
       return `
         bottom: 0%;
         left: 50%;
@@ -35,23 +44,23 @@ const Div = styled.div<privateUiDialogProps>`
       `;
     }
 
-    if (props.type === UiDialogType.LEFT) {
+    if (props.$type === UiDialogType.LEFT) {
       return `
         top: 0%;
         left: 0%;
         position: fixed;
         height: 100%;
-        width: 50%;
+        min-width: 20%;
       `;
     }
 
-    if (props.type === UiDialogType.RIGHT) {
+    if (props.$type === UiDialogType.RIGHT) {
       return `
         top: 0%;
         right: 0%;
         position: fixed;
         height: 100%;
-        width: 50%;
+        min-width: 20%;
       `;
     }
 
@@ -65,13 +74,31 @@ const Div = styled.div<privateUiDialogProps>`
   }}
 `;
 
+const ContentDiv = styled.div<privateUiDialogProps>`
+  ${(props) => `
+    background-color: ${getThemeColor(
+      props.$customTheme,
+      props.$selectedTheme,
+      ColorCategories.primary,
+      ColorTokens.token_200
+    )};
+    border-radius: ${getBorderRadius(props.$type)};
+    padding: 5px;
+    height: 100%;
+  `}
+`;
+
 export const DialogContent: React.FC<privateUiDialogProps> = ({
   children,
   $customTheme,
   $selectedTheme,
-  type,
+  $type,
 }: privateUiDialogProps) => (
-  <Div $customTheme={$customTheme} $selectedTheme={$selectedTheme} type={type} role="dialog">
-    {children}
+  <Div $customTheme={$customTheme} $selectedTheme={$selectedTheme} $type={$type} role="dialog">
+    <BorderedWrappedDiv $customTheme={$customTheme} $selectedTheme={$selectedTheme} $type={$type}>
+      <ContentDiv $customTheme={$customTheme} $selectedTheme={$selectedTheme} $type={$type}>
+        {children}
+      </ContentDiv>
+    </BorderedWrappedDiv>
   </Div>
 );

--- a/packages/dialog/src/hooks/use-dialog-hook.ts
+++ b/packages/dialog/src/hooks/use-dialog-hook.ts
@@ -20,7 +20,7 @@ export const useDialog = (dialogId: string): UseDialogHook => {
       openDialog: () => dialogController.openDialog(dialogId),
       closeDialog: () => dialogController.closeDialog(dialogId),
     };
-  }, [dialogId, dialogController]);
+  }, [dialogId]);
 
   React.useEffect(() => {
     let opened = false;
@@ -32,7 +32,7 @@ export const useDialog = (dialogId: string): UseDialogHook => {
     });
 
     setIsOpen(opened);
-  });
+  }, [dialogController, setIsOpen]);
 
   return { isOpen, actions };
 };

--- a/packages/dialog/src/theme/mapper.ts
+++ b/packages/dialog/src/theme/mapper.ts
@@ -5,7 +5,7 @@ export const mapper: ThemeMapper = {
     background: {
       category: ColorCategories.primary,
       inverse: false,
-      token: ColorTokens.token_50,
+      token: ColorTokens.token_100,
     },
     color: {
       category: ColorCategories.fonts,

--- a/packages/dialog/src/types/ui-dialog-props.ts
+++ b/packages/dialog/src/types/ui-dialog-props.ts
@@ -25,5 +25,5 @@ export type UiDialogProps = {
 
 export type privateUiDialogProps = {
   /** Position where the dialog will be rendered */
-  type?: UiDialogType;
+  $type?: UiDialogType;
 } & UiReactPrivateElementProps;

--- a/packages/dialog/src/ui-dialog.tsx
+++ b/packages/dialog/src/ui-dialog.tsx
@@ -60,7 +60,7 @@ export const UiDialog: React.FC<UiDialogProps> = ({
 
   if (type !== UiDialogType.CENTERED) {
     return (
-      <DialogContent $customTheme={theme.theme} $selectedTheme={theme.selectedTheme} type={type}>
+      <DialogContent $customTheme={theme.theme} $selectedTheme={theme.selectedTheme} $type={type}>
         {title && (
           <DialogToolbar title={title} hideCloseIcon={hideCloseIcon} closeCB={closeCB} closeLabel={closeLabel} />
         )}
@@ -78,7 +78,7 @@ export const UiDialog: React.FC<UiDialogProps> = ({
     <DialogWrapper>
       <>
         <DialogBackground onClick={closeCB} />
-        <DialogContent $customTheme={theme.theme} $selectedTheme={theme.selectedTheme} type={type}>
+        <DialogContent $customTheme={theme.theme} $selectedTheme={theme.selectedTheme} $type={type}>
           {title && (
             <DialogToolbar title={title} hideCloseIcon={hideCloseIcon} closeCB={closeCB} closeLabel={closeLabel} />
           )}

--- a/src/gatsby-theme-docz/custom-theme/custom-docs-theme.ts
+++ b/src/gatsby-theme-docz/custom-theme/custom-docs-theme.ts
@@ -15,7 +15,7 @@ export const DocsTheme: Theme = {
       token_50: '#2E2E2E',
       token_100: '#1C1C1C',
       token_150: '#0F0F0F',
-      token_200: '#000000',
+      token_200: '#0F0F0F',
     },
     secondary: {
       token_10: '#3A236A',


### PR DESCRIPTION
## 🔥 Adding an animated gradient border to dialog on dark
----------------------------------------------

### Description
On dark themes is pretty hard to create a great contrast between dark contents, a nit way that designers has used in the latest times is to add some borders and/or gradients to the contents. So, I'm adding this animated gradient border to the dialogs, this border only displays where there needs to be a contrast.  E.g. in fullscreen dialogs there is no border, but in centered dialogs is all around it, on left dialogs it only renders in the right border.

Again, this doesn't show up on LIGHT coloration as there the shades would get this work done.

### Screenshots
Dark theme centered:
![Sep-03-2023 00-54-00](https://github.com/inavac182/uireact/assets/16787893/2580d2a1-25a4-45ee-852d-e51a009b77c4)

e.g. bottom dialog, doesn't need border on the bottom:

<img width="358" alt="Screenshot 2023-09-03 at 12 54 13 AM" src="https://github.com/inavac182/uireact/assets/16787893/e031bda1-8805-4ec5-af21-283cd420ae10">


#### Before
![Sep-03-2023 00-52-35](https://github.com/inavac182/uireact/assets/16787893/d02be2c8-dc8e-4b84-9b49-30290ebbcb4b)

