### PR TITLE
fix: line height for typography elements

### DIFF
--- a/packages/button/docs/button.mdx
+++ b/packages/button/docs/button.mdx
@@ -114,7 +114,7 @@ import * as packageJson from '../package.json';
 #### Rounded button
 
 <Playground>
-  <UiCard>
+  <UiCard weight="10">
     <UiFlexGrid gap="three">
       <UiButton rounded>
         <UiSpacing padding={{ all: 'three' }}>
@@ -138,22 +138,22 @@ import * as packageJson from '../package.json';
 #### Iconized button
 
 <Playground>
-  <UiCard>
+  <UiCard weight="10">
     <UiFlexGrid gap="three" alignItems="center">
       <UiButton rounded iconized theme="primary">
-        <UiIcon icon="Alarm" size="xlarge" />
+        <UiIcon icon="EarthAmericas" size="xlarge" />
       </UiButton>
       <UiButton rounded iconized theme="secondary">
-        <UiIcon icon="Alarm" size="large" />
+        <UiIcon icon="EarthEuropa" size="large" />
       </UiButton>
       <UiButton rounded iconized theme="tertiary">
-        <UiIcon icon="Alarm" size="regular" />
+        <UiIcon icon="EarthAsia" size="regular" />
       </UiButton>
       <UiButton rounded iconized theme="positive">
-        <UiIcon icon="Alarm" size="small" />
+        <UiIcon icon="EarthAfrica" size="small" />
       </UiButton>
       <UiButton rounded iconized theme="error">
-        <UiIcon icon="Alarm" size="xsmall" />
+        <UiIcon icon="BadgeCheck" size="xsmall" />
       </UiButton>
     </UiFlexGrid>
   </UiCard>

--- a/packages/form/docs/ui-input.mdx
+++ b/packages/form/docs/ui-input.mdx
@@ -59,16 +59,7 @@ import { UiSpacing } from '@uireact/foundation';
 ## UiInput with icon
 
 <Playground>
-  <UiInput
-    label="Search"
-    placeholder="Type your search"
-    labelOnTop
-    icon={
-      <UiSpacing margin={{ top: 'two', left: 'four' }}>
-        <UiIcon icon="MagnifyingGlass" />
-      </UiSpacing>
-    }
-  />
+  <UiInput label="Search" placeholder="Type your search" labelOnTop icon={<UiIcon icon="Search" />} />
 </Playground>
 
 ## UiInput disabled

--- a/packages/form/src/ui-input.tsx
+++ b/packages/form/src/ui-input.tsx
@@ -58,6 +58,10 @@ const InputDiv = styled.div`
 
 const IconContainer = styled.span<{ $size?: SizesProp }>`
   position: absolute;
+  height: 100%;
+  display: flex;
+  align-items: center;
+  padding-left: 8px;
 `;
 
 export const UiInput: React.FC<UiInputProps> = ({

--- a/packages/foundation/src/spacing/spacing.tsx
+++ b/packages/foundation/src/spacing/spacing.tsx
@@ -66,7 +66,14 @@ const Div = styled.div<__UiSpacingProps>`
   `}
 `;
 
-export const UiSpacing: React.FC<UiSpacingProps> = ({ children, inline, margin, padding, testId }: UiSpacingProps) => {
+export const UiSpacing: React.FC<UiSpacingProps> = ({
+  children,
+  className,
+  inline,
+  margin,
+  padding,
+  testId,
+}: UiSpacingProps) => {
   const themeContext = React.useContext(ThemeContext);
 
   return (
@@ -76,6 +83,7 @@ export const UiSpacing: React.FC<UiSpacingProps> = ({ children, inline, margin, 
       $selectedTheme={themeContext.selectedTheme}
       $margin={margin}
       $padding={padding}
+      className={className}
       data-testid={testId}
     >
       {children}

--- a/packages/icons/src/ui-icon.tsx
+++ b/packages/icons/src/ui-icon.tsx
@@ -25,7 +25,9 @@ const Span = styled.span<privateIconProps>`
         props.$inverseColoration
       )
     )}
-    ${props.$size ? `font-size: ${getTextSizeFromSizeString(props.$customTheme, props.$size)};` : ''}
+    ${`font-size: ${getTextSizeFromSizeString(props.$customTheme, props.$size || 'regular')};`}
+    ${`line-height: ${getTextSizeFromSizeString(props.$customTheme, props.$size || 'regular')};`}
+    ${`height: ${getTextSizeFromSizeString(props.$customTheme, props.$size || 'regular')};`}
     ${props.$size ? `width: ${getTextSizeFromSizeString(props.$customTheme, props.$size)};` : ''}
     ${props.$size ? `height: ${getTextSizeFromSizeString(props.$customTheme, props.$size)};` : ''}
   `}

--- a/packages/table/src/ui-table.tsx
+++ b/packages/table/src/ui-table.tsx
@@ -1,6 +1,6 @@
 import React, { FormEvent, useCallback, useEffect, useState } from 'react';
 
-import { ColorCategory, ThemeContext, UiReactElementProps, UiSpacing, UiSpacingProps } from '@uireact/foundation';
+import { ColorCategory, ThemeContext, UiReactElementProps } from '@uireact/foundation';
 import { UiInput } from '@uireact/form';
 import { UiIcon } from '@uireact/icons';
 import { UiGrid, UiGridItem } from '@uireact/grid';
@@ -22,8 +22,6 @@ export type UiTableProps = {
   /** onClick CB to be executed when a row is selected */
   onClick?: (id: string) => void;
 } & UiReactElementProps;
-
-const iconSpacing: UiSpacingProps['margin'] = { top: 'two', left: 'four' };
 
 export const UiTable: React.FC<UiTableProps> = ({
   className,
@@ -69,15 +67,7 @@ export const UiTable: React.FC<UiTableProps> = ({
       {withFilter && (
         <UiGrid cols={{ small: 1, medium: 2, large: 3, xlarge: 3 }}>
           <UiGridItem cols={!filterBoxPosition ? 3 : 1} startingCol={filterBoxPosition === 'right' ? 3 : 1}>
-            <UiInput
-              value={filterPhrase}
-              onChange={onFilter}
-              icon={
-                <UiSpacing margin={iconSpacing}>
-                  <UiIcon icon="Search" />
-                </UiSpacing>
-              }
-            />
+            <UiInput value={filterPhrase} onChange={onFilter} icon={<UiIcon icon="Search" />} />
           </UiGridItem>
         </UiGrid>
       )}

--- a/packages/text/src/types/ui-link-props.ts
+++ b/packages/text/src/types/ui-link-props.ts
@@ -23,7 +23,7 @@ export type privateLinkProps = {
   /* Represents the theme to use for the link, default PRIMARY */
   $theme?: ColorCategory;
   /** Link size, default REGULAR */
-  $size?: SizesProp;
+  $size: SizesProp;
   /** If link should take the whole link, useful for rendering links as Navbar items */
   $fullWidth?: boolean;
   /** Font style */

--- a/packages/text/src/ui-heading.tsx
+++ b/packages/text/src/ui-heading.tsx
@@ -22,6 +22,7 @@ const H1 = styled.h1<privateHeadingProps>`
       getDynamicHeadingMapper(props.$selectedTheme, props.$inverseColoration)
     )}
   ${(props) => `font-size: ${getHeadingSize(props.$customTheme, props.$level)};`}
+  ${(props) => `line-height: ${getHeadingSize(props.$customTheme, props.$level)};`}
   ${(props) => `
     ${props.$centered ? `text-align: center;` : ``}
     ${
@@ -44,6 +45,7 @@ const H2 = styled.h2<privateHeadingProps>`
       getDynamicHeadingMapper(props.$selectedTheme, props.$inverseColoration)
     )}
   ${(props) => `font-size: ${getHeadingSize(props.$customTheme, props.$level)};`}
+  ${(props) => `line-height: ${getHeadingSize(props.$customTheme, props.$level)};`}
   ${(props) => `
     ${props.$centered ? `text-align: center;` : ``}
         ${
@@ -66,6 +68,7 @@ const H3 = styled.h3<privateHeadingProps>`
       getDynamicHeadingMapper(props.$selectedTheme, props.$inverseColoration)
     )}
   ${(props) => `font-size: ${getHeadingSize(props.$customTheme, props.$level)};`}
+  ${(props) => `line-height: ${getHeadingSize(props.$customTheme, props.$level)};`}
   ${(props) => `
     ${props.$centered ? `text-align: center;` : ``}
         ${
@@ -88,6 +91,7 @@ const H4 = styled.h4<privateHeadingProps>`
       getDynamicHeadingMapper(props.$selectedTheme, props.$inverseColoration)
     )}
   ${(props) => `font-size: ${getHeadingSize(props.$customTheme, props.$level)};`}
+  ${(props) => `line-height: ${getHeadingSize(props.$customTheme, props.$level)};`}
   ${(props) => `
     ${props.$centered ? `text-align: center;` : ``}
         ${
@@ -110,6 +114,7 @@ const H5 = styled.h5<privateHeadingProps>`
       getDynamicHeadingMapper(props.$selectedTheme, props.$inverseColoration)
     )}
   ${(props) => `font-size: ${getHeadingSize(props.$customTheme, props.$level)};`}
+  ${(props) => `line-height: ${getHeadingSize(props.$customTheme, props.$level)};`}
   ${(props) => `
     ${props.$centered ? `text-align: center;` : ``}
         ${
@@ -132,6 +137,7 @@ const H6 = styled.h6<privateHeadingProps>`
       getDynamicHeadingMapper(props.$selectedTheme, props.$inverseColoration)
     )}
   ${(props) => `font-size: ${getHeadingSize(props.$customTheme, props.$level)};`}
+  ${(props) => `line-height: ${getHeadingSize(props.$customTheme, props.$level)};`}
   ${(props) => `
     ${props.$centered ? `text-align: center;` : ``}
         ${

--- a/packages/text/src/ui-label.tsx
+++ b/packages/text/src/ui-label.tsx
@@ -21,6 +21,7 @@ const Label = styled.label<privateLabelProps>`
       props.$category ? getLabelDynamicMapper(getColorCategory(props.$category)) : LabelMapper
     )}
     ${`font-size: ${getTextSizeFromSizeString(props.$customTheme, props.$size)};`}
+    ${`line-height: ${getTextSizeFromSizeString(props.$customTheme, props.$size)};`}
   `}
 
   padding: 0;

--- a/packages/text/src/ui-link.tsx
+++ b/packages/text/src/ui-link.tsx
@@ -15,7 +15,7 @@ const AnchorWrapper = styled.span<privateLinkProps>`
         props.$selectedTheme,
         getDynamicLinkMapper(getColorCategory(props.$category))
       )}
-      font-size: ${getTextSizeFromSizeString(props.$customTheme, props.$size || 'regular')};
+      font-size: ${getTextSizeFromSizeString(props.$customTheme, props.$size)};
       ${props.$fullWidth ? 'width: 100%; display: inline-block;' : ''}
       ${props.$fontStyle === 'italic' ? `font-style: ${props.$fontStyle};` : ''}
       ${props.$fontStyle === 'bold' ? `font-weight: bold;` : ''}
@@ -37,7 +37,7 @@ export const UiLink: React.FC<UiLinkProps> = ({
   className,
   fullWidth,
   fontStyle,
-  size,
+  size = 'regular',
   testId,
   wrap,
 }: UiLinkProps) => {

--- a/packages/text/src/ui-text.tsx
+++ b/packages/text/src/ui-text.tsx
@@ -17,8 +17,8 @@ const SharedStyle = css<privateTextProps>`
   ${(props) => `
     ${props.$centered ? `text-align: center;` : ``}
     ${props.$align ? `text-align: ${props.$align};` : ``}
-    ${`font-size: ${getTextSizeFromSizeString(props.$customTheme, props.$size || 'regular')};`}
-    ${`line-height: ${getTextSizeFromSizeString(props.$customTheme, props.$size || 'regular')};`}
+    ${`font-size: ${getTextSizeFromSizeString(props.$customTheme, props.$size)};`}
+    ${`line-height: ${getTextSizeFromSizeString(props.$customTheme, props.$size)};`}
     ${props.$fontStyle === 'italic' ? `font-style: ${props.$fontStyle};` : ''}
     ${props.$fontStyle === 'bold' ? `font-weight: bold;` : ''}
     ${props.$fontStyle === 'light' ? `font-weight: 300;` : ''}

--- a/packages/text/src/ui-text.tsx
+++ b/packages/text/src/ui-text.tsx
@@ -17,7 +17,8 @@ const SharedStyle = css<privateTextProps>`
   ${(props) => `
     ${props.$centered ? `text-align: center;` : ``}
     ${props.$align ? `text-align: ${props.$align};` : ``}
-    ${`font-size: ${getTextSizeFromSizeString(props.$customTheme, props.$size)};`}
+    ${`font-size: ${getTextSizeFromSizeString(props.$customTheme, props.$size || 'regular')};`}
+    ${`line-height: ${getTextSizeFromSizeString(props.$customTheme, props.$size || 'regular')};`}
     ${props.$fontStyle === 'italic' ? `font-style: ${props.$fontStyle};` : ''}
     ${props.$fontStyle === 'bold' ? `font-weight: bold;` : ''}
     ${props.$fontStyle === 'light' ? `font-weight: 300;` : ''}

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -24,7 +24,8 @@
     "watch": "npm run tsc:watch"
   },
   "devDependencies": {
-    "@uireact/foundation": "^1.4.2"
+    "@uireact/foundation": "^1.4.2",
+    "@uireact/text": "^1.11.2"
   },
   "peerDependencies": {
     "@uireact/foundation": "^1.0.1",


### PR DESCRIPTION
## 🔥 Using correct line height for typography elements
----------------------------------------------

### Description
The line height was not being set and therefore the text elements were taking some weird height, this was impacting icons rendered inside input fields as the positioning was being chaotic, with this is as simple as just centering a flex element.

### Screenshots

#### Before
<img width="649" alt="Screenshot 2023-09-12 at 4 26 49 PM" src="https://github.com/inavac182/uireact/assets/16787893/78340813-ed0a-4386-a799-723fe90fc495">

#### After
<img width="547" alt="Screenshot 2023-09-12 at 4 27 06 PM" src="https://github.com/inavac182/uireact/assets/16787893/29b0884a-8976-4465-bf84-5a5f17e7584d">
