### PR TITLE
feat(navbar): adding gap prop

### DIFF
--- a/packages/charts/src/ui-linear-chart.tsx
+++ b/packages/charts/src/ui-linear-chart.tsx
@@ -13,7 +13,7 @@ export type UiLinearChartProps = {
 } & UiReactElementProps;
 
 const CurrentLabelWrapper = styled.div<{ $current: number }>`
-  padding-top: ${(props) => (props.$current > 0 ? '2px' : '8px')};
+  padding-top: ${(props) => (props.$current > 0 ? '5px' : '8px')};
 `;
 
 export const UiLinearChart: React.FC<UiLinearChartProps> = ({ className, testId, data }: UiLinearChartProps) => (

--- a/packages/navbar/__tests__/navbar.spec.tsx
+++ b/packages/navbar/__tests__/navbar.spec.tsx
@@ -4,6 +4,8 @@ import { render, screen } from '@testing-library/react';
 
 import { UiNavbar, UiNavbarItem } from '../src';
 
+import 'jest-styled-components';
+
 describe('<UiNavbar />', () => {
   it('Should render navbar', () => {
     render(
@@ -186,5 +188,18 @@ describe('<UiNavbar />', () => {
     expect(screen.queryByText('Option 1')).not.toBeInTheDocument();
     expect(screen.getByText('Option 2')).toBeVisible();
     expect(screen.getByText('Option 3')).toBeVisible();
+  });
+
+  it('Should render navbar with gap', () => {
+    render(
+      <UiNavbar gap="five" testId="UiNavbar">
+        <UiNavbarItem>Option 1</UiNavbarItem>
+        <UiNavbarItem>Option 2</UiNavbarItem>
+      </UiNavbar>
+    );
+
+    expect(screen.getByText('Option 1')).toBeVisible();
+    expect(screen.getByText('Option 2')).toBeVisible();
+    expect(screen.getByTestId('UiNavbar')).toHaveStyleRule('gap', 'var(--spacing-five)');
   });
 });

--- a/packages/navbar/docs/navbar.mdx
+++ b/packages/navbar/docs/navbar.mdx
@@ -91,10 +91,10 @@ import * as packageJson from '../package.json';
   </UiNavbar>
 </Playground>
 
-## With bordered styling
+## With bordered styling and gap
 
 <Playground>
-  <UiNavbar orientation="stacked" align="start" styling="bordered">
+  <UiNavbar orientation="stacked" align="start" styling="bordered" gap="five" category="tertiary">
     <UiNavbarItem active>
       <UiText>Option 1</UiText>
     </UiNavbarItem>

--- a/packages/navbar/src/navbar.tsx
+++ b/packages/navbar/src/navbar.tsx
@@ -17,6 +17,7 @@ const NavbarWrapper = styled.div<privateNavbarProps>`
     return `
       flex-direction: ${props.$orientation === 'stacked' ? 'column' : 'row'};
       ${getFlexAlignment(props.$align, props.$orientation)}
+      ${props.$gap ? `gap: var(--spacing-${props.$gap});` : ''}
     `;
   }}
 `;
@@ -27,6 +28,7 @@ export const UiNavbar: React.FC<UiNavbarProps> = ({
   children,
   className,
   orientation = 'inline',
+  gap,
   roundedCorners,
   stretchItems,
   styling,
@@ -58,7 +60,7 @@ export const UiNavbar: React.FC<UiNavbarProps> = ({
   }, [children]);
 
   return (
-    <NavbarWrapper $align={align} className={className} $orientation={orientation} data-testid={testId}>
+    <NavbarWrapper $align={align} className={className} $orientation={orientation} data-testid={testId} $gap={gap}>
       <>{NavbarContent}</>
     </NavbarWrapper>
   );

--- a/packages/navbar/src/types/navbar-props.ts
+++ b/packages/navbar/src/types/navbar-props.ts
@@ -1,4 +1,4 @@
-import { ColorCategory, UiReactElementProps } from '@uireact/foundation';
+import { ColorCategory, SpacingType, UiReactElementProps } from '@uireact/foundation';
 
 export type Alignment = 'start' | 'center' | 'end';
 
@@ -14,6 +14,8 @@ export type UiNavbarProps = {
   category?: ColorCategory;
   /** Navbar alignment */
   align?: Alignment;
+  /** Gap between navbar items */
+  gap?: SpacingType;
   /** If top and bottom item render rounded corners, useful for rendering navbar inside cards */
   roundedCorners?: boolean;
   /** If items should be stretched, useful when navbar is rendered to cover whole width */
@@ -29,6 +31,7 @@ export type privateNavbarProps = {
   /** If top and bottom item render rounded corners, useful for rendering navbar inside cards */
   $roundedCorners?: boolean;
   /** If items should be stretched, useful when navbar is rendered to cover whole width */
+  $gap?: SpacingType;
   $stretchItems?: boolean;
   $orientation: Orientation;
   $align: Alignment;


### PR DESCRIPTION
## 🔥 Adding a gap prop to navbar
----------------------------------------------

### Description
The navbar items render very close, so there is a need for a gap prop. 
Bonus feature, re-aligned the label in linear chart.

### Screenshots

#### Before
<img width="704" alt="Screenshot 2023-09-18 at 4 38 28 PM" src="https://github.com/inavac182/uireact/assets/16787893/bb40b182-3757-4cd8-9791-a3864824a3eb">

#### After
<img width="485" alt="Screenshot 2023-09-18 at 4 38 13 PM" src="https://github.com/inavac182/uireact/assets/16787893/6cd1d785-cdf9-473e-af68-a99709100dd2">

