### PR TITLE
feat: adding inverse coloration for icon

### DIFF
--- a/packages/icons/__tests__/theme/helpers/getInverse.spec.ts
+++ b/packages/icons/__tests__/theme/helpers/getInverse.spec.ts
@@ -1,0 +1,34 @@
+import { ThemeColor } from '@uireact/foundation';
+import { getInverse } from '../../../src/theme/helpers/getInverse';
+
+describe('getInverse', () => {
+  it('Should be inverse when boolean is true', () => {
+    const result = getInverse(ThemeColor.dark, true);
+    expect(result).toBeTruthy();
+  });
+
+  it('Should NOT be inverse when nothing is passed', () => {
+    const result = getInverse(ThemeColor.dark);
+    expect(result).toBeFalsy();
+  });
+
+  it('Should be inverse when inverse prop has light as true and selected theme is light', () => {
+    const result = getInverse(ThemeColor.light, { light: true, dark: false });
+    expect(result).toBeTruthy();
+  });
+
+  it('Should NOT be inverse when inverse prop has light as true and selected theme is dark', () => {
+    const result = getInverse(ThemeColor.dark, { light: true, dark: false });
+    expect(result).toBeFalsy();
+  });
+
+  it('Should be inverse when inverse prop has dark as true and selected theme is dark', () => {
+    const result = getInverse(ThemeColor.dark, { light: false, dark: true });
+    expect(result).toBeTruthy();
+  });
+
+  it('Should NOT be inverse when inverse prop has dark as true and selected theme is light', () => {
+    const result = getInverse(ThemeColor.light, { light: false, dark: true });
+    expect(result).toBeFalsy();
+  });
+});

--- a/packages/icons/__tests__/ui-icon.spec.tsx
+++ b/packages/icons/__tests__/ui-icon.spec.tsx
@@ -4,6 +4,7 @@ import { screen } from '@testing-library/react';
 
 import { uiRender } from '../../../__tests__/utils/render';
 import { UiIcon } from '../src';
+import { ThemeColor } from '@uireact/foundation';
 
 describe('<UiIcon />', () => {
   it('renders fine', () => {
@@ -20,6 +21,24 @@ describe('<UiIcon />', () => {
 
   it('renders fine with size', () => {
     uiRender(<UiIcon icon="At" size="regular" />);
+
+    expect(screen.getByTestId('Icon')).toBeVisible();
+  });
+
+  it('renders fine with inverse coloration', () => {
+    uiRender(<UiIcon icon="At" theme="error" inverseColoration />);
+
+    expect(screen.getByTestId('Icon')).toBeVisible();
+  });
+
+  it('renders fine with inverse coloration props on light', () => {
+    uiRender(<UiIcon icon="At" theme="error" inverseColoration={{ light: true, dark: false }} />, ThemeColor.light);
+
+    expect(screen.getByTestId('Icon')).toBeVisible();
+  });
+
+  it('renders fine with inverse coloration props on dark', () => {
+    uiRender(<UiIcon icon="At" theme="error" inverseColoration={{ light: true, dark: false }} />);
 
     expect(screen.getByTestId('Icon')).toBeVisible();
   });

--- a/packages/icons/docs/docs.mdx
+++ b/packages/icons/docs/docs.mdx
@@ -31,6 +31,12 @@ import { IconsList } from './utils';
   <UiIcon icon="At" size="xlarge" theme="positive" />
 </Playground>
 
+## UiIcon with inverse coloration
+
+<Playground>
+  <UiIcon icon="At" size="xlarge" theme="positive" inverseColoration />
+</Playground>
+
 ## Icons list
 
 <Playground hideThemeSelector>

--- a/packages/icons/src/theme/helpers/getInverse.ts
+++ b/packages/icons/src/theme/helpers/getInverse.ts
@@ -1,0 +1,18 @@
+import { ThemeColor } from '@uireact/foundation';
+import { InverseColorationProp } from '../../types';
+
+export const getInverse = (selectedTheme: ThemeColor, inverseColoration?: boolean | InverseColorationProp): boolean => {
+  let isInverse = false;
+
+  if (typeof inverseColoration === 'object') {
+    if (inverseColoration.dark && selectedTheme === ThemeColor.dark) {
+      isInverse = true;
+    } else if (inverseColoration.light && selectedTheme === ThemeColor.light) {
+      isInverse = true;
+    }
+  } else if (inverseColoration) {
+    isInverse = true;
+  }
+
+  return isInverse;
+};

--- a/packages/icons/src/theme/icon-mapper.ts
+++ b/packages/icons/src/theme/icon-mapper.ts
@@ -1,11 +1,17 @@
-import { ColorCategories, ColorTokens, ThemeMapper } from '@uireact/foundation';
+import { ColorCategories, ColorTokens, ThemeColor, ThemeMapper } from '@uireact/foundation';
+import { InverseColorationProp } from '../types';
+import { getInverse } from './helpers/getInverse';
 
-export const getDynamicMapper = (category: ColorCategories): ThemeMapper => {
+export const getDynamicMapper = (
+  category: ColorCategories,
+  selectedTheme: ThemeColor,
+  inverseColoration?: boolean | InverseColorationProp
+): ThemeMapper => {
   return {
     normal: {
       fill: {
         category: category,
-        inverse: false,
+        inverse: getInverse(selectedTheme, inverseColoration),
         token: ColorTokens.token_100,
       },
     },

--- a/packages/icons/src/types/icons-props.ts
+++ b/packages/icons/src/types/icons-props.ts
@@ -2,6 +2,11 @@ import { ColorCategory, SizesProp, UiReactElementProps, UiReactPrivateElementPro
 
 import * as SvgsComponent from '../public/svgs';
 
+export type InverseColorationProp = {
+  light: boolean;
+  dark: boolean;
+};
+
 export type UiIconProps = {
   /** Icon ID to be rendered */
   icon: keyof typeof SvgsComponent;
@@ -9,9 +14,12 @@ export type UiIconProps = {
   theme?: ColorCategory;
   /** Icon Size */
   size?: SizesProp;
+  /** If the font color should be inversed to use its counter part coloration. */
+  inverseColoration?: boolean | InverseColorationProp;
 } & UiReactElementProps;
 
 export type privateIconProps = {
   $size?: SizesProp;
   $category?: ColorCategory;
+  $inverseColoration?: boolean | InverseColorationProp;
 } & UiReactPrivateElementProps;

--- a/packages/icons/src/ui-icon.tsx
+++ b/packages/icons/src/ui-icon.tsx
@@ -19,7 +19,11 @@ const Span = styled.span<privateIconProps>`
     ${getThemeStyling(
       props.$customTheme,
       props.$selectedTheme,
-      getDynamicMapper(props.$category ? getColorCategory(props.$category) : ColorCategories.fonts)
+      getDynamicMapper(
+        props.$category ? getColorCategory(props.$category) : ColorCategories.fonts,
+        props.$selectedTheme,
+        props.$inverseColoration
+      )
     )}
     ${props.$size ? `font-size: ${getTextSizeFromSizeString(props.$customTheme, props.$size)};` : ''}
     ${props.$size ? `width: ${getTextSizeFromSizeString(props.$customTheme, props.$size)};` : ''}
@@ -31,7 +35,7 @@ const Span = styled.span<privateIconProps>`
   justify-content: center;
 `;
 
-export const UiIcon: React.FC<UiIconProps> = ({ theme, icon, size }: UiIconProps) => {
+export const UiIcon: React.FC<UiIconProps> = ({ theme, icon, size, inverseColoration }: UiIconProps) => {
   const themeProvided = React.useContext(ThemeContext);
 
   return (
@@ -40,6 +44,7 @@ export const UiIcon: React.FC<UiIconProps> = ({ theme, icon, size }: UiIconProps
       $customTheme={themeProvided.theme}
       $selectedTheme={themeProvided.selectedTheme}
       $size={size}
+      $inverseColoration={inverseColoration}
     >
       <IconComponent icon={icon} />
     </Span>


### PR DESCRIPTION
## 🔥 Adding inverse coloration for icon
----------------------------------------------

### Description
Adding inverse coloration for icon so it can be used on cases where the text color needs to be light on light themes e.g. on top of buttons.

### Screenshots

![Screenshot 2023-09-04 at 4 56 26 PM](https://github.com/inavac182/uireact/assets/16787893/7b888c8f-beee-4758-a01f-d4278b534699)

