### PR TITLE
feat: use client notation

### DIFF
--- a/packages/badge/src/ui-badge.tsx
+++ b/packages/badge/src/ui-badge.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import styled from 'styled-components';

--- a/packages/button/src/ui-button.tsx
+++ b/packages/button/src/ui-button.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 import styled from 'styled-components';

--- a/packages/card/src/card.tsx
+++ b/packages/card/src/card.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 import { ColorCategory, ColorToken, UiReactElementProps } from '@uireact/foundation';

--- a/packages/charts/src/ui-linear-chart.tsx
+++ b/packages/charts/src/ui-linear-chart.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 import { styled } from 'styled-components';
 

--- a/packages/dialog/src/__private/dialog-wrapper.tsx
+++ b/packages/dialog/src/__private/dialog-wrapper.tsx
@@ -3,6 +3,7 @@ import React from 'react';
 import styled from 'styled-components';
 
 type DialogWrapperProps = {
+  className?: string;
   children?: React.ReactElement;
 };
 

--- a/packages/dialog/src/ui-dialog.tsx
+++ b/packages/dialog/src/ui-dialog.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import styled from 'styled-components';
@@ -20,6 +21,8 @@ const Button = styled.button`
 
 export const UiDialog: React.FC<UiDialogProps> = ({
   closeLabel,
+  className,
+  testId,
   children,
   dialogId,
   handleDialogClose,
@@ -57,7 +60,7 @@ export const UiDialog: React.FC<UiDialogProps> = ({
 
   if (type !== UiDialogType.CENTERED) {
     return (
-      <DialogContent $type={type}>
+      <DialogContent $type={type} className={className} data-testId={testId}>
         {title && (
           <DialogToolbar title={title} hideCloseIcon={hideCloseIcon} closeCB={closeCB} closeLabel={closeLabel} />
         )}
@@ -72,7 +75,7 @@ export const UiDialog: React.FC<UiDialogProps> = ({
   }
 
   return (
-    <DialogWrapper>
+    <DialogWrapper className={className} data-testId={testId}>
       <>
         <DialogBackground onClick={closeCB} />
         <DialogContent $type={type}>

--- a/packages/flex/src/ui-flex-grid-item.tsx
+++ b/packages/flex/src/ui-flex-grid-item.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import styled from 'styled-components';

--- a/packages/flex/src/ui-flex-grid.tsx
+++ b/packages/flex/src/ui-flex-grid.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import styled from 'styled-components';

--- a/packages/form/src/ui-input.tsx
+++ b/packages/form/src/ui-input.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import styled from 'styled-components';

--- a/packages/form/src/ui-select.tsx
+++ b/packages/form/src/ui-select.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, { FormEvent, useCallback } from 'react';
 
 import styled from 'styled-components';
@@ -42,6 +43,8 @@ const SelectDiv = styled.div`
 
 export const UiSelect: React.FC<UiSelectProps> = ({
   children,
+  className,
+  testId,
   disabled,
   error,
   label,
@@ -61,7 +64,7 @@ export const UiSelect: React.FC<UiSelectProps> = ({
   );
 
   return (
-    <div>
+    <div className={className} data-testid={testId}>
       {label && labelOnTop && (
         <div>
           <UiLabel htmlFor={name} category={category}>

--- a/packages/form/src/ui-switch.tsx
+++ b/packages/form/src/ui-switch.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import styled from 'styled-components';
@@ -83,13 +84,15 @@ export const UiSwitch: React.FC<UiSwitchProps> = ({
   checked,
   disabled,
   label,
+  className,
+  testId,
   labelPosition = 'END',
   name,
   ref,
   category,
   onChange,
 }: UiSwitchProps) => (
-  <Div>
+  <Div className={className} data-testid={testId}>
     <CheckboxInput
       checked={checked}
       disabled={disabled}

--- a/packages/form/src/ui-textarea.tsx
+++ b/packages/form/src/ui-textarea.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import styled from 'styled-components';
@@ -50,6 +51,8 @@ export const UiTextArea: React.FC<UiTextAreaProps> = ({
   label,
   labelOnTop,
   maxlength,
+  className,
+  testId,
   name = 'textarea-name',
   placeholder,
   resize,
@@ -60,7 +63,7 @@ export const UiTextArea: React.FC<UiTextAreaProps> = ({
   onChange,
   required,
 }: UiTextAreaProps) => (
-  <>
+  <div className={className} data-testid={testId}>
     {label && labelOnTop && (
       <div>
         <UiLabel htmlFor={name} category={category}>
@@ -95,7 +98,7 @@ export const UiTextArea: React.FC<UiTextAreaProps> = ({
         {error && <UiText category={category}>{error}</UiText>}
       </InputDiv>
     </WrapperDiv>
-  </>
+  </div>
 );
 
 UiTextArea.displayName = 'UiTextArea';

--- a/packages/foundation/src/spacing/spacing.tsx
+++ b/packages/foundation/src/spacing/spacing.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 import styled from 'styled-components';

--- a/packages/grid/src/grid-item.tsx
+++ b/packages/grid/src/grid-item.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 import styled from 'styled-components';
 

--- a/packages/grid/src/grid.tsx
+++ b/packages/grid/src/grid.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, { useEffect, useState } from 'react';
 
 import styled from 'styled-components';

--- a/packages/header/src/ui-header.tsx
+++ b/packages/header/src/ui-header.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import styled from 'styled-components';

--- a/packages/icons/src/ui-icon.tsx
+++ b/packages/icons/src/ui-icon.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import styled from 'styled-components';

--- a/packages/list/src/ui-list-item.tsx
+++ b/packages/list/src/ui-list-item.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import styled from 'styled-components';

--- a/packages/list/src/ui-list.tsx
+++ b/packages/list/src/ui-list.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import styled from 'styled-components';

--- a/packages/menu/src/ui-menu.tsx
+++ b/packages/menu/src/ui-menu.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import styled from 'styled-components';
@@ -97,7 +98,7 @@ export const UiMenu: React.FC<UiMenuProps> = ({
 
   if (fullscreenOnSmall) {
     return (
-      <>
+      <div>
         <UiViewport criteria={Breakpoints.SMALL}>
           <UiDialog
             closeLabel={closeLabel}
@@ -114,17 +115,17 @@ export const UiMenu: React.FC<UiMenuProps> = ({
             {children}
           </MenuDiv>
         </UiViewport>
-      </>
+      </div>
     );
   }
 
   return (
-    <>
+    <div>
       <WrapperDiv onClick={closeMenuCB}></WrapperDiv>
       <MenuDiv $visible={visible} role="menu" ref={menuRef} $isOffset={isOffset} data-testid={testId}>
         {children}
       </MenuDiv>
-    </>
+    </div>
   );
 };
 

--- a/packages/navbar/src/navbar-item.tsx
+++ b/packages/navbar/src/navbar-item.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import { UiNavbarItemProps } from './types';

--- a/packages/navbar/src/navbar.tsx
+++ b/packages/navbar/src/navbar.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import styled from 'styled-components';

--- a/packages/progress-indicator/src/ui-progress-indicator-item.tsx
+++ b/packages/progress-indicator/src/ui-progress-indicator-item.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import { UiProgressIndicatorItemProps } from './types';

--- a/packages/progress-indicator/src/ui-progress-indicator.tsx
+++ b/packages/progress-indicator/src/ui-progress-indicator.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import styled from 'styled-components';

--- a/packages/separator/src/ui-bubbles-separator.tsx
+++ b/packages/separator/src/ui-bubbles-separator.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import styled from 'styled-components';

--- a/packages/separator/src/ui-diagonal-separator.tsx
+++ b/packages/separator/src/ui-diagonal-separator.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import styled from 'styled-components';

--- a/packages/separator/src/ui-line-separator.tsx
+++ b/packages/separator/src/ui-line-separator.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import { UiReactElementProps } from '@uireact/foundation';

--- a/packages/table/src/ui-table.tsx
+++ b/packages/table/src/ui-table.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, { FormEvent, useCallback, useEffect, useState } from 'react';
 
 import { ColorCategory, UiReactElementProps } from '@uireact/foundation';

--- a/packages/tabs/src/ui-tab-item.tsx
+++ b/packages/tabs/src/ui-tab-item.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import styled from 'styled-components';

--- a/packages/tabs/src/ui-tabs.tsx
+++ b/packages/tabs/src/ui-tabs.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import styled from 'styled-components';

--- a/packages/text/src/ui-heading.tsx
+++ b/packages/text/src/ui-heading.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import styled, { css } from 'styled-components';

--- a/packages/text/src/ui-label.tsx
+++ b/packages/text/src/ui-label.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import styled from 'styled-components';

--- a/packages/text/src/ui-link.tsx
+++ b/packages/text/src/ui-link.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import styled from 'styled-components';

--- a/packages/text/src/ui-text.tsx
+++ b/packages/text/src/ui-text.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import styled, { css } from 'styled-components';

--- a/packages/tooltip/src/ui-tooltip.tsx
+++ b/packages/tooltip/src/ui-tooltip.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, { useCallback, useState } from 'react';
 import { styled } from 'styled-components';
 

--- a/packages/view/src/ui-view-row.tsx
+++ b/packages/view/src/ui-view-row.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React from 'react';
 
 import styled from 'styled-components';

--- a/packages/view/src/ui-view.tsx
+++ b/packages/view/src/ui-view.tsx
@@ -1,3 +1,4 @@
+'use client';
 import React, { useEffect } from 'react';
 
 import styled, { createGlobalStyle } from 'styled-components';


### PR DESCRIPTION
## 🔥 Adding use client notation
----------------------------------------------

### Description
As this library uses styled components, I'm adding the `use client` notation at the top so when rendering in next JS projects the components render fine and there is no need for use client on client apps.

### Screenshots

N/A
