### PR TITLE
fix(view): centered row renders twice on SSR

### DIFF
--- a/packages/view/__tests__/ui-view-row.spec.tsx
+++ b/packages/view/__tests__/ui-view-row.spec.tsx
@@ -30,6 +30,19 @@ describe('<UiViewRow />', () => {
     expect(screen.getByText('Content 2')).toBeVisible();
   });
 
+  it('Should render fine when is centered and width xlarge', () => {
+    global.innerWidth = 1450;
+    uiRender(
+      <UiViewRow centeredContent>
+        <p>Content 1</p>
+        <p>Content 2</p>
+      </UiViewRow>
+    );
+
+    expect(screen.getByText('Content 1')).toBeVisible();
+    expect(screen.getByText('Content 2')).toBeVisible();
+  });
+
   it('Should add class name', () => {
     uiRender(<UiViewRow className="someClass">Content 1</UiViewRow>);
 

--- a/packages/view/docs/view.mdx
+++ b/packages/view/docs/view.mdx
@@ -81,7 +81,7 @@ export const ViewRowExample: React.FC = () => {
       <UiViewRow weight="10">
         <p>A row with weight 10</p>
       </UiViewRow>
-      <UiViewRow weight="50">
+      <UiViewRow weight="50" centeredContent>
         <p>A row with weight 50</p>
       </UiViewRow>
       <UiViewRow>

--- a/packages/view/src/ui-view-row.tsx
+++ b/packages/view/src/ui-view-row.tsx
@@ -2,7 +2,7 @@ import React from 'react';
 
 import styled from 'styled-components';
 
-import { Breakpoints, getThemeStyling, ThemeContext, UiViewport } from '@uireact/foundation';
+import { Breakpoints, getThemeStyling, ThemeContext, UiViewport, useViewport } from '@uireact/foundation';
 
 import { privateViewRowProps, UiViewRowProps } from './types';
 import { dynamicViewRowMapper } from './theme';
@@ -23,6 +23,7 @@ export const UiViewRow: React.FC<UiViewRowProps> = ({
   inverseFont,
   weight,
 }: UiViewRowProps) => {
+  const viewport = useViewport();
   const themeContext = React.useContext(ThemeContext);
 
   return (
@@ -36,11 +37,8 @@ export const UiViewRow: React.FC<UiViewRowProps> = ({
     >
       {centeredContent ? (
         <>
-          <UiViewport criteria={Breakpoints.XLARGE}>
-            <CenteredDiv $size="xl">{children}</CenteredDiv>
-          </UiViewport>
-          <UiViewport criteria={Breakpoints.LARGE}>
-            <CenteredDiv $size="l">{children}</CenteredDiv>
+          <UiViewport criteria={'l|xl'}>
+            <CenteredDiv $size={viewport.isLarge ? 'l' : 'xl'}>{children}</CenteredDiv>
           </UiViewport>
           <UiViewport criteria={'s|m'}>{children}</UiViewport>
         </>


### PR DESCRIPTION
## 🔥 Fix centered view row on SSR
----------------------------------------------

### Description
On SSR the view row was rendering twice the content given the viewport was letting render the 2 Uiviewports content as they were large or xlarge, now I'm using only 1 which should fix this issue.

### Screenshots

N/A
