### PR TITLE
feat(validator): strict mode

### DIFF
--- a/packages/validator/__tests__/ui-validator-length.spec.ts
+++ b/packages/validator/__tests__/ui-validator-length.spec.ts
@@ -1,0 +1,73 @@
+import { UiValidator } from '../src';
+
+describe('length validation', () => {
+  const validator = new UiValidator();
+
+  it('Should use default messaging if none is passed in schema', () => {
+    const schema = {
+      test: validator.ruler().length(5, 10),
+    };
+    const data = {
+      test: 'test',
+    };
+
+    const result = validator.validate(schema, data);
+
+    expect(result.passed).toBeFalsy();
+    expect(result.errors?.test[0].message).toBe(`This does not have a valid length of min 5 and max 10`);
+  });
+
+  it('Should validate correct length', () => {
+    const schema = {
+      test: validator.ruler().length(0, 10),
+    };
+    const data = {
+      test: 'testString',
+    };
+
+    const result = validator.validate(schema, data);
+
+    expect(result.passed).toBeTruthy();
+  });
+
+  it('Should error out when string is too short and retrieve error message', () => {
+    const schema = {
+      test: validator.ruler().length(5, 10, 'Value is too short'),
+    };
+    const data = {
+      test: 'test',
+    };
+
+    const result = validator.validate(schema, data);
+
+    expect(result.passed).toBeFalsy();
+    expect(result.errors?.test[0].message).toBe('Value is too short');
+  });
+
+  it('Should error out when string is too long and retrieve error code', () => {
+    const schema = {
+      test: validator.ruler().length(5, 10, 'Value is too long'),
+    };
+    const data = {
+      test: 'This is a very long phrase',
+    };
+
+    const result = validator.validate(schema, data);
+
+    expect(result.passed).toBeFalsy();
+    expect(result.errors?.test[0].message).toBe('Value is too long');
+  });
+
+  it('Should error out if value is not a tring', () => {
+    const schema = {
+      test: validator.ruler().length(5, 10),
+    };
+    const data = {
+      test: {},
+    };
+
+    const result = validator.validate(schema, data);
+
+    expect(result.passed).toBeFalsy();
+  });
+});

--- a/packages/validator/__tests__/ui-validator-optional.spec.ts
+++ b/packages/validator/__tests__/ui-validator-optional.spec.ts
@@ -1,0 +1,47 @@
+import { UiValidator } from '../src';
+
+describe('optional', () => {
+  const validator = new UiValidator();
+
+  it('Should pass when value is null', () => {
+    const schema = {
+      test: validator.ruler().isOptional(),
+    };
+
+    const data = {
+      test: null,
+    };
+
+    const result = validator.validate(schema, data);
+
+    expect(result.passed).toBeTruthy();
+  });
+
+  it('Should pass when value is undefined', () => {
+    const schema = {
+      test: validator.ruler().isOptional(),
+    };
+
+    const data = {
+      test: undefined,
+    };
+
+    const result = validator.validate(schema, data);
+
+    expect(result.passed).toBeTruthy();
+  });
+
+  it('Should pass when value is passed', () => {
+    const schema = {
+      test: validator.ruler().isOptional(),
+    };
+
+    const data = {
+      test: '',
+    };
+
+    const result = validator.validate(schema, data);
+
+    expect(result.passed).toBeTruthy();
+  });
+});

--- a/packages/validator/__tests__/ui-validator-range.spec.ts
+++ b/packages/validator/__tests__/ui-validator-range.spec.ts
@@ -1,0 +1,125 @@
+import { UiValidator } from '../src';
+
+describe('range validation', () => {
+  const validator = new UiValidator();
+
+  it('Should use default messaging if none is passed in schema', () => {
+    const schema = {
+      test: validator.ruler().range(10, 100),
+    };
+    const data = {
+      test: 5,
+    };
+
+    const result = validator.validate(schema, data);
+
+    expect(result.passed).toBeFalsy();
+    expect(result.errors?.test[0].message).toBe('This is not in valid range of 10 and 100');
+  });
+
+  it('Should validate correct range', () => {
+    const schema = {
+      test: validator.ruler().range(10, 100),
+    };
+    const data = {
+      test: 50,
+    };
+
+    const result = validator.validate(schema, data);
+
+    expect(result.passed).toBeTruthy();
+  });
+
+  it('Should error out if value is smaller than the min range', () => {
+    const schema = {
+      test: validator.ruler().range(10, 100),
+    };
+    const data = {
+      test: 3,
+    };
+
+    const result = validator.validate(schema, data);
+
+    expect(result.passed).toBeFalsy();
+  });
+
+  it('Should error out if value is bigger than the max range', () => {
+    const schema = {
+      test: validator.ruler().range(10, 100),
+    };
+    const data = {
+      test: 150,
+    };
+
+    const result = validator.validate(schema, data);
+
+    expect(result.passed).toBeFalsy();
+  });
+
+  it('Should error out if value null and retrieve error message', () => {
+    const schema = {
+      test: validator.ruler().range(10, 100, 'Value is not in range'),
+    };
+    const data = {
+      test: null,
+    };
+
+    const result = validator.validate(schema, data);
+
+    expect(result.passed).toBeFalsy();
+    expect(result.errors?.test[0].message).toBe('Value is not in range');
+  });
+
+  it('Should error out if value undefined and retrieve error code', () => {
+    const schema = {
+      test: validator.ruler().range(10, 100, 'Value is not in range'),
+    };
+    const data = {
+      test: undefined,
+    };
+
+    const result = validator.validate(schema, data);
+
+    expect(result.passed).toBeFalsy();
+    expect(result.errors?.test[0].message).toBe('Value is not in range');
+  });
+
+  it('Should error out if value is not numeric', () => {
+    const schema = {
+      test: validator.ruler().range(10, 100),
+    };
+    const data = {
+      test: '12aa0',
+    };
+
+    const result = validator.validate(schema, data);
+
+    expect(result.passed).toBeFalsy();
+  });
+
+  it('Should error out if value is numeric and does not pass validation', () => {
+    const schema = {
+      test: validator.ruler().range(10, 100),
+    };
+    const data = {
+      test: '120',
+    };
+
+    const result = validator.validate(schema, data);
+
+    expect(result.passed).toBeFalsy();
+  });
+
+  it('Should validate correctly if value is numeric and passes validation', () => {
+    const schema = {
+      test: validator.ruler().range(10, 100),
+    };
+    const data = {
+      test: '90',
+    };
+
+    const result = validator.validate(schema, data);
+
+    expect(result.passed).toBeTruthy();
+  });
+});

--- a/packages/validator/__tests__/ui-validator-require.spec.ts
+++ b/packages/validator/__tests__/ui-validator-require.spec.ts
@@ -1,0 +1,73 @@
+import { UiValidator } from '../src';
+
+describe('require validation', () => {
+  const validator = new UiValidator();
+
+  it('Should use default messaging if none is passed in schema', () => {
+    const schema = {
+      test: validator.ruler().isRequired(),
+    };
+    const data = {
+      test: null,
+    };
+
+    const result = validator.validate(schema, data);
+
+    expect(result.passed).toBeFalsy();
+    expect(result.errors?.test[0].message).toBe('This is required');
+  });
+
+  it('Should validate correct when is required', () => {
+    const schema = {
+      test: validator.ruler().isRequired(),
+    };
+    const data = {
+      test: 'test',
+    };
+
+    const result = validator.validate(schema, data);
+
+    expect(result.passed).toBeTruthy();
+  });
+
+  it('Should error out if value is null and retrieve error message', () => {
+    const schema = {
+      test: validator.ruler().isRequired('The value is required'),
+    };
+    const data = {
+      test: null,
+    };
+
+    const result = validator.validate(schema, data);
+
+    expect(result.passed).toBeFalsy();
+    expect(result.errors?.test[0].message).toBe('The value is required');
+  });
+
+  it('Should error out if value is undefined and retrieve error code', () => {
+    const schema = {
+      test: validator.ruler().isRequired('The value is required'),
+    };
+    const data = {
+      test: undefined,
+    };
+
+    const result = validator.validate(schema, data);
+
+    expect(result.passed).toBeFalsy();
+    expect(result.errors?.test[0].message).toBe('The value is required');
+  });
+
+  it('Should still fail if no custom error messaging is passed', () => {
+    const schema = {
+      test: validator.ruler().isRequired(),
+    };
+    const data = {
+      test: undefined,
+    };
+
+    const result = validator.validate(schema, data);
+
+    expect(result.passed).toBeFalsy();
+  });
+});

--- a/packages/validator/__tests__/ui-validator-type.spec.ts
+++ b/packages/validator/__tests__/ui-validator-type.spec.ts
@@ -1,0 +1,647 @@
+import { UiValidator } from '../src';
+
+describe('type validation', () => {
+  const validator = new UiValidator();
+
+  it('Should use default messaging if none is passed in schema', () => {
+    const schema = {
+      test: validator.ruler().type('string'),
+    };
+    const data = {
+      test: 123,
+    };
+
+    const result = validator.validate(schema, data);
+
+    expect(result.passed).toBeFalsy();
+    expect(result.errors?.test[0].message).toBe('This is not a valid string');
+  });
+
+  describe('strings', () => {
+    it('Should validate strings when string is provided', () => {
+      const schema = {
+        test: validator.ruler().type('string'),
+      };
+      const data = {
+        test: 'felipe',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeTruthy();
+    });
+
+    it('Should validate strings when value provided is a number', () => {
+      const schema = {
+        test: validator.ruler().type('string'),
+      };
+      const data = {
+        test: 123,
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+    });
+
+    it('Should error out when value provided is an object', () => {
+      const schema = {
+        test: validator.ruler().type('string'),
+      };
+      const data = {
+        test: {},
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+    });
+
+    it('Should error out when string is undefined and retrieve correct error message', () => {
+      const schema = {
+        test: validator.ruler().type('string', 'The value is not a string'),
+      };
+      const data = {
+        test: undefined,
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+      expect(result.errors?.test[0].message).toBe('The value is not a string');
+    });
+
+    it('Should error out if type is unrecognized', () => {
+      const schema = {
+        // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+        //@ts-ignore
+        test: validator.ruler().type('WHATEVER-VALUE'),
+      };
+      const data = {
+        test: null,
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+    });
+  });
+
+  describe('numeric', () => {
+    it('Should validate numeric values when received a number value', () => {
+      const schema = {
+        test: validator.ruler().type('numeric'),
+      };
+      const data = {
+        test: 123,
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeTruthy();
+    });
+
+    it('Should validate numeric values when received a number value in string type', () => {
+      const schema = {
+        test: validator.ruler().type('numeric'),
+      };
+      const data = {
+        test: '123',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeTruthy();
+    });
+
+    it('Should error out if provided value has letters and retrieve correct error message', () => {
+      const schema = {
+        test: validator.ruler().type('numeric', 'The value is not numeric'),
+      };
+      const data = {
+        test: '123a23',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+      expect(result.errors?.test[0].message).toBe('The value is not numeric');
+    });
+
+    it('Should error out if provided value has special characters and retrieve correct error code', () => {
+      const schema = {
+        test: validator.ruler().type('numeric', 'The value is not numeric'),
+      };
+      const data = {
+        test: '123+23',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+      expect(result.errors?.test[0].message).toBe('The value is not numeric');
+    });
+
+    it('Should error out if provided value is undefined', () => {
+      const schema = {
+        test: validator.ruler().type('numeric'),
+      };
+      const data = {
+        test: undefined,
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+    });
+
+    it('Should error out if provided value is null', () => {
+      const schema = {
+        test: validator.ruler().type('numeric'),
+      };
+      const data = {
+        test: null,
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+    });
+  });
+
+  describe('email', () => {
+    it('Should validate email', () => {
+      const schema = {
+        test: validator.ruler().type('email'),
+      };
+      const data = {
+        test: 'test@mail.com',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeTruthy();
+    });
+
+    it('Should validate email with double top level domain', () => {
+      const schema = {
+        test: validator.ruler().type('email'),
+      };
+      const data = {
+        test: 'test@mail.co.uk',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeTruthy();
+    });
+
+    it('Should validate email with short top level domain', () => {
+      const schema = {
+        test: validator.ruler().type('email'),
+      };
+      const data = {
+        test: 'test@mail.mx',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeTruthy();
+    });
+
+    it('Should validate email when using _ or - or . in their name', () => {
+      const schema = {
+        test: validator.ruler().type('email'),
+      };
+      const data = {
+        test: 't_e.s-t@mail.mx',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeTruthy();
+    });
+
+    it('Should validate email when using numbers in their name', () => {
+      const schema = {
+        test: validator.ruler().type('email'),
+      };
+      const data = {
+        test: 't_e.s-temail99@mail.mx',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeTruthy();
+    });
+
+    it('Should validate email when using numbers in their domain', () => {
+      const schema = {
+        test: validator.ruler().type('email'),
+      };
+      const data = {
+        test: 'test@mail99.mx',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeTruthy();
+    });
+
+    it('Should validate email when using - or . in their domain', () => {
+      const schema = {
+        test: validator.ruler().type('email'),
+      };
+      const data = {
+        test: 'test@ma-i.l.com',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeTruthy();
+    });
+
+    it('Should error out if mail name is empty and retrieve correct error message', () => {
+      const schema = {
+        test: validator.ruler().type('email', 'The email is not valid'),
+      };
+      const data = {
+        test: '@mail.com',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+      expect(result.errors?.test[0].message).toBe('The email is not valid');
+    });
+
+    it('Should error out if mail name has special characters and retrieve correct error code', () => {
+      const schema = {
+        test: validator.ruler().type('email', 'The email is not valid'),
+      };
+      const data = {
+        test: 'te/st@mail.com',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+      expect(result.errors?.test[0].message).toBe('The email is not valid');
+    });
+
+    it('Should error out if domain name is empty', () => {
+      const schema = {
+        test: validator.ruler().type('email'),
+      };
+      const data = {
+        test: 'te/st@.com',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+    });
+
+    it('Should error out if domain name has special characters', () => {
+      const schema = {
+        test: validator.ruler().type('email'),
+      };
+      const data = {
+        test: 'test@ma_il.com',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+    });
+
+    it('Should error out if top level domain is empty', () => {
+      const schema = {
+        test: validator.ruler().type('email'),
+      };
+      const data = {
+        test: 'test@mail.',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+    });
+
+    it('Should error out if top level domain has only 1 character', () => {
+      const schema = {
+        test: validator.ruler().type('email'),
+      };
+      const data = {
+        test: 'test@mail.x',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+    });
+
+    it('Should error out if top level domain has more than 4 character', () => {
+      const schema = {
+        test: validator.ruler().type('email'),
+      };
+      const data = {
+        test: 'test@mail.longd',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+    });
+
+    it('Should error out if top level domain has special characters', () => {
+      const schema = {
+        test: validator.ruler().type('email'),
+      };
+      const data = {
+        test: 'test@mail.co_m',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+    });
+
+    it('Should error out mail is null', () => {
+      const schema = {
+        test: validator.ruler().type('email'),
+      };
+      const data = {
+        test: null,
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+    });
+
+    it('Should error out mail is undefined', () => {
+      const schema = {
+        test: validator.ruler().type('email'),
+      };
+      const data = {
+        test: undefined,
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+    });
+
+    it('Should error out mail is not a string', () => {
+      const schema = {
+        test: validator.ruler().type('email'),
+      };
+      const data = {
+        test: {},
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+    });
+  });
+
+  describe('phone number', () => {
+    it('Should validate plain phone values without area code', () => {
+      const schema = {
+        test: validator.ruler().type('phone'),
+      };
+      const data = {
+        test: '1231313',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeTruthy();
+    });
+
+    it('Should validate plain phone values', () => {
+      const schema = {
+        test: validator.ruler().type('phone'),
+      };
+      const data = {
+        test: '1231231313',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeTruthy();
+    });
+
+    it('Should validate plain phone values with country code', () => {
+      const schema = {
+        test: validator.ruler().type('phone'),
+      };
+      const data = {
+        test: '11231231313',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeTruthy();
+    });
+
+    it('Should validate phone values when using parenthesis', () => {
+      const schema = {
+        test: validator.ruler().type('phone'),
+      };
+      const data = {
+        test: '1(123)1231313',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeTruthy();
+    });
+
+    it('Should validate phone values when using parenthesis and spaces', () => {
+      const schema = {
+        test: validator.ruler().type('phone'),
+      };
+      const data = {
+        test: '(123) 1231313',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeTruthy();
+    });
+
+    it('Should validate phone values when using country code', () => {
+      const schema = {
+        test: validator.ruler().type('phone'),
+      };
+      const data = {
+        test: '1 (123) 123 1313',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeTruthy();
+    });
+
+    it('Should validate phone values when using country code and spaces', () => {
+      const schema = {
+        test: validator.ruler().type('phone'),
+      };
+      const data = {
+        test: '1 123 123 1313',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeTruthy();
+    });
+
+    it('Should validate phone values when using dots', () => {
+      const schema = {
+        test: validator.ruler().type('phone'),
+      };
+      const data = {
+        test: '1.123.123.1313',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeTruthy();
+    });
+
+    it('Should validate phone values when using hyphens', () => {
+      const schema = {
+        test: validator.ruler().type('phone'),
+      };
+      const data = {
+        test: '1-123-123-1313',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeTruthy();
+    });
+
+    it('Should validate phone values when using plus sign for country code', () => {
+      const schema = {
+        test: validator.ruler().type('phone'),
+      };
+      const data = {
+        test: '+1 123-123-1313',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeTruthy();
+    });
+
+    it('Should validate phone values when using plus sign and parenthesis', () => {
+      const schema = {
+        test: validator.ruler().type('phone'),
+      };
+      const data = {
+        test: '+1 (123) 123-1313',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeTruthy();
+    });
+
+    it('Should error out if phone number is less than 7 characters', () => {
+      const schema = {
+        test: validator.ruler().type('phone'),
+      };
+      const data = {
+        test: '123456',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+    });
+
+    it('Should error out if phone number is more than 17 characters', () => {
+      const schema = {
+        test: validator.ruler().type('phone'),
+      };
+      const data = {
+        test: '+1 (312) 132 1111-',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+    });
+
+    it('Should error out if phone number has special characters', () => {
+      const schema = {
+        test: validator.ruler().type('phone'),
+      };
+      const data = {
+        test: '312 132/1111',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+    });
+
+    it('Should error out if phone number has letters', () => {
+      const schema = {
+        test: validator.ruler().type('phone'),
+      };
+      const data = {
+        test: '312 aaa 1111',
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+    });
+
+    it('Should error out if phone number is null and retrieve error message', () => {
+      const schema = {
+        test: validator.ruler().type('phone', 'The phone is not valid'),
+      };
+      const data = {
+        test: null,
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+      expect(result.errors?.test[0].message).toBe('The phone is not valid');
+    });
+
+    it('Should error out if phone number is undefined and retrieve error code', () => {
+      const schema = {
+        test: validator.ruler().type('phone', 'The phone is not valid'),
+      };
+      const data = {
+        test: undefined,
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+      expect(result.errors?.test[0].message).toBe('The phone is not valid');
+    });
+
+    it('Should error out if phone number is an object', () => {
+      const schema = {
+        test: validator.ruler().type('phone'),
+      };
+      const data = {
+        test: {},
+      };
+
+      const result = validator.validate(schema, data);
+
+      expect(result.passed).toBeFalsy();
+    });
+  });
+});

--- a/packages/validator/__tests__/ui-validator.spec.ts
+++ b/packages/validator/__tests__/ui-validator.spec.ts
@@ -2,6 +2,15 @@ import { UiValidator } from '../src';
 
 describe('UiValidator', () => {
   const validator = new UiValidator();
+  const consoleError = console.error;
+
+  beforeEach(() => {
+    console.error = jest.fn();
+  });
+
+  afterEach(() => {
+    console.error = consoleError;
+  });
 
   it('Should error out if the schema provided is not valid', () => {
     const schema = {};
@@ -12,22 +21,25 @@ describe('UiValidator', () => {
     const result = validator.validate(schema, data);
 
     expect(result.passed).toBeFalsy();
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('UiValidator - Schema is empty');
   });
 
   it('Should error out if the schema is null', () => {
-    const schema = null;
     const data = {
       test: 'felipe',
     };
 
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     //@ts-ignore
-    const result = validator.validate(schema, data);
+    const result = validator.validate(null, data);
 
     expect(result.passed).toBeFalsy();
+    expect(console.error).toHaveBeenCalledTimes(1);
+    expect(console.error).toHaveBeenCalledWith('UiValidator - Schema is empty');
   });
 
-  it('Should error out if no rules are found', () => {
+  it('Should NOT error out if no rules are found when run in NON strict', () => {
     const schema = {
       diffField: validator.ruler().type('string'),
     };
@@ -37,878 +49,59 @@ describe('UiValidator', () => {
 
     const result = validator.validate(schema, data);
 
-    expect(result.passed).toBeFalsy();
+    expect(result.passed).toBeTruthy();
+    expect(console.error).not.toHaveBeenCalled();
   });
 
-  describe('type validation', () => {
-    describe('strings', () => {
-      it('Should validate strings when string is provided', () => {
-        const schema = {
-          test: validator.ruler().type('string'),
-        };
-        const data = {
-          test: 'felipe',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeTruthy();
-      });
-
-      it('Should validate strings when value provided is a number', () => {
-        const schema = {
-          test: validator.ruler().type('string'),
-        };
-        const data = {
-          test: 123,
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-      });
-
-      it('Should error out when value provided is an object', () => {
-        const schema = {
-          test: validator.ruler().type('string'),
-        };
-        const data = {
-          test: {},
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-      });
-
-      it('Should error out when string is undefined and retrieve correct error message', () => {
-        const schema = {
-          test: validator.ruler().type('string', 'The value is not a string'),
-        };
-        const data = {
-          test: undefined,
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-        expect(result.errors?.test[0].message).toBe('The value is not a string');
-        expect(result.errors?.test[0].code).toBeUndefined();
-      });
-
-      it('Should error out when string is null and retrieve correct error code', () => {
-        const schema = {
-          test: validator.ruler().type('string', 'The value is not a string', 'E200'),
-        };
-        const data = {
-          test: null,
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-        expect(result.errors?.test[0].message).toBe('The value is not a string');
-        expect(result.errors?.test[0].code).toBe('E200');
-      });
-
-      it('Should error out if type is unrecognized', () => {
-        const schema = {
-          // eslint-disable-next-line @typescript-eslint/ban-ts-comment
-          //@ts-ignore
-          test: validator.ruler().type('WHATEVER-VALUE'),
-        };
-        const data = {
-          test: null,
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-      });
-    });
-
-    describe('numeric', () => {
-      it('Should validate numeric values when received a number value', () => {
-        const schema = {
-          test: validator.ruler().type('numeric'),
-        };
-        const data = {
-          test: 123,
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeTruthy();
-      });
-
-      it('Should validate numeric values when received a number value in string type', () => {
-        const schema = {
-          test: validator.ruler().type('numeric'),
-        };
-        const data = {
-          test: '123',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeTruthy();
-      });
-
-      it('Should error out if provided value has letters and retrieve correct error message', () => {
-        const schema = {
-          test: validator.ruler().type('numeric', 'The value is not numeric'),
-        };
-        const data = {
-          test: '123a23',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-        expect(result.errors?.test[0].message).toBe('The value is not numeric');
-      });
-
-      it('Should error out if provided value has special characters and retrieve correct error code', () => {
-        const schema = {
-          test: validator.ruler().type('numeric', 'The value is not numeric', 500),
-        };
-        const data = {
-          test: '123+23',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-        expect(result.errors?.test[0].message).toBe('The value is not numeric');
-        expect(result.errors?.test[0].code).toBe(500);
-      });
-
-      it('Should error out if provided value is undefined', () => {
-        const schema = {
-          test: validator.ruler().type('numeric'),
-        };
-        const data = {
-          test: undefined,
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-      });
-
-      it('Should error out if provided value is null', () => {
-        const schema = {
-          test: validator.ruler().type('numeric'),
-        };
-        const data = {
-          test: null,
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-      });
-    });
-
-    describe('email', () => {
-      it('Should validate email', () => {
-        const schema = {
-          test: validator.ruler().type('email'),
-        };
-        const data = {
-          test: 'test@mail.com',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeTruthy();
-      });
-
-      it('Should validate email with double top level domain', () => {
-        const schema = {
-          test: validator.ruler().type('email'),
-        };
-        const data = {
-          test: 'test@mail.co.uk',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeTruthy();
-      });
-
-      it('Should validate email with short top level domain', () => {
-        const schema = {
-          test: validator.ruler().type('email'),
-        };
-        const data = {
-          test: 'test@mail.mx',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeTruthy();
-      });
-
-      it('Should validate email when using _ or - or . in their name', () => {
-        const schema = {
-          test: validator.ruler().type('email'),
-        };
-        const data = {
-          test: 't_e.s-t@mail.mx',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeTruthy();
-      });
-
-      it('Should validate email when using numbers in their name', () => {
-        const schema = {
-          test: validator.ruler().type('email'),
-        };
-        const data = {
-          test: 't_e.s-temail99@mail.mx',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeTruthy();
-      });
-
-      it('Should validate email when using numbers in their domain', () => {
-        const schema = {
-          test: validator.ruler().type('email'),
-        };
-        const data = {
-          test: 'test@mail99.mx',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeTruthy();
-      });
-
-      it('Should validate email when using - or . in their domain', () => {
-        const schema = {
-          test: validator.ruler().type('email'),
-        };
-        const data = {
-          test: 'test@ma-i.l.com',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeTruthy();
-      });
-
-      it('Should error out if mail name is empty and retrieve correct error message', () => {
-        const schema = {
-          test: validator.ruler().type('email', 'The email is not valid'),
-        };
-        const data = {
-          test: '@mail.com',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-        expect(result.errors?.test[0].message).toBe('The email is not valid');
-      });
-
-      it('Should error out if mail name has special characters and retrieve correct error code', () => {
-        const schema = {
-          test: validator.ruler().type('email', 'The email is not valid', 'E400'),
-        };
-        const data = {
-          test: 'te/st@mail.com',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-        expect(result.errors?.test[0].message).toBe('The email is not valid');
-        expect(result.errors?.test[0].code).toBe('E400');
-      });
-
-      it('Should error out if domain name is empty', () => {
-        const schema = {
-          test: validator.ruler().type('email'),
-        };
-        const data = {
-          test: 'te/st@.com',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-      });
-
-      it('Should error out if domain name has special characters', () => {
-        const schema = {
-          test: validator.ruler().type('email'),
-        };
-        const data = {
-          test: 'test@ma_il.com',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-      });
-
-      it('Should error out if top level domain is empty', () => {
-        const schema = {
-          test: validator.ruler().type('email'),
-        };
-        const data = {
-          test: 'test@mail.',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-      });
-
-      it('Should error out if top level domain has only 1 character', () => {
-        const schema = {
-          test: validator.ruler().type('email'),
-        };
-        const data = {
-          test: 'test@mail.x',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-      });
-
-      it('Should error out if top level domain has more than 4 character', () => {
-        const schema = {
-          test: validator.ruler().type('email'),
-        };
-        const data = {
-          test: 'test@mail.longd',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-      });
-
-      it('Should error out if top level domain has special characters', () => {
-        const schema = {
-          test: validator.ruler().type('email'),
-        };
-        const data = {
-          test: 'test@mail.co_m',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-      });
-
-      it('Should error out mail is null', () => {
-        const schema = {
-          test: validator.ruler().type('email'),
-        };
-        const data = {
-          test: null,
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-      });
-
-      it('Should error out mail is undefined', () => {
-        const schema = {
-          test: validator.ruler().type('email'),
-        };
-        const data = {
-          test: undefined,
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-      });
-
-      it('Should error out mail is not a string', () => {
-        const schema = {
-          test: validator.ruler().type('email'),
-        };
-        const data = {
-          test: {},
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-      });
-    });
-
-    describe('phone number', () => {
-      it('Should validate plain phone values without area code', () => {
-        const schema = {
-          test: validator.ruler().type('phone'),
-        };
-        const data = {
-          test: '1231313',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeTruthy();
-      });
-
-      it('Should validate plain phone values', () => {
-        const schema = {
-          test: validator.ruler().type('phone'),
-        };
-        const data = {
-          test: '1231231313',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeTruthy();
-      });
-
-      it('Should validate plain phone values with country code', () => {
-        const schema = {
-          test: validator.ruler().type('phone'),
-        };
-        const data = {
-          test: '11231231313',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeTruthy();
-      });
-
-      it('Should validate phone values when using parenthesis', () => {
-        const schema = {
-          test: validator.ruler().type('phone'),
-        };
-        const data = {
-          test: '1(123)1231313',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeTruthy();
-      });
-
-      it('Should validate phone values when using parenthesis and spaces', () => {
-        const schema = {
-          test: validator.ruler().type('phone'),
-        };
-        const data = {
-          test: '(123) 1231313',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeTruthy();
-      });
-
-      it('Should validate phone values when using country code', () => {
-        const schema = {
-          test: validator.ruler().type('phone'),
-        };
-        const data = {
-          test: '1 (123) 123 1313',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeTruthy();
-      });
-
-      it('Should validate phone values when using country code and spaces', () => {
-        const schema = {
-          test: validator.ruler().type('phone'),
-        };
-        const data = {
-          test: '1 123 123 1313',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeTruthy();
-      });
-
-      it('Should validate phone values when using dots', () => {
-        const schema = {
-          test: validator.ruler().type('phone'),
-        };
-        const data = {
-          test: '1.123.123.1313',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeTruthy();
-      });
-
-      it('Should validate phone values when using hyphens', () => {
-        const schema = {
-          test: validator.ruler().type('phone'),
-        };
-        const data = {
-          test: '1-123-123-1313',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeTruthy();
-      });
-
-      it('Should validate phone values when using plus sign for country code', () => {
-        const schema = {
-          test: validator.ruler().type('phone'),
-        };
-        const data = {
-          test: '+1 123-123-1313',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeTruthy();
-      });
-
-      it('Should validate phone values when using plus sign and parenthesis', () => {
-        const schema = {
-          test: validator.ruler().type('phone'),
-        };
-        const data = {
-          test: '+1 (123) 123-1313',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeTruthy();
-      });
-
-      it('Should error out if phone number is less than 7 characters', () => {
-        const schema = {
-          test: validator.ruler().type('phone'),
-        };
-        const data = {
-          test: '123456',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-      });
-
-      it('Should error out if phone number is more than 17 characters', () => {
-        const schema = {
-          test: validator.ruler().type('phone'),
-        };
-        const data = {
-          test: '+1 (312) 132 1111-',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-      });
-
-      it('Should error out if phone number has special characters', () => {
-        const schema = {
-          test: validator.ruler().type('phone'),
-        };
-        const data = {
-          test: '312 132/1111',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-      });
-
-      it('Should error out if phone number has letters', () => {
-        const schema = {
-          test: validator.ruler().type('phone'),
-        };
-        const data = {
-          test: '312 aaa 1111',
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-      });
-
-      it('Should error out if phone number is null and retrieve error message', () => {
-        const schema = {
-          test: validator.ruler().type('phone', 'The phone is not valid'),
-        };
-        const data = {
-          test: null,
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-        expect(result.errors?.test[0].message).toBe('The phone is not valid');
-      });
-
-      it('Should error out if phone number is undefined and retrieve error code', () => {
-        const schema = {
-          test: validator.ruler().type('phone', 'The phone is not valid', 400),
-        };
-        const data = {
-          test: undefined,
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-        expect(result.errors?.test[0].message).toBe('The phone is not valid');
-        expect(result.errors?.test[0].code).toBe(400);
-      });
-
-      it('Should error out if phone number is an object', () => {
-        const schema = {
-          test: validator.ruler().type('phone'),
-        };
-        const data = {
-          test: {},
-        };
-
-        const result = validator.validate(schema, data);
-
-        expect(result.passed).toBeFalsy();
-      });
-    });
-  });
-
-  describe('range validation', () => {
-    it('Should validate correct range', () => {
+  describe('Strict', () => {
+    it('Should error out if no rules are found in schema for a given data field when run in strict', () => {
       const schema = {
-        test: validator.ruler().range(10, 100),
+        diffField: validator.ruler().type('string'),
       };
       const data = {
-        test: 50,
+        test: 'felipe',
       };
 
-      const result = validator.validate(schema, data);
-
-      expect(result.passed).toBeTruthy();
-    });
-
-    it('Should error out if value is smaller than the min range', () => {
-      const schema = {
-        test: validator.ruler().range(10, 100),
-      };
-      const data = {
-        test: 3,
-      };
-
-      const result = validator.validate(schema, data);
+      const result = validator.validate(schema, data, true);
 
       expect(result.passed).toBeFalsy();
+      expect(console.error).toHaveBeenCalledTimes(2);
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      //@ts-ignore
+      expect(console.error.mock.calls[0][0]).toBe('UiValidator - Field test is NOT in schema');
     });
 
-    it('Should error out if value is bigger than the max range', () => {
+    it('Should error out if schema has different fields than the data passed in strict', () => {
       const schema = {
-        test: validator.ruler().range(10, 100),
+        diffField: validator.ruler().type('string'),
       };
       const data = {
-        test: 150,
+        test: 'felipe',
       };
 
-      const result = validator.validate(schema, data);
+      const result = validator.validate(schema, data, true);
 
       expect(result.passed).toBeFalsy();
+      expect(console.error).toHaveBeenCalledTimes(2);
+
+      // eslint-disable-next-line @typescript-eslint/ban-ts-comment
+      //@ts-ignore
+      expect(console.error.mock.calls[1][0]).toBe('UiValidator - schema has different fields than the data passed');
     });
 
-    it('Should error out if value null and retrieve error message', () => {
+    it('Should error out if schema field has empty rules when run in strict', () => {
       const schema = {
-        test: validator.ruler().range(10, 100, 'Value is not in range'),
+        test: validator.ruler(),
       };
       const data = {
-        test: null,
+        test: 'felipe',
       };
 
-      const result = validator.validate(schema, data);
+      const result = validator.validate(schema, data, true);
 
       expect(result.passed).toBeFalsy();
-      expect(result.errors?.test[0].message).toBe('Value is not in range');
-    });
-
-    it('Should error out if value undefined and retrieve error code', () => {
-      const schema = {
-        test: validator.ruler().range(10, 100, 'Value is not in range', 'E120'),
-      };
-      const data = {
-        test: undefined,
-      };
-
-      const result = validator.validate(schema, data);
-
-      expect(result.passed).toBeFalsy();
-      expect(result.errors?.test[0].message).toBe('Value is not in range');
-      expect(result.errors?.test[0].code).toBe('E120');
-    });
-
-    it('Should error out if value is not numeric', () => {
-      const schema = {
-        test: validator.ruler().range(10, 100),
-      };
-      const data = {
-        test: '12aa0',
-      };
-
-      const result = validator.validate(schema, data);
-
-      expect(result.passed).toBeFalsy();
-    });
-
-    it('Should error out if value is numeric and does not pass validation', () => {
-      const schema = {
-        test: validator.ruler().range(10, 100),
-      };
-      const data = {
-        test: '120',
-      };
-
-      const result = validator.validate(schema, data);
-
-      expect(result.passed).toBeFalsy();
-    });
-
-    it('Should validate correctly if value is numeric and passes validation', () => {
-      const schema = {
-        test: validator.ruler().range(10, 100),
-      };
-      const data = {
-        test: '90',
-      };
-
-      const result = validator.validate(schema, data);
-
-      expect(result.passed).toBeTruthy();
-    });
-  });
-
-  describe('length validation', () => {
-    it('Should validate correct length', () => {
-      const schema = {
-        test: validator.ruler().length(0, 10),
-      };
-      const data = {
-        test: 'testString',
-      };
-
-      const result = validator.validate(schema, data);
-
-      expect(result.passed).toBeTruthy();
-    });
-
-    it('Should error out when string is too short and retrieve error message', () => {
-      const schema = {
-        test: validator.ruler().length(5, 10, 'Value is too short'),
-      };
-      const data = {
-        test: 'test',
-      };
-
-      const result = validator.validate(schema, data);
-
-      expect(result.passed).toBeFalsy();
-      expect(result.errors?.test[0].message).toBe('Value is too short');
-    });
-
-    it('Should error out when string is too long and retrieve error code', () => {
-      const schema = {
-        test: validator.ruler().length(5, 10, 'Value is too long', 300),
-      };
-      const data = {
-        test: 'This is a very long phrase',
-      };
-
-      const result = validator.validate(schema, data);
-
-      expect(result.passed).toBeFalsy();
-      expect(result.errors?.test[0].message).toBe('Value is too long');
-      expect(result.errors?.test[0].code).toBe(300);
-    });
-
-    it('Should error out if value is not a tring', () => {
-      const schema = {
-        test: validator.ruler().length(5, 10),
-      };
-      const data = {
-        test: {},
-      };
-
-      const result = validator.validate(schema, data);
-
-      expect(result.passed).toBeFalsy();
-    });
-  });
-
-  describe('require validation', () => {
-    it('Should validate correct when is required', () => {
-      const schema = {
-        test: validator.ruler().isRequired(),
-      };
-      const data = {
-        test: 'test',
-      };
-
-      const result = validator.validate(schema, data);
-
-      expect(result.passed).toBeTruthy();
-    });
-
-    it('Should error out if value is null and retrieve error message', () => {
-      const schema = {
-        test: validator.ruler().isRequired('The value is required'),
-      };
-      const data = {
-        test: null,
-      };
-
-      const result = validator.validate(schema, data);
-
-      expect(result.passed).toBeFalsy();
-      expect(result.errors?.test[0].message).toBe('The value is required');
-    });
-
-    it('Should error out if value is undefined and retrieve error code', () => {
-      const schema = {
-        test: validator.ruler().isRequired('The value is required', 'E400'),
-      };
-      const data = {
-        test: undefined,
-      };
-
-      const result = validator.validate(schema, data);
-
-      expect(result.passed).toBeFalsy();
-      expect(result.errors?.test[0].message).toBe('The value is required');
-      expect(result.errors?.test[0].code).toBe('E400');
-    });
-
-    it('Should still fail if no custom error messaging is passed', () => {
-      const schema = {
-        test: validator.ruler().isRequired(),
-      };
-      const data = {
-        test: undefined,
-      };
-
-      const result = validator.validate(schema, data);
-
-      expect(result.passed).toBeFalsy();
+      expect(console.error).toHaveBeenCalledTimes(1);
+      expect(console.error).toHaveBeenCalledWith('UiValidator - Field test has NOT valid rules');
     });
   });
 

--- a/packages/validator/docs/docs.mdx
+++ b/packages/validator/docs/docs.mdx
@@ -57,8 +57,6 @@ const schema = {
 };
 ```
 
-All chainable functions have 2 common attributes `errorMessage` and `errorCode`, these are used to provide a message or a code if the validation fails.
-
 Then, we can simple call the function `validator.validate()` passing our schema and our data object to be validated:
 
 ```tsx
@@ -91,8 +89,8 @@ export type UiValidatorResult = {
 };
 ```
 
-So, for a overall validation result `passed` will give you that, for specific errors from the validation `errors` field will have that object with a list of all errors found per each field,
-you can then decide how and which ones to show to your user.
+The `errors` property will have an object with a list of all errors found keyed by field, you can then decide how and which ones to show to your user.
+All chainable functions have a common attribute `errorMessage`, this overrides the default error messaging from the utility.
 
 export const validator = new UiValidator();
 
@@ -116,7 +114,49 @@ Example using a component that receives the schema and the data and then renders
 
 <small>ValidatorRunner is just for demo purposes this package only exports the UiValidator class.</small>
 
+<br />
+<br />
+<br />
+<br />
+
 ## Details 🤓
+
+### Strict mode 🐣
+
+The strict is set as the 3rd parameter to the validate function:
+
+```tsx
+const result = validator.validate(schema, data, true);
+```
+
+This will run the validations in a more strict way and the things validated are:
+
+<UiList>
+  <li>❌ - When the schema has more properties than the data passed.</li>
+  <li>❌ - When the a data field exists in the schema but doesn't have rules to be applied.</li>
+  <li>❌ - When the a data field doesn't exist in the schema.</li>
+</UiList>
+
+<br />
+<br />
+
+## More details 😴
+
+As if it weren't already from here downwards is a wall of text, go under your own risk...
+
+<iframe
+  src="https://giphy.com/embed/XuDlhFtiWXZEk"
+  width="480"
+  height="271"
+  frameBorder="0"
+  class="giphy-embed"
+  allowFullScreen
+></iframe>
+
+<br />
+<br />
+
+## All chainable rules 🤖
 
 These are the chainable functions that you can use, to set the rules, their possible values and examples:
 
@@ -127,11 +167,26 @@ These are the chainable functions that you can use, to set the rules, their poss
     <th>Validates</th>
   </tr>
   <tr>
+    <td>
+      <UiText>isOptional()</UiText>
+    </td>
+    <td></td>
+    <td>
+      <UiList>
+        <li>✅ everything</li>
+      </UiList>
+      <small>
+        As this is always true, this is used as a bypass when you don't want any rules to be applied/validated to a
+        specific field and you are running the validation in strict.
+      </small>
+    </td>
+  </tr>
+  <tr>
     <td>isRequired()</td>
     <td>
       <UiList>
         <li> ❓ errorMessage</li>
-        <li> ❓ errorCode </li>
+        <li>DEFAULT: `This is required`</li>
       </UiList>
     </td>
     <td>
@@ -155,9 +210,8 @@ These are the chainable functions that you can use, to set the rules, their poss
             <li>&nbsp;&nbsp; email</li>
           </UiList>
         </li>
-        <li></li>
         <li> ❓ errorMessage</li>
-        <li> ❓ errorCode </li>
+        <li>DEFAULT: `This is not a valid (type)`</li>
       </UiList>
     </td>
     <td>
@@ -208,7 +262,7 @@ These are the chainable functions that you can use, to set the rules, their poss
         <li> ❗️ min</li>
         <li> ❗️ max</li>
         <li> ❓ errorMessage</li>
-        <li> ❓ errorCode </li>
+        <li>DEFAULT: `This is not in valid range of (min) and (max)`</li>
       </UiList>
     </td>
     <td>
@@ -225,7 +279,7 @@ These are the chainable functions that you can use, to set the rules, their poss
         <li> ❗️ min</li>
         <li> ❗️ max</li>
         <li> ❓ errorMessage</li>
-        <li> ❓ errorCode </li>
+        <li>DEFAULT: "This does not have a valid length of min (min) and max (max)"</li>
       </UiList>
     </td>
     <td>

--- a/packages/validator/docs/docs.mdx
+++ b/packages/validator/docs/docs.mdx
@@ -133,8 +133,8 @@ This will run the validations in a more strict way and the things validated are:
 
 <UiList>
   <li>❌ - When the schema has more properties than the data passed.</li>
-  <li>❌ - When the a data field exists in the schema but doesn't have rules to be applied.</li>
-  <li>❌ - When the a data field doesn't exist in the schema.</li>
+  <li>❌ - When a data field exists in the schema but doesn't have rules to be applied.</li>
+  <li>❌ - When a data field doesn't exist in the schema.</li>
 </UiList>
 
 <br />

--- a/packages/validator/src/index.ts
+++ b/packages/validator/src/index.ts
@@ -1,1 +1,2 @@
 export * from './ui-validator';
+export type { UiValidatorErrors, UiValidatorData, UiValidatorSchema, UiValidatorResult } from './types';

--- a/packages/validator/src/types/schema-type.ts
+++ b/packages/validator/src/types/schema-type.ts
@@ -6,7 +6,7 @@ export type UiValidatorExpectationRule<T> = {
   /** The expected value for this rule */
   expected: T;
   /** The error message to provide in the response if this check doesn't pass */
-  error?: UiValidatorError;
+  error: UiValidatorError;
 };
 
 /** The value for each rule */
@@ -16,7 +16,7 @@ export type UiValidatorLengthRule = {
   /** The expected max length for this rule */
   max: number;
   /** The error message to provide in the response if this check doesn't pass */
-  error?: UiValidatorError;
+  error: UiValidatorError;
 };
 
 /** The value for each rule */
@@ -26,7 +26,7 @@ export type UiValidatorRangeRule = {
   /** The expected max range for this rule */
   max: number;
   /** The error message to provide in the response if this check doesn't pass */
-  error?: UiValidatorError;
+  error: UiValidatorError;
 };
 
 /** Set of possible rules for each field */

--- a/packages/validator/src/types/validator-result.ts
+++ b/packages/validator/src/types/validator-result.ts
@@ -2,8 +2,6 @@
 export type UiValidatorError = {
   /** A message to be provided in the error */
   message?: string;
-  /** A code to be provided in the error */
-  code?: string | number;
 };
 
 /** Errors per each field */

--- a/packages/validator/src/ui-ruler.ts
+++ b/packages/validator/src/ui-ruler.ts
@@ -3,63 +3,67 @@ import { UiValidatorRules } from './types';
 export class UiRuler {
   private rules: UiValidatorRules = {};
 
-  isRequired(errorMessage?: string, errorCode?: string | number): UiRuler {
+  isRequired(errorMessage?: string): UiRuler {
     this.rules.required = {
       expected: true,
-      error:
-        errorMessage || errorCode
-          ? {
-              message: errorMessage,
-              code: errorCode,
-            }
-          : undefined,
+      error: errorMessage
+        ? {
+            message: errorMessage,
+          }
+        : {
+            message: 'This is required',
+          },
     };
 
     return this;
   }
 
-  type(type: 'string' | 'numeric' | 'email' | 'phone', errorMessage?: string, errorCode?: string | number): UiRuler {
+  isOptional(): UiRuler {
+    return this;
+  }
+
+  type(type: 'string' | 'numeric' | 'email' | 'phone', errorMessage?: string): UiRuler {
     this.rules.type = {
       expected: type,
-      error:
-        errorMessage || errorCode
-          ? {
-              message: errorMessage,
-              code: errorCode,
-            }
-          : undefined,
+      error: errorMessage
+        ? {
+            message: errorMessage,
+          }
+        : {
+            message: `This is not a valid ${type}`,
+          },
     };
 
     return this;
   }
 
-  range(min: number, max: number, errorMessage?: string, errorCode?: string | number): UiRuler {
+  range(min: number, max: number, errorMessage?: string): UiRuler {
     this.rules.range = {
       min,
       max,
-      error:
-        errorMessage || errorCode
-          ? {
-              message: errorMessage,
-              code: errorCode,
-            }
-          : undefined,
+      error: errorMessage
+        ? {
+            message: errorMessage,
+          }
+        : {
+            message: `This is not in valid range of ${min} and ${max}`,
+          },
     };
 
     return this;
   }
 
-  length(min: number, max: number, errorMessage?: string, errorCode?: string | number): UiRuler {
+  length(min: number, max: number, errorMessage?: string): UiRuler {
     this.rules.length = {
       min,
       max,
-      error:
-        errorMessage || errorCode
-          ? {
-              message: errorMessage,
-              code: errorCode,
-            }
-          : undefined,
+      error: errorMessage
+        ? {
+            message: errorMessage,
+          }
+        : {
+            message: `This does not have a valid length of min ${min} and max ${max}`,
+          },
     };
 
     return this;


### PR DESCRIPTION
## 🔥 Adding strict mode to validator
----------------------------------------------

### Description
I'm adding a strict mode to validator, this will make sure a few things as validated such as:

- when schema has more fields than the data
- when data field is not present in schema
- when data field doesn't have valid rules

I'm also improving the logging, so is easier to identify what is failing when a set up error is returned. (Not an actual validation error, an incorrect schema or something like it).

### Screenshots

N/A
