### PR TITLE
fix: linear chart current label padding

### DIFF
--- a/packages/charts/__tests__/ui-linear-chart.spec.tsx
+++ b/packages/charts/__tests__/ui-linear-chart.spec.tsx
@@ -68,6 +68,22 @@ describe('<UiLinearChart />', () => {
     expect(screen.getByText('Current label')).toBeVisible();
   });
 
+  it('renders current label when value is 0', () => {
+    const data: UiLinearChartData = {
+      current: {
+        label: 'Current label',
+        value: 0,
+      },
+      limit: {
+        value: 30,
+      },
+    };
+
+    uiRender(<UiLinearChart data={data} />);
+
+    expect(screen.getByText('Current label')).toBeVisible();
+  });
+
   it('renders current static label', () => {
     const data: UiLinearChartData = {
       current: {

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@uireact/charts",
-  "description": "@uireact/charts package needed for @uireact packages",
+  "description": "@uireact/charts package from @uireact library",
   "repository": "https://github.com/inavac182/ui-react",
   "license": "MIT",
   "version": "0.2.0",

--- a/packages/charts/src/ui-linear-chart.tsx
+++ b/packages/charts/src/ui-linear-chart.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
+import { styled } from 'styled-components';
 
-import { ThemeContext, UiReactElementProps, UiSpacing, UiSpacingProps } from '@uireact/foundation';
+import { ThemeContext, UiReactElementProps } from '@uireact/foundation';
 import { UiText } from '@uireact/text';
 import { UiFlexGrid } from '@uireact/flex-grid';
 
@@ -11,7 +12,9 @@ export type UiLinearChartProps = {
   data: UiLinearChartData;
 } & UiReactElementProps;
 
-const currentLabelSpacing: UiSpacingProps['padding'] = { top: 'three' };
+const CurrentLabelWrapper = styled.div<{ $current: number }>`
+  padding-top: ${(props) => (props.$current > 0 ? '2px' : '8px')};
+`;
 
 export const UiLinearChart: React.FC<UiLinearChartProps> = ({ className, testId, data }: UiLinearChartProps) => {
   const themeContext = React.useContext(ThemeContext);
@@ -38,9 +41,9 @@ export const UiLinearChart: React.FC<UiLinearChartProps> = ({ className, testId,
           $currentColor={data.current.color}
         >
           {data.current.label && !data.current.labelStatic && (
-            <UiSpacing padding={currentLabelSpacing}>
+            <CurrentLabelWrapper $current={data.current.value}>
               <UiText align="right">{data.current.label}</UiText>
-            </UiSpacing>
+            </CurrentLabelWrapper>
           )}
         </CurrentDiv>
       </WrapperDiv>


### PR DESCRIPTION
## 🔥 Fixing current label padding
----------------------------------------------

### Description
The current label padding was not correct when the value was 0, so this fixes it.

### Screenshots
#### Before
![Screenshot 2023-09-04 at 7 12 53 PM](https://github.com/inavac182/uireact/assets/16787893/6bd68d86-c4b3-4c1e-8264-02df9d13fd8e)

#### After
![Screenshot 2023-09-04 at 7 12 38 PM](https://github.com/inavac182/uireact/assets/16787893/19ebc7f6-e9f0-4a71-a6d6-9de019061430)
