### PR TITLE
feat: adding a prop for no bg in uiview

### DIFF
--- a/packages/view/__tests__/ui-view-row.spec.tsx
+++ b/packages/view/__tests__/ui-view-row.spec.tsx
@@ -69,9 +69,19 @@ describe('<UiViewRow />', () => {
     expect(screen.getByText('Content 1')).toBeVisible();
   });
 
-  it('Should render fine with noBackground', () => {
+  it('Should render fine with noBackground and inverse font', () => {
     uiRender(
       <UiViewRow inverseFont noBackground>
+        <p>Content 1</p>
+      </UiViewRow>
+    );
+
+    expect(screen.getByText('Content 1')).toBeVisible();
+  });
+
+  it('Should render fine with noBackground', () => {
+    uiRender(
+      <UiViewRow noBackground>
         <p>Content 1</p>
       </UiViewRow>
     );

--- a/packages/view/__tests__/ui-view-row.spec.tsx
+++ b/packages/view/__tests__/ui-view-row.spec.tsx
@@ -68,4 +68,14 @@ describe('<UiViewRow />', () => {
 
     expect(screen.getByText('Content 1')).toBeVisible();
   });
+
+  it('Should render fine with noBackground', () => {
+    uiRender(
+      <UiViewRow inverseFont noBackground>
+        <p>Content 1</p>
+      </UiViewRow>
+    );
+
+    expect(screen.getByText('Content 1')).toBeVisible();
+  });
 });

--- a/packages/view/__tests__/ui-view.spec.tsx
+++ b/packages/view/__tests__/ui-view.spec.tsx
@@ -10,6 +10,7 @@ import { UiView } from '../src/ui-view';
 type MockedComponentProps = {
   centeredContent?: boolean;
   className?: string;
+  noBackground?: boolean;
 };
 
 const closeDialogMockedFn = jest.fn();
@@ -43,6 +44,7 @@ const MockedComponent = (props: MockedComponentProps) => (
     dialogController={customDialogController}
     className={props.className}
     centeredContent={props.centeredContent}
+    noBackground={props.noBackground}
   >
     <p>Content</p>
     <DialogComponent />
@@ -79,6 +81,12 @@ describe('<UiView />', () => {
     expect(screen.getByText('Content')).toBeVisible();
   });
 
+  it('renders fine with no background', () => {
+    render(<MockedComponent noBackground />);
+
+    expect(screen.getByText('Content')).toBeVisible();
+  });
+
   it('renders fine when is centered and xlarge', () => {
     // eslint-disable-next-line @typescript-eslint/ban-ts-comment
     //@ts-ignore
@@ -88,6 +96,7 @@ describe('<UiView />', () => {
 
     expect(screen.getByText('Content')).toBeVisible();
   });
+
   it('Should add class name', () => {
     render(<MockedComponent className="someClass" />);
 

--- a/packages/view/docs/util/view-row-example.tsx
+++ b/packages/view/docs/util/view-row-example.tsx
@@ -29,6 +29,9 @@ export const ViewRowExample: React.FC = () => {
       <UiViewRow weight="200">
         <p>A row with weight 200</p>
       </UiViewRow>
+      <UiViewRow weight="200" noBackground>
+        <p>A row without background color</p>
+      </UiViewRow>
       <UiViewRow inverseFont category="negative">
         <p>Row with inverse font and category</p>
       </UiViewRow>

--- a/packages/view/docs/view.mdx
+++ b/packages/view/docs/view.mdx
@@ -93,6 +93,9 @@ export const ViewRowExample: React.FC = () => {
       <UiViewRow weight="200">
         <p>A row with weight 200</p>
       </UiViewRow>
+      <UiViewRow weight="200" noBackground>
+        <p>A row without background color</p>
+      </UiViewRow>
       <UiViewRow inverseFont category="negative">
         <p>Row with inverse font and category</p>
       </UiViewRow>

--- a/packages/view/src/theme/dynamic-view-row-mapper.ts
+++ b/packages/view/src/theme/dynamic-view-row-mapper.ts
@@ -3,7 +3,8 @@ import { ThemeMapper, ColorCategories, ColorTokens, ColorCategory, getColorCateg
 export const dynamicViewRowMapper = (
   weight: '10' | '50' | '100' | '150' | '200' = '100',
   category?: ColorCategory,
-  inverseFont?: boolean
+  inverseFont?: boolean,
+  noBackground?: boolean
 ): ThemeMapper => {
   let token = ColorTokens.token_100;
   let fontToken = ColorTokens.token_100;
@@ -32,6 +33,18 @@ export const dynamicViewRowMapper = (
     default:
       token = ColorTokens.token_100;
       fontToken = ColorTokens.token_100;
+  }
+
+  if (noBackground) {
+    return {
+      normal: {
+        color: {
+          category: ColorCategories.fonts,
+          inverse: inverseFont ?? false,
+          token: fontToken,
+        },
+      },
+    };
   }
 
   return {

--- a/packages/view/src/theme/mapper.ts
+++ b/packages/view/src/theme/mapper.ts
@@ -1,16 +1,30 @@
 import { ColorCategories, ColorTokens, ThemeMapper } from '@uireact/foundation';
 
-export const themeMapper: ThemeMapper = {
-  normal: {
-    background: {
-      category: ColorCategories.primary,
-      inverse: false,
-      token: ColorTokens.token_100,
+export const getDynamicMapper = (noBackground?: boolean): ThemeMapper => {
+  if (noBackground) {
+    return {
+      normal: {
+        color: {
+          category: ColorCategories.fonts,
+          inverse: false,
+          token: ColorTokens.token_100,
+        },
+      },
+    };
+  }
+
+  return {
+    normal: {
+      background: {
+        category: ColorCategories.primary,
+        inverse: false,
+        token: ColorTokens.token_100,
+      },
+      color: {
+        category: ColorCategories.fonts,
+        inverse: false,
+        token: ColorTokens.token_100,
+      },
     },
-    color: {
-      category: ColorCategories.fonts,
-      inverse: false,
-      token: ColorTokens.token_100,
-    },
-  },
+  };
 };

--- a/packages/view/src/types/ui-view-props.ts
+++ b/packages/view/src/types/ui-view-props.ts
@@ -15,6 +15,8 @@ export type UiViewProps = {
   selectedTheme: ThemeColor;
   /** Theme for the view */
   theme: Theme;
+  /** If the view container should not render a bg */
+  noBackground?: boolean;
 } & UiReactElementProps;
 
 export type UiViewRowProps = {
@@ -26,13 +28,21 @@ export type UiViewRowProps = {
   inverseFont?: boolean;
   /** The weigth of the background color to use */
   weight?: '10' | '50' | '100' | '150' | '200';
+  /** If the view container should not render a bg */
+  noBackground?: boolean;
 } & UiReactElementProps;
 
-export type privateViewProps = Omit<Omit<Omit<UiViewProps, 'selectedTheme'>, 'theme'>, 'dialogController'> &
-  UiReactPrivateElementProps;
+export type privateViewProps = {
+  /** If content should render centered and not fullscreen */
+  $centeredContent?: boolean;
+  /** If the view container should not render a bg */
+  $noBackground?: boolean;
+} & UiReactPrivateElementProps;
+
 export type privateViewRowProps = {
   $centeredContent?: boolean;
   $weight?: '10' | '50' | '100' | '150' | '200';
   $category?: ColorCategory;
   $inverseFont?: boolean;
+  $noBackground?: boolean;
 } & UiReactPrivateElementProps;

--- a/packages/view/src/ui-view-row.tsx
+++ b/packages/view/src/ui-view-row.tsx
@@ -10,7 +10,7 @@ import { CenteredDiv } from './__private';
 
 const Div = styled.div<privateViewRowProps>`
   ${(props) => {
-    const mapper = dynamicViewRowMapper(props.$weight, props.$category, props.$inverseFont);
+    const mapper = dynamicViewRowMapper(props.$weight, props.$category, props.$inverseFont, props.$noBackground);
     return getThemeStyling(props.$customTheme, props.$selectedTheme, mapper);
   }}
 `;
@@ -22,6 +22,7 @@ export const UiViewRow: React.FC<UiViewRowProps> = ({
   className,
   inverseFont,
   weight,
+  noBackground,
 }: UiViewRowProps) => {
   const viewport = useViewport();
   const themeContext = React.useContext(ThemeContext);
@@ -34,6 +35,7 @@ export const UiViewRow: React.FC<UiViewRowProps> = ({
       className={className}
       $category={category}
       $inverseFont={inverseFont}
+      $noBackground={noBackground}
     >
       {centeredContent ? (
         <>

--- a/packages/view/src/ui-view.tsx
+++ b/packages/view/src/ui-view.tsx
@@ -16,7 +16,7 @@ import {
 import { UiDialogsControllerContext, useDialogController } from '@uireact/foundation';
 
 import { UiViewProps, privateViewProps } from './types/ui-view-props';
-import { themeMapper } from './theme';
+import { getDynamicMapper } from './theme';
 import { CenteredDiv } from './__private';
 
 /* istanbul ignore next */
@@ -55,7 +55,7 @@ const GlobalStyle = createGlobalStyle<privateViewProps>`
 
 const Div = styled.div<privateViewProps>`
   ${(props) => `
-    ${getThemeStyling(props.$customTheme, props.$selectedTheme, themeMapper)}
+    ${getThemeStyling(props.$customTheme, props.$selectedTheme, getDynamicMapper(props.$noBackground))}
     ${`font-family: ${props.$customTheme.texts.font};`}
     ${`font-size: ${getTextSize(props.$customTheme, TextSize.regular)};`}
   `}
@@ -70,30 +70,39 @@ export const UiView: React.FC<UiViewProps> = ({
   theme,
   selectedTheme,
   children,
+  noBackground,
 }: UiViewProps) => {
   const defaultDialogController = useDialogController();
 
   return (
-    <ThemeContext.Provider value={{ theme, selectedTheme }}>
-      <UiDialogsControllerContext.Provider value={dialogController ?? defaultDialogController}>
-        <GlobalStyle $customTheme={theme} $selectedTheme={selectedTheme} />
-        <Div $customTheme={theme} $selectedTheme={selectedTheme} className={className} data-testid="UiView">
-          {centeredContent ? (
-            <>
-              <UiViewport criteria={Breakpoints.XLARGE}>
-                <CenteredDiv $size="xl">{children}</CenteredDiv>
-              </UiViewport>
-              <UiViewport criteria={Breakpoints.LARGE}>
-                <CenteredDiv $size="l">{children}</CenteredDiv>
-              </UiViewport>
-              <UiViewport criteria={'s|m'}>{children}</UiViewport>
-            </>
-          ) : (
-            <>{children}</>
-          )}
-        </Div>
-      </UiDialogsControllerContext.Provider>
-    </ThemeContext.Provider>
+    <Div
+      $customTheme={theme}
+      $selectedTheme={selectedTheme}
+      className={className}
+      data-testid="UiView"
+      $noBackground={noBackground}
+    >
+      <ThemeContext.Provider value={{ theme, selectedTheme }}>
+        <UiDialogsControllerContext.Provider value={dialogController ?? defaultDialogController}>
+          <GlobalStyle $customTheme={theme} $selectedTheme={selectedTheme} />
+          <>
+            {centeredContent ? (
+              <>
+                <UiViewport criteria={Breakpoints.XLARGE}>
+                  <CenteredDiv $size="xl">{children}</CenteredDiv>
+                </UiViewport>
+                <UiViewport criteria={Breakpoints.LARGE}>
+                  <CenteredDiv $size="l">{children}</CenteredDiv>
+                </UiViewport>
+                <UiViewport criteria={'s|m'}>{children}</UiViewport>
+              </>
+            ) : (
+              <>{children}</>
+            )}
+          </>
+        </UiDialogsControllerContext.Provider>
+      </ThemeContext.Provider>
+    </Div>
   );
 };
 


### PR DESCRIPTION
## 🔥 Adding a prop to skip the bg color in the ui view
----------------------------------------------

### Description
There are some use cases where applications want to render some gradient or imagery as background so that should be handled in their own apps, although having the uiview always rendering a bg makes that not possible. So, I'm adding an option to prevent the bg rendered from the UiView.

### Screenshots
N/A
