### PR TITLE
feat: disable past dates in datepicker

### DIFF
--- a/packages/datepicker/__tests__/ui-datepicker.spec.tsx
+++ b/packages/datepicker/__tests__/ui-datepicker.spec.tsx
@@ -33,6 +33,22 @@ describe('<UiDatepicker />', () => {
     expect(screen.getByRole('button', { name: '31' })).toBeVisible();
   });
 
+  it('renders fine with past dates disabled', () => {
+    // January 25, 2028
+    const date = new Date('2028-01-25 ');
+
+    uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} highlightToday isOpen disablePastDates />);
+
+    expect(screen.getByText('January 2028')).toBeVisible();
+    expect(screen.getByText('Sun')).toBeVisible();
+
+    expect(screen.getByRole('button', { name: '25' })).toBeVisible();
+    expect(screen.getByRole('button', { name: '25' })).not.toBeDisabled();
+    expect(screen.getByRole('button', { name: '23' })).toBeDisabled();
+    expect(screen.getByRole('button', { name: '24' })).toBeVisible();
+    expect(screen.getByRole('button', { name: '24' })).toBeDisabled();
+  });
+
   it('renders fine with simple month', () => {
     uiRender(<UiDatepicker date={date} onSelectDate={jest.fn()} monthTitlesFormat="simple" isOpen />);
 

--- a/packages/datepicker/__tests__/ui-input-datepicker.spec.tsx
+++ b/packages/datepicker/__tests__/ui-input-datepicker.spec.tsx
@@ -34,6 +34,19 @@ describe('<UiDatepicker />', () => {
     expect(screen.getByRole('menu')).toBeVisible();
   });
 
+  it('renders fine when using disablePastDates', () => {
+    const someDate = new Date('2029-01-25 ');
+
+    uiRender(<UiInputDatepicker onChange={jest.fn()} date={someDate} name="someDate" disablePastDates />);
+
+    expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+
+    fireEvent.focus(screen.getByRole('textbox'));
+
+    expect(screen.getByRole('menu')).toBeVisible();
+    expect(screen.getByRole('button', { name: '24' })).toBeDisabled();
+  });
+
   it('renders error correctly', () => {
     uiRender(<UiInputDatepicker onChange={jest.fn()} name="someDate" error="Select another date" />);
 

--- a/packages/datepicker/docs/docs.mdx
+++ b/packages/datepicker/docs/docs.mdx
@@ -32,7 +32,7 @@ import { UiBadge } from '@uireact/badge';
 ## Just the datepicker
 
 <Playground>
-  <div style={{ height: '350px' }}>
+  <div style={{ height: '400px' }}>
     <UiDatepicker
       date={new Date()}
       highlightToday
@@ -48,7 +48,7 @@ import { UiBadge } from '@uireact/badge';
 ## 2 months datepicker
 
 <Playground>
-  <div style={{ height: '350px' }}>
+  <div style={{ height: '400px' }}>
     <UiDatepicker
       date={new Date()}
       highlightToday
@@ -144,6 +144,25 @@ export const DatePickerExample: React.FC = () => {
   );
 };
 ```
+
+## Datepicker with disabled dates in the past
+
+<Playground>
+  <div style={{ height: '400px' }}>
+    <UiDatepicker
+      date={new Date('2028-01-25')}
+      highlightToday
+      onSelectDate={(date) => {
+        console.log(date);
+      }}
+      isOpen
+      closeLabel="Done"
+      disablePastDates
+    />
+  </div>
+</Playground>
+
+When using `disablePastDates` prop it will disable all dates in the past from the given date.
 
 ### Props
 

--- a/packages/datepicker/src/private/picker-month.tsx
+++ b/packages/datepicker/src/private/picker-month.tsx
@@ -11,25 +11,29 @@ const Div = styled.div`
 `;
 
 type PickerMonthProps = {
-  date: Date;
+  focusDate: Date;
+  today: Date;
   dayTitlesFormat: DateTitleFormats;
   highlightToday?: boolean;
   onSelectDate: (selectedDate: Date) => void;
   selectedDate?: Date;
+  disablePastDates?: boolean;
 };
 
 export const PickerMonth: React.FC<PickerMonthProps> = ({
-  date,
+  focusDate,
+  today,
   highlightToday,
   dayTitlesFormat,
   onSelectDate,
+  disablePastDates,
   selectedDate,
 }: PickerMonthProps) => {
   // Using plus one in month, so we can get the last day of the previous month by using 0 as day
-  const daysInMonth = getDaysInMonth(date.getMonth() + 1, date.getFullYear());
+  const daysInMonth = getDaysInMonth(focusDate.getMonth() + 1, focusDate.getFullYear());
 
   // Using current month, so we can get the first day of the current month by using 1 as day
-  const startingDayOfTheWeek = getStartingDayOfTheWeek(date.getMonth(), date.getFullYear());
+  const startingDayOfTheWeek = getStartingDayOfTheWeek(focusDate.getMonth(), focusDate.getFullYear());
 
   const daysByWeek = getDaysByWeek(daysInMonth, startingDayOfTheWeek);
 
@@ -39,13 +43,14 @@ export const PickerMonth: React.FC<PickerMonthProps> = ({
       {daysByWeek.map((value, index) => (
         <PickerWeek
           key={`picker-week-${index}`}
+          today={today}
           startingWeekDay={index === 0 ? startingDayOfTheWeek : 0}
           weekDays={value}
           highlightToday={highlightToday}
-          year={date.getFullYear()}
-          month={date.getMonth()}
+          focusDate={focusDate}
           onSelectDate={onSelectDate}
           selectedDate={selectedDate}
+          disablePastDates={disablePastDates}
         />
       ))}
     </Div>

--- a/packages/datepicker/src/private/picker-week.tsx
+++ b/packages/datepicker/src/private/picker-week.tsx
@@ -21,7 +21,7 @@ const DayWrapperButton = styled.button<{ $highlight?: boolean; $selected: boolea
   padding: 0;
   border: 0;
   background-color: transparent;
-  color: var(--texts-token_100);
+  color: var(--fonts-token_100);
   transition: background-color 0.3s;
 
   ${(props) => `
@@ -34,38 +34,51 @@ const DayWrapperButton = styled.button<{ $highlight?: boolean; $selected: boolea
       ${props.$selected ? 'background-color: var(--tertiary-token_200);' : 'background-color: var(--primary-token_10);'}
     `}
   }
+
+  &:disabled {
+    opacity: 0.8;
+    cursor: not-allowed;
+    &:hover {
+      background-color: transparent;
+    }
+  }
 `;
 
 type PickerWeekProps = {
+  focusDate: Date;
+  today: Date;
   startingWeekDay: number;
   weekDays: number[];
   highlightToday?: boolean;
-  month: number;
-  year: number;
   onSelectDate: (selectedDate: Date) => void;
   selectedDate?: Date;
+  disablePastDates?: boolean;
 };
 
 export const PickerWeek: React.FC<PickerWeekProps> = ({
   startingWeekDay,
   highlightToday,
   weekDays,
-  month,
-  year,
+  focusDate,
+  today,
   onSelectDate,
   selectedDate,
+  disablePastDates,
 }: PickerWeekProps) => {
-  const today = new Date();
-
+  const yesterday = new Date(focusDate.getFullYear(), focusDate.getMonth(), focusDate.getDate() - 1);
+  const selectedDateString = selectedDate
+    ? `${selectedDate.getFullYear()}/${selectedDate.getMonth()}/${selectedDate.getDate()}`
+    : '';
+  const month = focusDate.getMonth();
   const onDateSelected = useCallback(
     (e: FormEvent<HTMLButtonElement>) => {
       const day = e.currentTarget.value;
       if (day) {
-        const date = new Date(year, month, parseInt(day));
+        const date = new Date(focusDate.getFullYear(), focusDate.getMonth(), parseInt(day));
         onSelectDate(date);
       }
     },
-    [onSelectDate, year, month]
+    [onSelectDate, focusDate]
   );
 
   return (
@@ -74,20 +87,21 @@ export const PickerWeek: React.FC<PickerWeekProps> = ({
         <EmptySlot key={`empty-picker-day-${index}`} />
       ))}
       {weekDays.map((value) => {
-        const date = `${year}/${month}/${value}`;
-        const todayDate = `${today.getFullYear()}/${today.getMonth()}/${today.getDate()}`;
-        const selectedDateString = selectedDate
-          ? `${selectedDate.getFullYear()}/${selectedDate.getMonth()}/${selectedDate.getDate()}`
-          : '';
+        const currentDateString = `${focusDate.getFullYear()}/${focusDate.getMonth()}/${value}`;
+        const todayDateString = `${today.getFullYear()}/${today.getMonth()}/${today.getDate()}`;
+
+        const buttonDate = new Date(focusDate.getFullYear(), focusDate.getMonth(), value);
+        const isDisabled = disablePastDates && buttonDate <= yesterday;
 
         return (
           <DayWrapperButton
             type="button"
-            key={`picker-day-${value}`}
-            $highlight={highlightToday && date === todayDate}
+            key={`picker-day-${month}-${value}`}
+            $highlight={highlightToday && currentDateString === todayDateString}
             onClick={onDateSelected}
             value={value}
-            $selected={date === selectedDateString}
+            $selected={currentDateString === selectedDateString}
+            disabled={isDisabled}
           >
             {value}
           </DayWrapperButton>

--- a/packages/datepicker/src/types/datepicker-props.ts
+++ b/packages/datepicker/src/types/datepicker-props.ts
@@ -22,4 +22,6 @@ export type UiDatepickerProps = {
   isOpen?: boolean;
   /** The close label used in the close button when `useDialogOnSmall` is passed and datepicker is opened on small breakpoint */
   closeLabel?: string;
+  /** Disable all past dates from the given date */
+  disablePastDates?: boolean;
 } & UiReactElementProps;

--- a/packages/datepicker/src/types/input-datepicker.ts
+++ b/packages/datepicker/src/types/input-datepicker.ts
@@ -77,4 +77,6 @@ export type UiInputDatepickerProps = {
   showNextMonth?: boolean;
   /** Makes the datepicker render as fullscreen dialog on small devices */
   useDialogOnSmall?: boolean;
+  /** Disables the dates in the past from the given date, if no date is passed today's date is used */
+  disablePastDates?: boolean;
 } & UiReactElementProps;

--- a/packages/datepicker/src/ui-datepicker.tsx
+++ b/packages/datepicker/src/ui-datepicker.tsx
@@ -42,6 +42,7 @@ export const UiDatepicker: React.FC<UiDatepickerProps> = ({
   date,
   dayTitlesFormat = 'simple',
   monthTitlesFormat = 'complete',
+  disablePastDates,
   highlightToday,
   onSelectDate,
   onClose,
@@ -52,6 +53,7 @@ export const UiDatepicker: React.FC<UiDatepickerProps> = ({
   isOpen = false,
 }: UiDatepickerProps) => {
   const { isSmall } = useViewport();
+  const today = new Date();
   const [focusDate, setFocusDate] = useState<Date>(date);
   const [nextFocusDate, setNextFocusDate] = useState<Date>(new Date(date.getFullYear(), date.getMonth() + 1, 1));
   const [selectedDate, setSelectedDate] = useState<Date | undefined>();
@@ -120,11 +122,13 @@ export const UiDatepicker: React.FC<UiDatepickerProps> = ({
       <UiFlexGrid direction={isSmall ? 'column' : 'row'}>
         <UiFlexGridItem grow={1}>
           <PickerMonth
-            date={focusDate}
+            today={today}
+            focusDate={focusDate}
             dayTitlesFormat={dayTitlesFormat}
             highlightToday={highlightToday}
             onSelectDate={onSelectInternalDate}
             selectedDate={selectedDate}
+            disablePastDates={disablePastDates}
           />
         </UiFlexGridItem>
         {showNextMonth && (
@@ -137,11 +141,13 @@ export const UiDatepicker: React.FC<UiDatepickerProps> = ({
               </UiSpacing>
             )}
             <PickerMonth
-              date={nextFocusDate}
+              today={today}
+              focusDate={nextFocusDate}
               dayTitlesFormat={dayTitlesFormat}
               highlightToday={highlightToday}
               onSelectDate={onSelectInternalDate}
               selectedDate={selectedDate}
+              disablePastDates={disablePastDates}
             />
           </MonthWrapper>
         )}

--- a/packages/datepicker/src/ui-input-datepicker.tsx
+++ b/packages/datepicker/src/ui-input-datepicker.tsx
@@ -31,6 +31,7 @@ export const UiInputDatepicker: React.FC<UiInputDatepickerProps> = ({
   showNextMonth,
   useDialogOnSmall,
   useDateAsDefaultInputValue = false,
+  disablePastDates = false,
 }: UiInputDatepickerProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [datepickerDate, setDatepickerDate] = useState<Date>(date || new Date());
@@ -110,6 +111,7 @@ export const UiInputDatepicker: React.FC<UiInputDatepickerProps> = ({
         closeLabel={closeLabel}
         showNextMonth={showNextMonth}
         useDialogOnSmall={useDialogOnSmall}
+        disablePastDates={disablePastDates}
       />
     </div>
   );


### PR DESCRIPTION
## 🔥 Disable past dates prop in datepicker
----------------------------------------------

### Description
This prop can be used when we don't have the user to select a date in the past, we specify what is our starting date and anything from there backwards is disabled.

### Screenshots
<img width="652" alt="Screenshot 2023-11-10 at 1 24 40 PM" src="https://github.com/inavac182/uireact/assets/16787893/4789e985-fcd0-4cb9-8140-dbcdc34cacb9">
