### PR TITLE
feat: adding dialog on small prop and isOpen prop

### DIFF
--- a/packages/datepicker/__tests__/ui-datepicker.spec.tsx
+++ b/packages/datepicker/__tests__/ui-datepicker.spec.tsx
@@ -10,9 +10,11 @@ describe('<UiDatepicker />', () => {
   const date = new Date(2028, 1, 0);
 
   it('renders fine', () => {
-    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} />);
+    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} isOpen />);
 
     expect(screen.getByText('January 2028')).toBeVisible();
+    expect(screen.getByRole('menu')).toBeVisible();
+
     expect(screen.getByText('Sun')).toBeVisible();
     expect(screen.getByText('Mon')).toBeVisible();
     expect(screen.getByText('Tue')).toBeVisible();
@@ -22,7 +24,7 @@ describe('<UiDatepicker />', () => {
   });
 
   it('renders fine with highlight', () => {
-    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} highlightToday />);
+    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} highlightToday isOpen />);
 
     expect(screen.getByText('January 2028')).toBeVisible();
     expect(screen.getByText('Sun')).toBeVisible();
@@ -32,13 +34,15 @@ describe('<UiDatepicker />', () => {
   });
 
   it('renders fine with simple month', () => {
-    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} monthTitlesFormat="simple" />);
+    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} monthTitlesFormat="simple" isOpen />);
 
     expect(screen.getByText('Jan 2028')).toBeVisible();
   });
 
   it('renders fine with complete dates', () => {
-    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} dayTitlesFormat="complete" testId="date-picker-id" />);
+    uiRender(
+      <UiDatepicker date={date} onSelectDate={jest.fn()} dayTitlesFormat="complete" testId="date-picker-id" isOpen />
+    );
 
     expect(screen.getByText('Sunday')).toBeVisible();
     expect(screen.getByText('Monday')).toBeVisible();
@@ -53,7 +57,7 @@ describe('<UiDatepicker />', () => {
   });
 
   it('renders previous month when previous month is in previous year', () => {
-    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} />);
+    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} isOpen />);
 
     expect(screen.getByText('January 2028')).toBeVisible();
 
@@ -65,7 +69,7 @@ describe('<UiDatepicker />', () => {
     // December 2028
     const date = new Date(2028, 12, 0);
 
-    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} />);
+    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} isOpen />);
 
     expect(screen.getByText('December 2028')).toBeVisible();
 
@@ -77,7 +81,7 @@ describe('<UiDatepicker />', () => {
     // December 2028
     const date = new Date(2028, 12, 0);
 
-    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} />);
+    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} isOpen />);
 
     expect(screen.getByText('December 2028')).toBeVisible();
 
@@ -89,7 +93,7 @@ describe('<UiDatepicker />', () => {
     // September 2028
     const date = new Date(2028, 8, 1);
 
-    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} />);
+    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} isOpen />);
 
     expect(screen.getByText('September 2028')).toBeVisible();
 
@@ -100,7 +104,7 @@ describe('<UiDatepicker />', () => {
 
   it('gets selected date', () => {
     const onSelectedDate = jest.fn();
-    uiRender(<UiDatepicker date={date} onSelectDate={onSelectedDate} />);
+    uiRender(<UiDatepicker date={date} onSelectDate={onSelectedDate} isOpen />);
 
     expect(screen.getByText('January 2028')).toBeVisible();
 
@@ -114,7 +118,9 @@ describe('<UiDatepicker />', () => {
     const onSelectedDate = jest.fn();
     const onCloseCb = jest.fn();
 
-    uiRender(<UiDatepicker date={date} onSelectDate={onSelectedDate} onClose={onCloseCb} testId="date-picker-id" />);
+    uiRender(
+      <UiDatepicker date={date} onSelectDate={onSelectedDate} onClose={onCloseCb} testId="date-picker-id" isOpen />
+    );
 
     expect(screen.getByText('January 2028')).toBeVisible();
 
@@ -127,7 +133,7 @@ describe('<UiDatepicker />', () => {
   it('renders fine with 2 months', () => {
     // January 2028
     const date = new Date(2028, 1, 0);
-    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} showNextMonth />);
+    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} showNextMonth isOpen />);
 
     expect(screen.getByText('January 2028')).toBeVisible();
 
@@ -156,7 +162,7 @@ describe('<UiDatepicker />', () => {
   it('renders fine with 2 months when initial month is eoy', () => {
     // January 2028
     const date = new Date(2028, 11, 31);
-    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} showNextMonth />);
+    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} showNextMonth isOpen />);
 
     expect(screen.getByText('December 2028')).toBeVisible();
 
@@ -176,7 +182,7 @@ describe('<UiDatepicker />', () => {
   it('Navigates correctly to next month when showing 2 months', () => {
     // November 2028
     const date = new Date(2028, 10, 30);
-    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} showNextMonth />);
+    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} showNextMonth isOpen />);
 
     expect(screen.getByText('November 2028')).toBeVisible();
     expect(screen.getByText('December 2028')).toBeVisible();
@@ -190,7 +196,7 @@ describe('<UiDatepicker />', () => {
   it('Navigates correctly to previous month when showing 2 months', () => {
     // December 2028
     const date = new Date(2028, 11, 31);
-    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} showNextMonth />);
+    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} showNextMonth isOpen />);
 
     expect(screen.getByText('December 2028')).toBeVisible();
     expect(screen.getByText('January 2029')).toBeVisible();
@@ -199,5 +205,27 @@ describe('<UiDatepicker />', () => {
 
     expect(screen.getByText('November 2028')).toBeVisible();
     expect(screen.getByText('December 2028')).toBeVisible();
+  });
+
+  it('Renders on dialog when useDialogOnSmall is passed and breakpoint is small', () => {
+    global.innerWidth = 400;
+
+    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} isOpen useDialogOnSmall showNextMonth />);
+
+    expect(screen.getByRole('dialog')).toBeVisible();
+  });
+
+  it('Renders on menu when useDialogOnSmall is passed but breakpoint is not small', () => {
+    global.innerWidth = 800;
+
+    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} isOpen useDialogOnSmall showNextMonth />);
+
+    expect(screen.getByRole('menu')).toBeVisible();
+  });
+
+  it('Datepicker is closed in isOpen is not present', () => {
+    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} />);
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
   });
 });

--- a/packages/datepicker/docs/docs.mdx
+++ b/packages/datepicker/docs/docs.mdx
@@ -9,6 +9,11 @@ import * as packageJson from '../package.json';
 import Playground from '../../../src/Playground';
 
 import { UiDatepicker } from '../src';
+import { DatePickerExample } from './example';
+
+import { UiBadge } from '@uireact/badge';
+
+<UiBadge category="warning">❗️ Beta</UiBadge>
 
 # UiDatepicker
 
@@ -34,6 +39,7 @@ import { UiDatepicker } from '../src';
       onSelectDate={(date) => {
         console.log(date);
       }}
+      isOpen
     />
   </div>
 </Playground>
@@ -49,9 +55,93 @@ import { UiDatepicker } from '../src';
       onSelectDate={(date) => {
         console.log(date);
       }}
+      isOpen
     />
   </div>
 </Playground>
+
+## Datepicker real example
+
+<Playground>
+  <DatePickerExample />
+</Playground>
+
+<br />
+
+This example uses these 2 props to change the behavior of the date picker in small screens:
+
+<ol>
+  <li>`useDialogOnSmall` - When screen is small the datepicker will be opened in a dialog.</li>
+
+{' '}
+<li>
+  As there the visibility is now in a state, we can show and hide the datepicker to our convenience.
+  <ul>
+    <li> The Datepicker will be closed if user presses ESC key. </li>
+    <li> The Datepicker will be closed if the user clicks outside the datepicker. </li>
+    <li> Inside the Dialog if the user clicks on the `Close` button then it will trigger the `onClose` CB. </li>
+  </ul>
+</li>
+
+  <li> 3. The `closeLabel` prop is passing the label used inside the dialog in the close button. </li>
+</ol>
+
+<br />
+
+The callback `onClose` is optional as there might be a use case where you would like to close the datepicker when the `onSelectDate` callback
+is triggered, depends on the use case you might rely on the selection or on the close callback. In this example we are using the
+onClose CB to close the datepicker.
+
+<br />
+
+DatePickerExample:
+
+```tsx
+export const DatePickerExample: React.FC = () => {
+  const [dateSelected, setDateSelected] = useState<Date | undefined>();
+  const [datepickerVisible, setDatepickerVisible] = useState<boolean>(false);
+
+  const onSelectDate = useCallback(
+    (date) => {
+      setDateSelected(date);
+    },
+    [setDateSelected]
+  );
+
+  const onOpenClick = useCallback(() => {
+    setDatepickerVisible(true);
+  }, [setDatepickerVisible]);
+
+  const onClose = useCallback(() => {
+    setDatepickerVisible(false);
+  }, [setDatepickerVisible]);
+
+  return (
+    <div>
+      <UiButton onClick={onOpenClick} category="tertiary">
+        <UiSpacing padding={buttonSpacing}>Open date picker</UiSpacing>
+      </UiButton>
+      <UiDatepicker
+        date={today}
+        onSelectDate={onSelectDate}
+        highlightToday
+        isOpen={datepickerVisible}
+        onClose={onClose}
+        useDialogOnSmall
+        showNextMonth
+        closeLabel="Accept"
+      />
+      {dateSelected && (
+        <UiSpacing padding={textSpacing}>
+          <UiText>
+            Date selected: {`${dateSelected.getFullYear()}/${dateSelected.getMonth() + 1}/${dateSelected.getDate()}`}
+          </UiText>
+        </UiSpacing>
+      )}
+    </div>
+  );
+};
+```
 
 ### Props
 

--- a/packages/datepicker/docs/example/datepicker-example.tsx
+++ b/packages/datepicker/docs/example/datepicker-example.tsx
@@ -1,0 +1,56 @@
+import React, { useCallback, useState } from 'react';
+
+import { UiButton } from '@uireact/button';
+import { UiText } from '@uireact/text';
+
+import { UiDatepicker } from '../../src';
+import { UiSpacing, UiSpacingProps } from '@uireact/foundation';
+
+const today = new Date();
+const buttonSpacing: UiSpacingProps['padding'] = { all: 'four' };
+const textSpacing: UiSpacingProps['padding'] = { block: 'four' };
+
+export const DatePickerExample: React.FC = () => {
+  const [dateSelected, setDateSelected] = useState<Date | undefined>();
+  const [datepickerVisible, setDatepickerVisible] = useState<boolean>(false);
+
+  const onSelectDate = useCallback(
+    (date) => {
+      setDateSelected(date);
+    },
+    [setDateSelected]
+  );
+
+  const onOpenClick = useCallback(() => {
+    setDatepickerVisible(true);
+  }, [setDatepickerVisible]);
+
+  const onClose = useCallback(() => {
+    setDatepickerVisible(false);
+  }, [setDatepickerVisible]);
+
+  return (
+    <div>
+      <UiButton onClick={onOpenClick} category="tertiary">
+        <UiSpacing padding={buttonSpacing}>Open date picker</UiSpacing>
+      </UiButton>
+      <UiDatepicker
+        date={today}
+        onSelectDate={onSelectDate}
+        highlightToday
+        isOpen={datepickerVisible}
+        onClose={onClose}
+        useDialogOnSmall
+        showNextMonth
+        closeLabel="Accept"
+      />
+      {dateSelected && (
+        <UiSpacing padding={textSpacing}>
+          <UiText>
+            Date selected: {`${dateSelected.getFullYear()}/${dateSelected.getMonth() + 1}/${dateSelected.getDate()}`}
+          </UiText>
+        </UiSpacing>
+      )}
+    </div>
+  );
+};

--- a/packages/datepicker/docs/example/index.ts
+++ b/packages/datepicker/docs/example/index.ts
@@ -1,0 +1,1 @@
+export * from './datepicker-example';

--- a/packages/datepicker/src/private/picker-month.tsx
+++ b/packages/datepicker/src/private/picker-month.tsx
@@ -1,10 +1,10 @@
 import React from 'react';
+import styled from 'styled-components';
 
 import { getDaysInMonth, getStartingDayOfTheWeek, getDaysByWeek } from '../utils';
 import { DateTitleFormats } from '../types';
 import { WeekTitle } from './week-title';
 import { PickerWeek } from './picker-week';
-import styled from 'styled-components';
 
 const Div = styled.div`
   padding: 5px;

--- a/packages/datepicker/src/private/picker-week.tsx
+++ b/packages/datepicker/src/private/picker-week.tsx
@@ -22,7 +22,7 @@ const DayWrapperButton = styled.button<{ $highlight?: boolean; $selected: boolea
   border: 0;
   background-color: transparent;
   color: var(--texts-token_100);
-  transition: background-color 0.5s;
+  transition: background-color 0.3s;
 
   ${(props) => `
     ${props.$highlight && !props.$selected ? 'background-color: var(--primary-token_50);' : ''}
@@ -30,7 +30,9 @@ const DayWrapperButton = styled.button<{ $highlight?: boolean; $selected: boolea
   `}
 
   &:hover {
-    background-color: var(--primary-token_10);
+    ${(props) => `
+      ${props.$selected ? 'background-color: var(--tertiary-token_200);' : 'background-color: var(--primary-token_10);'}
+    `}
   }
 `;
 

--- a/packages/datepicker/src/types/datepicker-props.ts
+++ b/packages/datepicker/src/types/datepicker-props.ts
@@ -2,11 +2,24 @@ import { UiReactElementProps } from '@uireact/foundation';
 import { DateTitleFormats } from './date-titles';
 
 export type UiDatepickerProps = {
+  /** The main date used to start the datepicker */
   date: Date;
+  /** The format of the day title, e.g. Sunday vs Sun vs S */
   dayTitlesFormat?: DateTitleFormats;
+  /** The format of the month title, e.g. December vs Dec vs D */
   monthTitlesFormat?: DateTitleFormats;
+  /** This adds a highlighted background to todau's day in the datepicker */
   highlightToday?: boolean;
+  /** Callback executed when a date is selected */
   onSelectDate: (selectedDate: Date) => void;
+  /** Callback executed when a closure action is triggered */
   onClose?: () => void;
+  /** Makes the following month from the passed `date` shown in the datepicker */
   showNextMonth?: boolean;
+  /** Makes the datepicker render as fullscreen dialog on small devices */
+  useDialogOnSmall?: boolean;
+  /** If the datepicker is opened */
+  isOpen?: boolean;
+  /** The close label used in the close button when `useDialogOnSmall` is passed and datepicker is opened on small breakpoint */
+  closeLabel?: string;
 } & UiReactElementProps;


### PR DESCRIPTION
## 🔥 Adding dialog on small prop
----------------------------------------------

### Description
On small breakpoints there are use cases were a dialog is better for rendering a datepicker so adding this prop will handle this use case. As part of this I'm also modifying the flex direction for small breakpoints when using 2 months so the datepicker fits in the screen.

### Screenshots

#### Before
<img width="510" alt="Screenshot 2023-11-08 at 11 14 36 PM" src="https://github.com/inavac182/uireact/assets/16787893/5e5d2012-336a-48b0-824c-670480157f81">

#### After
![Nov-08-2023 23-13-48](https://github.com/inavac182/uireact/assets/16787893/00737e9f-c705-4305-9d95-16452e5fb899)

<img width="500" alt="Screenshot 2023-11-08 at 11 14 18 PM" src="https://github.com/inavac182/uireact/assets/16787893/c9ffd591-55b0-44b9-b31a-76675e0ee4db">

