### PR TITLE
fix: inline navbar border flicker on hover

### DIFF
--- a/packages/navbar/src/private/navbar-item-wrapper.tsx
+++ b/packages/navbar/src/private/navbar-item-wrapper.tsx
@@ -46,6 +46,7 @@ const Div = styled.div<NavbarItemWrapperProps>`
       ${
         props.$styling === 'bordered'
           ? `
+          border-${props.$orientation === 'inline' ? 'bottom' : 'left'}: 2px solid transparent;
             &:hover {
               border-${props.$orientation === 'inline' ? 'bottom' : 'left'}: 2px solid var(--${getColorCategory(
               props.$category


### PR DESCRIPTION
## 🔥 Fix: Inline navbar border flicker on hover
----------------------------------------------

### Description
There is a flickering in the inline navbar when hovered as the space for border was not allovated.

### Screenshots

#### Before
![Mar-10-2024 17-52-09](https://github.com/inavac182/uireact/assets/16787893/23875bd5-da8d-42f6-88bf-83b08443fa98)

#### After
![Mar-10-2024 17-51-43](https://github.com/inavac182/uireact/assets/16787893/1d6359b7-fc66-4e31-9773-87dd3f7d08ea)

