### PR TITLE
fix: centering top and bottom tooltip

### DIFF
--- a/packages/tooltip/src/ui-tooltip.tsx
+++ b/packages/tooltip/src/ui-tooltip.tsx
@@ -35,6 +35,8 @@ const ToolbarDiv = styled.div<privateTooltipProps>`
     if (props.$position === 'bottom') {
       return `
         bottom: calc(40px * -1);
+        left: 50%;
+        transform: translateX(-50%);
 
         &::before {
           bottom: 100%;
@@ -77,6 +79,8 @@ const ToolbarDiv = styled.div<privateTooltipProps>`
 
     return `
         top: calc(40px * -1);
+        left: 50%;
+        transform: translateX(-50%);
 
         &::before {
           top: 100%;


### PR DESCRIPTION
## 🔥 Centering top and bottom tooltip
----------------------------------------------

### Description
Fixing an issue with the centering of top and bottom tooltips.

### Screenshots

#### Before
<img width="156" alt="Screenshot 2023-11-06 at 8 43 33 PM" src="https://github.com/inavac182/uireact/assets/16787893/33af710b-bd59-4ca4-af06-0ab7eedbf6b0">

#### After
<img width="122" alt="Screenshot 2023-11-06 at 8 43 14 PM" src="https://github.com/inavac182/uireact/assets/16787893/b7f27c50-8f02-4151-b844-bed1a78cccb9">
