### PR TITLE
feat: adding default coloration to typography elements

### DIFF
--- a/packages/icons/__tests__/ui-icon.spec.tsx
+++ b/packages/icons/__tests__/ui-icon.spec.tsx
@@ -4,7 +4,7 @@ import { screen } from '@testing-library/react';
 
 import { uiRender } from '../../../__tests__/utils/render';
 import { UiIcon } from '../src';
-import { ThemeColor } from '@uireact/foundation';
+import { DefaultTheme } from '@uireact/foundation';
 
 import 'jest-styled-components';
 
@@ -37,18 +37,17 @@ describe('<UiIcon />', () => {
   });
 
   it('renders fine with inverse coloration props on light', () => {
-    uiRender(
-      <UiIcon icon="Search" category="error" inverseColoration={{ light: true, dark: false }} />,
-      ThemeColor.light
-    );
+    uiRender(<UiIcon icon="Search" category="error" coloration="light" testId="UiIcon" />);
 
     expect(screen.getByTestId('Icon')).toBeVisible();
+    expect(screen.getByTestId('UiIcon')).toHaveStyleRule('fill', DefaultTheme.light.error.token_100);
   });
 
   it('renders fine with inverse coloration props on dark', () => {
-    uiRender(<UiIcon icon="Search" category="error" inverseColoration={{ light: true, dark: false }} />);
+    uiRender(<UiIcon icon="Search" category="error" coloration="dark" testId="UiIcon" />);
 
     expect(screen.getByTestId('Icon')).toBeVisible();
+    expect(screen.getByTestId('UiIcon')).toHaveStyleRule('fill', DefaultTheme.dark.error.token_100);
   });
 
   it('renders nothing if id is unrecognized', () => {

--- a/packages/icons/docs/docs.mdx
+++ b/packages/icons/docs/docs.mdx
@@ -37,6 +37,13 @@ import { IconsList } from './utils';
   <UiIcon icon="Search" size="xlarge" category="tertiary" inverseColoration />
 </Playground>
 
+## UiIcon with default coloration
+
+<Playground>
+  <UiIcon icon="Search" size="xlarge" category="tertiary" coloration="dark" /> Always render DARK coloration <br />
+  <UiIcon icon="Search" size="xlarge" category="tertiary" coloration="light" /> Always render LIGHT coloration
+</Playground>
+
 ## Icons list
 
 <Playground hideThemeSelector>

--- a/packages/icons/src/types/icons-props.ts
+++ b/packages/icons/src/types/icons-props.ts
@@ -1,4 +1,4 @@
-import { ColorCategory, SizesProp, UiReactElementProps } from '@uireact/foundation';
+import { ColorCategory, SizesProp, Theme, UiReactElementProps } from '@uireact/foundation';
 
 import * as SvgsComponent from '../public/svgs';
 
@@ -15,11 +15,15 @@ export type UiIconProps = {
   /** Icon Size */
   size?: SizesProp;
   /** If the font color should be inversed to use its counter part coloration. */
-  inverseColoration?: boolean | InverseColorationProp;
+  inverseColoration?: boolean;
+  /* Defaults the element to a specific theme coloration */
+  coloration?: 'dark' | 'light';
 } & UiReactElementProps;
 
 export type privateIconProps = {
   $size?: SizesProp;
   $category?: ColorCategory;
-  $inverseColoration?: boolean | InverseColorationProp;
+  $inverseColoration?: boolean;
+  $coloration?: 'dark' | 'light';
+  $theme: Theme;
 };

--- a/packages/icons/src/ui-icon.tsx
+++ b/packages/icons/src/ui-icon.tsx
@@ -1,16 +1,41 @@
 'use client';
-import React from 'react';
+import React, { useContext } from 'react';
 
 import styled from 'styled-components';
 
-import { getColorCategory } from '@uireact/foundation';
+import { ColorTokens, ThemeColor, ThemeContext, getColorCategory, getThemeColor } from '@uireact/foundation';
 
 import { UiIconProps, privateIconProps } from './types';
 import { IconComponent } from './public';
 
 const Span = styled.span<privateIconProps>`
   ${(props: privateIconProps) => `
-    fill: var(--${props.$inverseColoration ? 'inverse-' : ''}${getColorCategory(props.$category)}-token_100);
+    ${
+      props.$coloration === 'dark'
+        ? `fill: ${getThemeColor(
+            props.$theme,
+            ThemeColor.dark,
+            getColorCategory(props.$category),
+            ColorTokens.token_100
+          )};`
+        : ''
+    }
+        ${
+          props.$coloration === 'light'
+            ? `fill: ${getThemeColor(
+                props.$theme,
+                ThemeColor.light,
+                getColorCategory(props.$category),
+                ColorTokens.token_100
+              )};`
+            : ''
+        }
+    ${
+      !props.$coloration
+        ? `fill: var(--${props.$inverseColoration ? 'inverse-' : ''}${getColorCategory(props.$category)}-token_100);`
+        : ''
+    }
+    
 
     ${`font-size: var(--texts-${props.$size});`}
     ${`line-height: var(--texts-${props.$size});`}
@@ -25,14 +50,26 @@ const Span = styled.span<privateIconProps>`
 
 export const UiIcon: React.FC<UiIconProps> = ({
   category,
+  coloration,
   icon,
   size = 'regular',
   testId,
   inverseColoration,
-}: UiIconProps) => (
-  <Span $category={category} $size={size} $inverseColoration={inverseColoration} data-testid={testId}>
-    <IconComponent icon={icon} />
-  </Span>
-);
+}: UiIconProps) => {
+  const { theme } = useContext(ThemeContext);
+
+  return (
+    <Span
+      $category={category}
+      $size={size}
+      $inverseColoration={inverseColoration}
+      data-testid={testId}
+      $theme={theme}
+      $coloration={coloration}
+    >
+      <IconComponent icon={icon} />
+    </Span>
+  );
+};
 
 UiIcon.displayName = 'UiIcon';

--- a/packages/text/__tests__/ui-button-link.spec.tsx
+++ b/packages/text/__tests__/ui-button-link.spec.tsx
@@ -63,4 +63,24 @@ describe('<UiLink />', () => {
 
     expect(screen.getByRole('link', { name: 'Link' })).toBeVisible();
   });
+
+  it('renders fine with dark coloration', () => {
+    uiRender(
+      <UiButtonLink fontStyle="regular" coloration="dark">
+        <a href="#">Link</a>
+      </UiButtonLink>
+    );
+
+    expect(screen.getByRole('link', { name: 'Link' })).toBeVisible();
+  });
+
+  it('renders fine with light coloration', () => {
+    uiRender(
+      <UiButtonLink fontStyle="regular" coloration="light">
+        <a href="#">Link</a>
+      </UiButtonLink>
+    );
+
+    expect(screen.getByRole('link', { name: 'Link' })).toBeVisible();
+  });
 });

--- a/packages/text/__tests__/ui-heading.spec.tsx
+++ b/packages/text/__tests__/ui-heading.spec.tsx
@@ -2,6 +2,8 @@ import React from 'react';
 
 import { screen } from '@testing-library/react';
 
+import { DefaultTheme } from '@uireact/foundation';
+
 import { uiRender } from '../../../__tests__/utils/render';
 import { UiHeading } from '../src';
 
@@ -196,5 +198,25 @@ describe('<UiHeading />', () => {
     );
 
     expect(screen.getByRole('heading', { name: 'Heading', level: 6 })).toBeVisible();
+  });
+
+  it('renders fine with coloration dark', () => {
+    uiRender(<UiHeading coloration="dark">Heading</UiHeading>);
+
+    expect(screen.getByRole('heading', { name: 'Heading' })).toBeVisible();
+    expect(screen.getByRole('heading', { name: 'Heading' })).toHaveStyleRule(
+      'color',
+      DefaultTheme.dark.fonts.token_100
+    );
+  });
+
+  it('renders fine with coloration light', () => {
+    uiRender(<UiHeading coloration="light">Heading</UiHeading>);
+
+    expect(screen.getByRole('heading', { name: 'Heading' })).toBeVisible();
+    expect(screen.getByRole('heading', { name: 'Heading' })).toHaveStyleRule(
+      'color',
+      DefaultTheme.light.fonts.token_100
+    );
   });
 });

--- a/packages/text/__tests__/ui-label.spec.tsx
+++ b/packages/text/__tests__/ui-label.spec.tsx
@@ -1,6 +1,7 @@
 import React from 'react';
 
 import { screen } from '@testing-library/react';
+import { DefaultTheme } from '@uireact/foundation';
 
 import { uiRender } from '../../../__tests__/utils/render';
 import { UiLabel } from '../src';
@@ -26,5 +27,28 @@ describe('<UiLabel />', () => {
 
     expect(screen.getByText('Text')).toBeVisible();
     expect(screen.getByText('Text')).toHaveStyleRule('font-size', 'var(--texts-large)');
+  });
+
+  it('renders fine with dark coloration', () => {
+    uiRender(
+      <UiLabel size="large" coloration="dark">
+        Text
+      </UiLabel>
+    );
+
+    expect(screen.getByText('Text')).toBeVisible();
+    expect(screen.getByText('Text')).toHaveStyleRule('font-size', 'var(--texts-large)');
+    expect(screen.getByText('Text')).toHaveStyleRule('color', DefaultTheme.dark.fonts.token_100);
+  });
+
+  it('renders fine with light coloration', () => {
+    uiRender(
+      <UiLabel size="large" coloration="light">
+        Text
+      </UiLabel>
+    );
+
+    expect(screen.getByText('Text')).toBeVisible();
+    expect(screen.getByText('Text')).toHaveStyleRule('color', DefaultTheme.light.fonts.token_100);
   });
 });

--- a/packages/text/__tests__/ui-link.spec.tsx
+++ b/packages/text/__tests__/ui-link.spec.tsx
@@ -66,6 +66,26 @@ describe('<UiLink />', () => {
     expect(screen.getByRole('link', { name: 'Link' })).toBeVisible();
   });
 
+  it('renders fine with light coloration', () => {
+    uiRender(
+      <UiLink href="#" size={TextSize.large} fontStyle="bold" coloration="light">
+        <a href="#">Link</a>
+      </UiLink>
+    );
+
+    expect(screen.getByRole('link', { name: 'Link' })).toBeVisible();
+  });
+
+  it('renders fine with dark coloration', () => {
+    uiRender(
+      <UiLink href="#" size={TextSize.large} fontStyle="bold" coloration="dark">
+        <a href="#">Link</a>
+      </UiLink>
+    );
+
+    expect(screen.getByRole('link', { name: 'Link' })).toBeVisible();
+  });
+
   it('renders fine when fontStyle is regular', () => {
     uiRender(
       <UiLink href="#" size={TextSize.large} fontStyle="regular">

--- a/packages/text/__tests__/ui-text.spec.tsx
+++ b/packages/text/__tests__/ui-text.spec.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 
 import { screen } from '@testing-library/react';
-import { ThemeColor } from '@uireact/foundation';
+import { DefaultTheme, ThemeColor } from '@uireact/foundation';
 
 import { uiRender } from '../../../__tests__/utils/render';
 import { UiText } from '../src';
@@ -34,6 +34,20 @@ describe('<UiText />', () => {
 
     expect(screen.getByText('Text')).toBeVisible();
     expect(screen.getByText('Text')).toHaveStyleRule('color', 'var(--inverse-fonts-token_100)');
+  });
+
+  it('renders fine with dark coloration', () => {
+    uiRender(<UiText coloration="dark">Text</UiText>);
+
+    expect(screen.getByText('Text')).toBeVisible();
+    expect(screen.getByText('Text')).toHaveStyleRule('color', DefaultTheme.dark.fonts.token_100);
+  });
+
+  it('renders fine with light coloration', () => {
+    uiRender(<UiText coloration="light">Text</UiText>);
+
+    expect(screen.getByText('Text')).toBeVisible();
+    expect(screen.getByText('Text')).toHaveStyleRule('color', DefaultTheme.light.fonts.token_100);
   });
 
   it('renders fine with wrap', () => {

--- a/packages/text/docs/button-link-docs.mdx
+++ b/packages/text/docs/button-link-docs.mdx
@@ -47,3 +47,14 @@ import { UiSpacing } from '@uireact/foundation';
     </UiSpacing>
   </UiButtonLink>
 </Playground>
+
+## UiButtonLink with default coloration
+
+<Playground>
+  <UiButtonLink coloration="dark">
+    <a href="https://uireact.io/">Will always render text as DARK coloration</a>
+  </UiButtonLink>
+  <UiButtonLink coloration="light">
+    <a href="https://uireact.io/">Will always render text as LIGHT coloration</a>
+  </UiButtonLink>
+</Playground>

--- a/packages/text/docs/heading-docs.mdx
+++ b/packages/text/docs/heading-docs.mdx
@@ -54,6 +54,17 @@ import { UiHeading } from '../src';
   </UiHeading>
 </Playground>
 
+## UiHeading with default coloration
+
+<Playground>
+  <UiHeading level={1} coloration="dark">
+    Will always render with DARK coloration
+  </UiHeading>
+  <UiHeading level={1} coloration="light">
+    Will always render with LIGHT coloration
+  </UiHeading>
+</Playground>
+
 ### Props
 
 <Props of={UiHeading} />

--- a/packages/text/docs/label-docs.mdx
+++ b/packages/text/docs/label-docs.mdx
@@ -38,6 +38,13 @@ import { UiLabel } from '../src';
   <UiLabel category="negative">Some label</UiLabel> <br />
 </Playground>
 
+## UiLabel with default coloration
+
+<Playground>
+  <UiLabel coloration="light">Will aways render LIGHT coloration</UiLabel> <br />
+  <UiLabel coloration="dark">Will aways render DARK coloration</UiLabel>
+</Playground>
+
 ### Props
 
 <Props of={UiLabel} />

--- a/packages/text/docs/link-docs.mdx
+++ b/packages/text/docs/link-docs.mdx
@@ -48,6 +48,18 @@ import { UiLink } from '../src';
   </UiLink>
 </Playground>
 
+## UiText with default coloration
+
+<Playground>
+  <UiLink coloration="dark">
+    <a href="https://uireact.io/">Will always render with DARK coloration</a>
+  </UiLink>
+  <br />
+  <UiLink coloration="light">
+    <a href="https://uireact.io/">Will always render with LIGHT coloration</a>
+  </UiLink>{' '}
+</Playground>
+
 ### Props
 
 <Props of={UiLink} />

--- a/packages/text/docs/text-docs.mdx
+++ b/packages/text/docs/text-docs.mdx
@@ -74,7 +74,13 @@ When using inline the text will be rendered in a `Span` tag
 
 <Playground>
   <UiText inverseColoration>Some text </UiText>
-  <UiText inverseColoration={{ dark: true, light: false }}>Only in dark theme</UiText>
+</Playground>
+
+## UiText with default coloration
+
+<Playground>
+  <UiText coloration="dark">Will always show DARK coloration</UiText>
+  <UiText coloration="light">Will always show LIGHT coloration</UiText>
 </Playground>
 
 ### Props

--- a/packages/text/src/types/ui-button-link-props.ts
+++ b/packages/text/src/types/ui-button-link-props.ts
@@ -1,4 +1,4 @@
-import { ColorCategory, SizesProp, UiReactElementProps } from '@uireact/foundation';
+import { ColorCategory, SizesProp, Theme, UiReactElementProps } from '@uireact/foundation';
 
 import { FontStyle } from './ui-text-props';
 
@@ -19,11 +19,11 @@ export type UiButtonLinkProps = {
   wrap?: boolean;
   /** If link text should render inverse text coloration */
   inverseTextColoration?: boolean;
+  /* Defaults the element to a specific theme coloration */
+  coloration?: 'dark' | 'light';
 } & UiReactElementProps;
 
 export type privateButtonLinkProps = {
-  /* Represents the theme to use for the link, default PRIMARY */
-  $theme?: ColorCategory;
   /** Link size, default REGULAR */
   $size: SizesProp;
   /** If link should take the whole link, useful for rendering links as Navbar items */
@@ -31,7 +31,9 @@ export type privateButtonLinkProps = {
   /** Font style */
   $fontStyle?: FontStyle;
   $category?: ColorCategory;
+  $coloration?: 'dark' | 'light';
   $wrap?: boolean;
   /** If link text should render inverse text coloration */
   $inverseTextColoration?: boolean;
+  $theme: Theme;
 };

--- a/packages/text/src/types/ui-heading-props.ts
+++ b/packages/text/src/types/ui-heading-props.ts
@@ -1,4 +1,4 @@
-import { UiReactElementProps } from '@uireact/foundation';
+import { Theme, UiReactElementProps } from '@uireact/foundation';
 import { InverseColorationProp } from './ui-text-props';
 
 export type UiHeadingProps = {
@@ -10,6 +10,8 @@ export type UiHeadingProps = {
   wrap?: boolean;
   /* If heading should use inverse theme coloration */
   inverseColoration?: boolean | InverseColorationProp;
+  /* Defaults the element to a specific theme coloration */
+  coloration?: 'dark' | 'light';
 } & UiReactElementProps;
 
 export type privateHeadingProps = {
@@ -17,4 +19,6 @@ export type privateHeadingProps = {
   $level: 1 | 2 | 3 | 4 | 5 | 6;
   $wrap?: boolean;
   $inverseColoration?: boolean | InverseColorationProp;
+  $coloration?: 'dark' | 'light';
+  $theme: Theme;
 };

--- a/packages/text/src/types/ui-label-props.ts
+++ b/packages/text/src/types/ui-label-props.ts
@@ -1,4 +1,4 @@
-import { ColorCategory, SizesProp, UiReactElementProps } from '@uireact/foundation';
+import { ColorCategory, SizesProp, Theme, UiReactElementProps } from '@uireact/foundation';
 
 export type UiLabelProps = {
   /* For what elements this label is */
@@ -7,6 +7,8 @@ export type UiLabelProps = {
   size?: SizesProp;
   /* Represents the theme to use for the text, default PRIMARY */
   category?: ColorCategory;
+  /* Defaults the element to a specific theme coloration */
+  coloration?: 'dark' | 'light';
 } & UiReactElementProps;
 
 export type privateLabelProps = {
@@ -15,4 +17,6 @@ export type privateLabelProps = {
   /* Represents the theme to use for the text, default PRIMARY */
   $category?: ColorCategory;
   $size: SizesProp;
+  $coloration?: 'dark' | 'light';
+  $theme: Theme;
 };

--- a/packages/text/src/types/ui-link-props.ts
+++ b/packages/text/src/types/ui-link-props.ts
@@ -1,8 +1,10 @@
-import { ColorCategory, SizesProp, UiReactElementProps } from '@uireact/foundation';
+import { ColorCategory, SizesProp, Theme, UiReactElementProps } from '@uireact/foundation';
 
 import { FontStyle } from './ui-text-props';
 
 export type UiLinkProps = {
+  /* Defaults the element to a specific theme coloration */
+  coloration?: 'dark' | 'light';
   /* Represents the theme to use for the link, default PRIMARY */
   category?: ColorCategory;
   /** URL to be opened */
@@ -20,8 +22,6 @@ export type UiLinkProps = {
 } & UiReactElementProps;
 
 export type privateLinkProps = {
-  /* Represents the theme to use for the link, default PRIMARY */
-  $theme?: ColorCategory;
   /** Link size, default REGULAR */
   $size: SizesProp;
   /** If link should take the whole link, useful for rendering links as Navbar items */
@@ -30,4 +30,6 @@ export type privateLinkProps = {
   $fontStyle?: FontStyle;
   $category?: ColorCategory;
   $wrap?: boolean;
+  $coloration?: 'dark' | 'light';
+  $theme: Theme;
 };

--- a/packages/text/src/types/ui-text-props.ts
+++ b/packages/text/src/types/ui-text-props.ts
@@ -1,4 +1,4 @@
-import { ColorCategory, SizesProp, UiReactElementProps } from '@uireact/foundation';
+import { ColorCategory, SizesProp, Theme, UiReactElementProps } from '@uireact/foundation';
 
 export type FontStyle = 'italic' | 'bold' | 'regular' | 'light';
 
@@ -8,6 +8,8 @@ export type InverseColorationProp = {
 };
 
 export type UiTextProps = {
+  /* Defaults the element to a specific theme coloration */
+  coloration?: 'dark' | 'light';
   /* Text size to be used, default is regular */
   size?: SizesProp;
   /* Render text centered */
@@ -19,7 +21,7 @@ export type UiTextProps = {
   /* Represents the color category to use for the text, default PRIMARY */
   category?: ColorCategory;
   /** If the font color should be inversed to use its counter part coloration. */
-  inverseColoration?: boolean | InverseColorationProp;
+  inverseColoration?: boolean;
   /** Align text left or right, default LEFT */
   align?: 'left' | 'right';
   wrap?: boolean;
@@ -35,7 +37,9 @@ export type privateTextProps = {
   /* Render text inlined */
   $inline?: boolean;
   $category?: ColorCategory;
-  $inverseColoration?: boolean | InverseColorationProp;
+  $inverseColoration?: boolean;
+  $coloration?: 'dark' | 'light';
   $align?: 'left' | 'right';
   $wrap?: boolean;
+  $theme: Theme;
 };

--- a/packages/text/src/ui-button-link.tsx
+++ b/packages/text/src/ui-button-link.tsx
@@ -1,9 +1,16 @@
 'use client';
-import React from 'react';
+import React, { useContext } from 'react';
 
 import styled from 'styled-components';
 
-import { getColorCategory } from '@uireact/foundation';
+import {
+  ColorCategories,
+  ColorTokens,
+  getColorCategory,
+  getThemeColor,
+  ThemeColor,
+  ThemeContext,
+} from '@uireact/foundation';
 
 import { privateButtonLinkProps, UiButtonLinkProps } from './types';
 
@@ -44,7 +51,19 @@ const ButtonWrapper = styled.button<privateButtonLinkProps>`
     ${(props) => `
       font-size: var(--texts-${props.$size});
       line-height: var(--texts-${props.$size});
-      color: var(--${props.$inverseTextColoration ? 'inverse-' : ''}fonts-token_100);
+
+      ${
+        props.$coloration === 'dark'
+          ? `color: ${getThemeColor(props.$theme, ThemeColor.dark, ColorCategories.fonts, ColorTokens.token_100)};`
+          : ''
+      }
+      ${
+        props.$coloration === 'light'
+          ? `color: ${getThemeColor(props.$theme, ThemeColor.light, ColorCategories.fonts, ColorTokens.token_100)};`
+          : ''
+      }
+      ${!props.$coloration ? `color: var(--${props.$inverseTextColoration ? 'inverse-' : ''}fonts-token_100);` : ''}
+      
       display: flex;
       align-items: center;
       justify-content: center;
@@ -68,6 +87,7 @@ const ButtonWrapper = styled.button<privateButtonLinkProps>`
 export const UiButtonLink: React.FC<UiButtonLinkProps> = ({
   category = 'tertiary',
   children,
+  coloration,
   handleClick,
   className,
   fullWidth,
@@ -76,20 +96,26 @@ export const UiButtonLink: React.FC<UiButtonLinkProps> = ({
   testId,
   wrap,
   inverseTextColoration,
-}: UiButtonLinkProps) => (
-  <ButtonWrapper
-    $category={category}
-    $fullWidth={fullWidth}
-    $fontStyle={fontStyle}
-    onClick={handleClick}
-    className={className}
-    $size={size}
-    data-testid={testId}
-    $wrap={wrap}
-    $inverseTextColoration={inverseTextColoration}
-  >
-    {children}
-  </ButtonWrapper>
-);
+}: UiButtonLinkProps) => {
+  const { theme } = useContext(ThemeContext);
+
+  return (
+    <ButtonWrapper
+      $category={category}
+      $coloration={coloration}
+      $fullWidth={fullWidth}
+      $fontStyle={fontStyle}
+      onClick={handleClick}
+      className={className}
+      $size={size}
+      data-testid={testId}
+      $wrap={wrap}
+      $inverseTextColoration={inverseTextColoration}
+      $theme={theme}
+    >
+      {children}
+    </ButtonWrapper>
+  );
+};
 
 UiButtonLink.displayName = 'UiButtonLink';

--- a/packages/text/src/ui-heading.tsx
+++ b/packages/text/src/ui-heading.tsx
@@ -1,16 +1,27 @@
 'use client';
-import React from 'react';
+import React, { useContext } from 'react';
 
 import styled, { css } from 'styled-components';
 
 import { UiHeadingProps, privateHeadingProps } from './types';
+import { ColorCategories, ColorTokens, ThemeColor, ThemeContext, getThemeColor } from '@uireact/foundation';
 
 const commonStyles = css<privateHeadingProps>`
   ${(props) => `
     font-size: var(--headings-level${props.$level});
     line-height: var(--headings-level${props.$level});
 
-    color: var(--${props.$inverseColoration ? 'inverse-' : ''}fonts-token_100);
+    ${
+      props.$coloration === 'dark'
+        ? `color: ${getThemeColor(props.$theme, ThemeColor.dark, ColorCategories.fonts, ColorTokens.token_100)};`
+        : ''
+    }
+    ${
+      props.$coloration === 'light'
+        ? `color: ${getThemeColor(props.$theme, ThemeColor.light, ColorCategories.fonts, ColorTokens.token_100)};`
+        : ''
+    }
+    ${!props.$coloration ? `color: var(--${props.$inverseColoration ? 'inverse-' : ''}fonts-token_100);` : ''}
 
     ${props.$centered ? `text-align: center;` : ``}
     ${
@@ -50,50 +61,102 @@ const H6 = styled.h6<privateHeadingProps>`
 export const UiHeading: React.FC<UiHeadingProps> = ({
   level = 3,
   inverseColoration,
+  coloration,
   centered,
   children,
   wrap,
 }: UiHeadingProps) => {
+  const { theme } = useContext(ThemeContext);
+
   switch (level) {
     case 1:
       return (
-        <H1 $centered={centered} $level={level} $wrap={wrap} $inverseColoration={inverseColoration}>
+        <H1
+          $coloration={coloration}
+          $centered={centered}
+          $level={level}
+          $wrap={wrap}
+          $inverseColoration={inverseColoration}
+          $theme={theme}
+        >
           {children}
         </H1>
       );
     case 2:
       return (
-        <H2 $centered={centered} $level={level} $wrap={wrap} $inverseColoration={inverseColoration}>
+        <H2
+          $coloration={coloration}
+          $centered={centered}
+          $level={level}
+          $wrap={wrap}
+          $inverseColoration={inverseColoration}
+          $theme={theme}
+        >
           {children}
         </H2>
       );
     case 3:
       return (
-        <H3 $centered={centered} $level={level} $wrap={wrap} $inverseColoration={inverseColoration}>
+        <H3
+          $coloration={coloration}
+          $centered={centered}
+          $level={level}
+          $wrap={wrap}
+          $inverseColoration={inverseColoration}
+          $theme={theme}
+        >
           {children}
         </H3>
       );
     case 4:
       return (
-        <H4 $centered={centered} $level={level} $wrap={wrap} $inverseColoration={inverseColoration}>
+        <H4
+          $coloration={coloration}
+          $centered={centered}
+          $level={level}
+          $wrap={wrap}
+          $inverseColoration={inverseColoration}
+          $theme={theme}
+        >
           {children}
         </H4>
       );
     case 5:
       return (
-        <H5 $centered={centered} $level={level} $wrap={wrap} $inverseColoration={inverseColoration}>
+        <H5
+          $coloration={coloration}
+          $centered={centered}
+          $level={level}
+          $wrap={wrap}
+          $inverseColoration={inverseColoration}
+          $theme={theme}
+        >
           {children}
         </H5>
       );
     case 6:
       return (
-        <H6 $centered={centered} $level={level} $wrap={wrap} $inverseColoration={inverseColoration}>
+        <H6
+          $coloration={coloration}
+          $centered={centered}
+          $level={level}
+          $wrap={wrap}
+          $inverseColoration={inverseColoration}
+          $theme={theme}
+        >
           {children}
         </H6>
       );
     default:
       return (
-        <H3 $centered={centered} $level={level} $wrap={wrap} $inverseColoration={inverseColoration}>
+        <H3
+          $coloration={coloration}
+          $centered={centered}
+          $level={level}
+          $wrap={wrap}
+          $inverseColoration={inverseColoration}
+          $theme={theme}
+        >
           {children}
         </H3>
       );

--- a/packages/text/src/ui-label.tsx
+++ b/packages/text/src/ui-label.tsx
@@ -1,15 +1,35 @@
 'use client';
-import React from 'react';
+import React, { useContext } from 'react';
 
 import styled from 'styled-components';
 
-import { getColorCategory } from '@uireact/foundation';
+import { ColorTokens, ThemeColor, ThemeContext, getColorCategory, getThemeColor } from '@uireact/foundation';
 
 import { UiLabelProps, privateLabelProps } from './types';
 
 const Label = styled.label<privateLabelProps>`
   ${(props) => `
-    color: var(--${getColorCategory(props.$category)}-token_100);
+    ${
+      props.$coloration === 'dark'
+        ? `color: ${getThemeColor(
+            props.$theme,
+            ThemeColor.dark,
+            getColorCategory(props.$category),
+            ColorTokens.token_100
+          )};`
+        : ''
+    }
+    ${
+      props.$coloration === 'light'
+        ? `color: ${getThemeColor(
+            props.$theme,
+            ThemeColor.light,
+            getColorCategory(props.$category),
+            ColorTokens.token_100
+          )};`
+        : ''
+    }
+    ${!props.$coloration ? `color: var(--${getColorCategory(props.$category)}-token_100);` : ''}
     ${`font-size: var(--texts-${props.$size});`}
     ${`line-height: var(--texts-${props.$size});`}
   `}
@@ -18,10 +38,19 @@ const Label = styled.label<privateLabelProps>`
   margin: 0;
 `;
 
-export const UiLabel: React.FC<UiLabelProps> = ({ children, htmlFor, size = 'small', category }: UiLabelProps) => (
-  <Label $size={size} $category={category} htmlFor={htmlFor}>
-    {children}
-  </Label>
-);
+export const UiLabel: React.FC<UiLabelProps> = ({
+  children,
+  coloration,
+  htmlFor,
+  size = 'small',
+  category,
+}: UiLabelProps) => {
+  const { theme } = useContext(ThemeContext);
+  return (
+    <Label $size={size} $coloration={coloration} $category={category} htmlFor={htmlFor} $theme={theme}>
+      {children}
+    </Label>
+  );
+};
 
 UiLabel.displayName = 'UiLabel';

--- a/packages/text/src/ui-link.tsx
+++ b/packages/text/src/ui-link.tsx
@@ -1,16 +1,37 @@
 'use client';
-import React from 'react';
+import React, { useContext } from 'react';
 
 import styled from 'styled-components';
 
-import { getColorCategory } from '@uireact/foundation';
+import { ColorTokens, ThemeColor, ThemeContext, getColorCategory, getThemeColor } from '@uireact/foundation';
 
 import { UiLinkProps, privateLinkProps } from './types';
 
 const AnchorWrapper = styled.span<privateLinkProps>`
   > a {
     ${(props) => `
-      color: var(--${getColorCategory(props.$category)}-token_100);
+      ${
+        props.$coloration === 'dark'
+          ? `color: ${getThemeColor(
+              props.$theme,
+              ThemeColor.dark,
+              getColorCategory(props.$category),
+              ColorTokens.token_100
+            )};`
+          : ''
+      }
+      ${
+        props.$coloration === 'light'
+          ? `color: ${getThemeColor(
+              props.$theme,
+              ThemeColor.light,
+              getColorCategory(props.$category),
+              ColorTokens.token_100
+            )};`
+          : ''
+      }
+      ${!props.$coloration ? `color: var(--${getColorCategory(props.$category)}-token_100);` : ''}
+      
       font-size: var(--texts-${props.$size});
       line-height: var(--texts-${props.$size});
 
@@ -39,6 +60,7 @@ const AnchorWrapper = styled.span<privateLinkProps>`
 export const UiLink: React.FC<UiLinkProps> = ({
   category = 'tertiary',
   children,
+  coloration,
   handleClick,
   className,
   fullWidth,
@@ -46,19 +68,25 @@ export const UiLink: React.FC<UiLinkProps> = ({
   size = 'regular',
   testId,
   wrap,
-}: UiLinkProps) => (
-  <AnchorWrapper
-    $category={category}
-    $fullWidth={fullWidth}
-    $fontStyle={fontStyle}
-    onClick={handleClick}
-    className={className}
-    $size={size}
-    data-testid={testId}
-    $wrap={wrap}
-  >
-    {children}
-  </AnchorWrapper>
-);
+}: UiLinkProps) => {
+  const { theme } = useContext(ThemeContext);
+
+  return (
+    <AnchorWrapper
+      $category={category}
+      $coloration={coloration}
+      $fullWidth={fullWidth}
+      $fontStyle={fontStyle}
+      onClick={handleClick}
+      className={className}
+      $size={size}
+      data-testid={testId}
+      $wrap={wrap}
+      $theme={theme}
+    >
+      {children}
+    </AnchorWrapper>
+  );
+};
 
 UiLink.displayName = 'UiLink';

--- a/packages/text/src/ui-text.tsx
+++ b/packages/text/src/ui-text.tsx
@@ -1,9 +1,16 @@
 'use client';
-import React from 'react';
+import React, { useContext } from 'react';
 
 import styled, { css } from 'styled-components';
 
-import { getColorCategory } from '@uireact/foundation';
+import {
+  ColorCategories,
+  ColorTokens,
+  ThemeColor,
+  ThemeContext,
+  getColorCategory,
+  getThemeColor,
+} from '@uireact/foundation';
 
 import { UiTextProps, privateTextProps } from './types';
 
@@ -18,7 +25,22 @@ const SharedStyle = css<privateTextProps>`
     ${props.$fontStyle === 'light' ? `font-weight: 300;` : ''}
     ${props.$fontStyle === 'regular' ? `font-weight: normal;` : ''}
 
-    color: var(--${props.$inverseColoration ? 'inverse-' : ''}${getColorCategory(props.$category)}-token_100);
+    ${
+      props.$coloration === 'dark'
+        ? `color: ${getThemeColor(props.$theme, ThemeColor.dark, ColorCategories.fonts, ColorTokens.token_100)};`
+        : ''
+    }
+    ${
+      props.$coloration === 'light'
+        ? `color: ${getThemeColor(props.$theme, ThemeColor.light, ColorCategories.fonts, ColorTokens.token_100)};`
+        : ''
+    }
+    ${
+      !props.$coloration
+        ? `color: var(--${props.$inverseColoration ? 'inverse-' : ''}${getColorCategory(props.$category)}-token_100);`
+        : ''
+    }
+    
     padding: 0;
     margin: 0;
 
@@ -46,6 +68,7 @@ export const UiText: React.FC<UiTextProps> = ({
   children,
   className,
   centered,
+  coloration,
   inline,
   fontStyle,
   size = 'regular',
@@ -53,6 +76,8 @@ export const UiText: React.FC<UiTextProps> = ({
   inverseColoration,
   wrap,
 }: UiTextProps) => {
+  const { theme } = useContext(ThemeContext);
+
   if (inline) {
     return (
       <Span
@@ -64,7 +89,9 @@ export const UiText: React.FC<UiTextProps> = ({
         $centered={centered}
         $inline={inline}
         $inverseColoration={inverseColoration}
+        $coloration={coloration}
         $wrap={wrap}
+        $theme={theme}
       >
         {children}
       </Span>
@@ -81,7 +108,9 @@ export const UiText: React.FC<UiTextProps> = ({
       $centered={centered}
       $inline={inline}
       $inverseColoration={inverseColoration}
+      $coloration={coloration}
       $wrap={wrap}
+      $theme={theme}
     >
       {children}
     </Text>


### PR DESCRIPTION
## 🔥 Default coloration to typography
----------------------------------------------

### Description
Adding a prop to default typography elements to a default coloration, there are use cases when the text elements benefit from having a static coloration even when theme changes so this allows for that flexibility.

### Screenshots

#### Before
![Mar-16-2024 00-39-04](https://github.com/inavac182/uireact/assets/16787893/833222a1-c229-46f7-b0fc-08db077e8db8)

#### After
![Mar-16-2024 00-38-19](https://github.com/inavac182/uireact/assets/16787893/7c06cce2-f651-4e22-b53e-05e3ca77d531)

