### PR TITLE
feat: datepicker update

### DIFF
--- a/packages/datepicker/__tests__/ui-input-datepicker.spec.tsx
+++ b/packages/datepicker/__tests__/ui-input-datepicker.spec.tsx
@@ -16,7 +16,7 @@ describe('<UiDatepicker />', () => {
     expect(screen.queryByRole('menu')).not.toBeInTheDocument();
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
     expect(screen.getByRole('textbox')).toBeVisible();
-    expect(screen.getByRole('textbox')).toHaveValue('');
+    expect(screen.getByRole('textbox')).toHaveValue('2028-01-31');
 
     fireEvent.focus(screen.getByRole('textbox'));
 
@@ -32,6 +32,7 @@ describe('<UiDatepicker />', () => {
     fireEvent.focus(screen.getByRole('textbox'));
 
     expect(screen.getByRole('menu')).toBeVisible();
+    expect(screen.getByRole('textbox')).toHaveValue('');
   });
 
   it('renders fine when using disablePastDates', () => {
@@ -59,7 +60,7 @@ describe('<UiDatepicker />', () => {
     // January 2028
     const date = new Date(2028, 1, 0);
 
-    uiRender(<UiInputDatepicker date={date} onChange={jest.fn()} name="someDate" useDateAsDefaultInputValue />);
+    uiRender(<UiInputDatepicker date={date} onChange={jest.fn()} name="someDate" />);
 
     expect(screen.queryByRole('menu')).not.toBeInTheDocument();
     expect(screen.queryByRole('dialog')).not.toBeInTheDocument();
@@ -198,7 +199,7 @@ describe('<UiDatepicker />', () => {
   });
 
   it('input value does not change on input typing', () => {
-    uiRender(<UiInputDatepicker date={date} onChange={jest.fn()} />);
+    uiRender(<UiInputDatepicker onChange={jest.fn()} />);
 
     const input = screen.getByRole('textbox');
 

--- a/packages/datepicker/docs/docs-input.mdx
+++ b/packages/datepicker/docs/docs-input.mdx
@@ -38,6 +38,30 @@ import { UiIcon } from '@uireact/icons';
       label="Date"
       labelOnTop
       placeholder="Select the date"
+      highlightToday
+      onChange={(value) => {
+        console.log(value);
+      }}
+      icon={<UiIcon icon="CalendarLines" />}
+      size="large"
+      useDialogOnSmall
+      closeLabel="Done"
+    />
+  </div>
+</Playground>
+
+## Date picker with initial value
+
+If a prop `date` is passed then it will be used as the default value for the input and the date selected in the datepicker
+
+<Playground>
+  <div style={{ height: '350px' }}>
+    <UiInputDatepicker
+      label="Date"
+      date={new Date('2024-01-01 00:00:00')}
+      labelOnTop
+      placeholder="Select the date"
+      highlightToday
       onChange={(value) => {
         console.log(value);
       }}

--- a/packages/datepicker/docs/docs.mdx
+++ b/packages/datepicker/docs/docs.mdx
@@ -29,39 +29,7 @@ import { UiBadge } from '@uireact/badge';
 
 > npm i @uireact/foundation @uireact/flex @uireact/button @uireact/grid @uireact/menu @uireact/text @uireact/datepicker
 
-## Just the datepicker
-
-<Playground>
-  <div style={{ height: '400px' }}>
-    <UiDatepicker
-      date={new Date()}
-      highlightToday
-      onSelectDate={(date) => {
-        console.log(date);
-      }}
-      isOpen
-      closeLabel="Done"
-    />
-  </div>
-</Playground>
-
-## 2 months datepicker
-
-<Playground>
-  <div style={{ height: '400px' }}>
-    <UiDatepicker
-      date={new Date()}
-      highlightToday
-      showNextMonth
-      onSelectDate={(date) => {
-        console.log(date);
-      }}
-      isOpen
-    />
-  </div>
-</Playground>
-
-## Datepicker real example
+## Datepicker
 
 <Playground>
   <DatePickerExample />
@@ -144,25 +112,6 @@ export const DatePickerExample: React.FC = () => {
   );
 };
 ```
-
-## Datepicker with disabled dates in the past
-
-<Playground>
-  <div style={{ height: '400px' }}>
-    <UiDatepicker
-      date={new Date('2028-01-25')}
-      highlightToday
-      onSelectDate={(date) => {
-        console.log(date);
-      }}
-      isOpen
-      closeLabel="Done"
-      disablePastDates
-    />
-  </div>
-</Playground>
-
-When using `disablePastDates` prop it will disable all dates in the past from the given date.
 
 ### Props
 

--- a/packages/datepicker/docs/example/datepicker-input-example.tsx
+++ b/packages/datepicker/docs/example/datepicker-input-example.tsx
@@ -58,6 +58,7 @@ export const DatePickerInputExample: React.FC = () => {
             label="Date"
             labelOnTop
             placeholder="Select a future date"
+            highlightToday
             onChange={onChange}
             icon={<UiIcon icon="CalendarLines" />}
             size="large"
@@ -65,6 +66,7 @@ export const DatePickerInputExample: React.FC = () => {
             error={errorMessage}
             category={errorMessage ? 'error' : undefined}
             showNextMonth
+            useDialogOnSmall
           />
           <UiSpacing padding={buttonMargin}>
             <UiButton type="submit" category="tertiary">

--- a/packages/datepicker/src/types/datepicker-props.ts
+++ b/packages/datepicker/src/types/datepicker-props.ts
@@ -2,8 +2,8 @@ import { UiReactElementProps } from '@uireact/foundation';
 import { DateTitleFormats } from './date-titles';
 
 export type UiDatepickerProps = {
-  /** The main date used to start the datepicker */
-  date: Date;
+  /** The date used to focus the datepicker */
+  date?: Date;
   /** The format of the day title, e.g. Sunday vs Sun vs S */
   dayTitlesFormat?: DateTitleFormats;
   /** The format of the month title, e.g. December vs Dec vs D */
@@ -24,4 +24,6 @@ export type UiDatepickerProps = {
   closeLabel?: string;
   /** Disable all past dates from the given date */
   disablePastDates?: boolean;
+  /** Select init date */
+  selectInitDate?: boolean;
 } & UiReactElementProps;

--- a/packages/datepicker/src/types/datepicker-props.ts
+++ b/packages/datepicker/src/types/datepicker-props.ts
@@ -2,7 +2,7 @@ import { UiReactElementProps } from '@uireact/foundation';
 import { DateTitleFormats } from './date-titles';
 
 export type UiDatepickerProps = {
-  /** The date used to focus the datepicker */
+  /** The date to initialize the datepicker, if empty today date is used */
   date?: Date;
   /** The format of the day title, e.g. Sunday vs Sun vs S */
   dayTitlesFormat?: DateTitleFormats;

--- a/packages/datepicker/src/types/input-datepicker.ts
+++ b/packages/datepicker/src/types/input-datepicker.ts
@@ -45,8 +45,6 @@ export type UiInputDatepickerProps = {
   name?: string;
   /** Date format for the input value */
   dateFormat?: UiDatePickerDateFormats;
-  /** Takes the date in the datepicker as the default value for the input */
-  useDateAsDefaultInputValue?: boolean;
   /** Label for input field */
   label?: string;
   /** Label on top of field */

--- a/packages/datepicker/src/ui-datepicker.tsx
+++ b/packages/datepicker/src/ui-datepicker.tsx
@@ -51,12 +51,15 @@ export const UiDatepicker: React.FC<UiDatepickerProps> = ({
   showNextMonth,
   useDialogOnSmall = false,
   isOpen = false,
+  selectInitDate = false,
 }: UiDatepickerProps) => {
   const { isSmall } = useViewport();
   const today = new Date();
-  const [focusDate, setFocusDate] = useState<Date>(date);
-  const [nextFocusDate, setNextFocusDate] = useState<Date>(new Date(date.getFullYear(), date.getMonth() + 1, 1));
-  const [selectedDate, setSelectedDate] = useState<Date | undefined>();
+  const [focusDate, setFocusDate] = useState<Date>(date || today);
+  const [nextFocusDate, setNextFocusDate] = useState<Date>(
+    new Date(focusDate.getFullYear(), focusDate.getMonth() + 1, 1)
+  );
+  const [selectedDate, setSelectedDate] = useState<Date | undefined>(selectInitDate ? date : undefined);
   const isDialogShown = isSmall && useDialogOnSmall;
 
   const onCloseMenu = useCallback(() => {

--- a/packages/datepicker/src/ui-input-datepicker.tsx
+++ b/packages/datepicker/src/ui-input-datepicker.tsx
@@ -30,13 +30,12 @@ export const UiInputDatepicker: React.FC<UiInputDatepickerProps> = ({
   closeLabel,
   showNextMonth,
   useDialogOnSmall,
-  useDateAsDefaultInputValue = false,
   disablePastDates = false,
 }: UiInputDatepickerProps) => {
   const inputRef = useRef<HTMLInputElement>(null);
-  const [datepickerDate, setDatepickerDate] = useState<Date>(date || new Date());
+  const [datepickerDate, setDatepickerDate] = useState<Date | undefined>(date);
   const [inputValue, setInputValue] = useState<string>(
-    useDateAsDefaultInputValue ? getFormattedDate(dateFormat, datepickerDate) : ''
+    datepickerDate ? getFormattedDate(dateFormat, datepickerDate) : ''
   );
   const [datepickerVisible, setDatepickerVisible] = useState(false);
 
@@ -88,9 +87,9 @@ export const UiInputDatepicker: React.FC<UiInputDatepickerProps> = ({
               name={name}
               placeholder={placeholder}
               ref={inputRef}
+              value={inputValue}
               onChange={onChangeInternal}
               $category={category}
-              value={inputValue}
               $size={size}
               required={required}
               $withIcon={icon !== undefined}
@@ -112,6 +111,7 @@ export const UiInputDatepicker: React.FC<UiInputDatepickerProps> = ({
         showNextMonth={showNextMonth}
         useDialogOnSmall={useDialogOnSmall}
         disablePastDates={disablePastDates}
+        selectInitDate
       />
     </div>
   );


### PR DESCRIPTION
## 🔥 UiDatepicker default date value
----------------------------------------------

### Description
- Updating the `UiDatepicker` , if `date` prop is passed, this is used as default value, if no passed today's date is used to initialize the date picker.

- Updating the `UiInputDatepicker`, The `value` passed is also used as the selected date for the datepicker.
- Deleting `useDateAsDefaultInputValue` prop as it's not needed now.

### Screenshots

#### Before

#### After
<img width="649" alt="Screenshot 2024-03-10 at 6 51 00 PM" src="https://github.com/inavac182/uireact/assets/16787893/4246ba78-c9d5-4824-aa52-ad159f56b852">

