### PR TITLE
feat: adding notifications callbacks

### DIFF
--- a/packages/foundation/src/hooks/use-viewport.ts
+++ b/packages/foundation/src/hooks/use-viewport.ts
@@ -1,5 +1,6 @@
 import { useWindowDimensions } from './use-window-dimensions';
 import { BreakpointsSizes } from '../responsive/breakpoints-sizes';
+import { useEffect, useMemo, useState } from 'react';
 
 export type useViewportResponse = {
   isSmall: boolean;
@@ -10,16 +11,33 @@ export type useViewportResponse = {
 
 export const useViewport = (): useViewportResponse => {
   const { width } = useWindowDimensions();
+  const [hydratred, setHydrated] = useState(false);
+  const viewportResponse = useMemo((): useViewportResponse => {
+    const isSmall = width <= BreakpointsSizes.s.max;
+    const isMedium = width >= BreakpointsSizes.m.min && width <= BreakpointsSizes.m.max;
+    const isLarge = width >= BreakpointsSizes.l.min && width <= BreakpointsSizes.l.max;
+    const isXLarge = width >= BreakpointsSizes.xl.min;
 
-  const isSmall = width <= BreakpointsSizes.s.max;
-  const isMedium = width >= BreakpointsSizes.m.min && width <= BreakpointsSizes.m.max;
-  const isLarge = width >= BreakpointsSizes.l.min && width <= BreakpointsSizes.l.max;
-  const isXLarge = width >= BreakpointsSizes.xl.min;
+    return {
+      isSmall,
+      isMedium,
+      isLarge,
+      isXLarge,
+    };
+  }, [width]);
+
+  useEffect(() => {
+    setHydrated(true);
+  }, []);
+
+  if (hydratred) {
+    return viewportResponse;
+  }
 
   return {
-    isSmall,
-    isMedium,
-    isLarge,
-    isXLarge,
+    isSmall: false,
+    isMedium: false,
+    isLarge: true,
+    isXLarge: false,
   };
 };

--- a/packages/foundation/src/responsive/viewport.tsx
+++ b/packages/foundation/src/responsive/viewport.tsx
@@ -1,3 +1,4 @@
+'use client';
 import * as React from 'react';
 
 import { Breakpoints } from '../types';

--- a/packages/foundation/src/types/notifications.ts
+++ b/packages/foundation/src/types/notifications.ts
@@ -29,4 +29,10 @@ export type UiNotificationOptions = {
   timer?: number;
   /** If the close button should render */
   closeButton?: boolean;
+  /** Triggers callback when link is clicked */
+  onLinkClicked?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
+  /** Triggers callback when notification is shown */
+  onNotificationShown?: () => void;
+  /** Triggers callback when notification is dismissed */
+  onNotificationDismissed?: () => void;
 };

--- a/packages/notifications/__tests__/ui-notifications.spec.tsx
+++ b/packages/notifications/__tests__/ui-notifications.spec.tsx
@@ -79,13 +79,24 @@ describe('<UiNotifications />', () => {
   });
 
   it('delete notification when close button is used', () => {
-    uiRender(<NotificationsExample />);
+    const onNotificationDismissed = jest.fn();
+    const onNotificationShown = jest.fn();
+
+    uiRender(
+      <NotificationsExample
+        onNotificationDismissed={onNotificationDismissed}
+        onNotificationShown={onNotificationShown}
+      />
+    );
 
     fireEvent.click(screen.getByRole('button', { name: 'Notification with link' }));
 
     expect(screen.getByRole('heading', { name: 'Notification with link' })).toBeVisible();
 
     fireEvent.click(screen.getByTestId('notification-close-button'));
+
+    expect(onNotificationDismissed).toHaveBeenCalledTimes(1);
+    expect(onNotificationShown).toHaveBeenCalledTimes(1);
 
     expect(screen.queryByRole('heading', { name: 'Notification with link' })).not.toBeInTheDocument();
   });

--- a/packages/notifications/docs/example/notifications-example.tsx
+++ b/packages/notifications/docs/example/notifications-example.tsx
@@ -1,4 +1,4 @@
-import React, { useCallback } from 'react';
+import React, { useCallback, useEffect } from 'react';
 
 import { UiButton } from '@uireact/button';
 import { UiText } from '@uireact/text';
@@ -10,7 +10,17 @@ import { UiSpacing, UiSpacingProps } from '@uireact/foundation';
 
 const buttonContentPadding: UiSpacingProps['padding'] = { block: 'four' };
 
-export const NotificationsExample: React.FC = () => {
+type NotificationsExampleProps = {
+  onNotificationShown?: () => void;
+  onNotificationDismissed?: () => void;
+  onLinkClicked?: (event: React.MouseEvent<HTMLAnchorElement>) => void;
+};
+
+export const NotificationsExample: React.FC<NotificationsExampleProps> = ({
+  onNotificationShown,
+  onNotificationDismissed,
+  onLinkClicked,
+}: NotificationsExampleProps) => {
   const { showNotification } = useNotifications();
 
   const addNotification = useCallback(() => {
@@ -29,6 +39,11 @@ export const NotificationsExample: React.FC = () => {
       link: {
         label: 'Ui React docs',
         url: 'https://uireact.io',
+      },
+      options: {
+        onNotificationShown,
+        onNotificationDismissed,
+        onLinkClicked,
       },
     });
   }, [showNotification]);

--- a/packages/notifications/src/private/ui-notiication.tsx
+++ b/packages/notifications/src/private/ui-notiication.tsx
@@ -44,6 +44,9 @@ export const UiNotificationWrapper: React.FC<UiNotificationProps> = ({
       category: notification.options?.category || 'primary',
       closeButton: notification.options?.closeButton !== undefined ? notification.options.closeButton : true,
       timer: notification.options?.timer !== undefined ? notification.options.timer : 5000,
+      onLinkClicked: notification.options?.onLinkClicked,
+      onNotificationDismissed: notification.options?.onNotificationDismissed,
+      onNotificationShown: notification.options?.onNotificationShown,
     };
   }, [notification]);
 
@@ -59,9 +62,14 @@ export const UiNotificationWrapper: React.FC<UiNotificationProps> = ({
     return () => clearTimeout(timer);
   }, [onClose]);
 
+  useEffect(() => {
+    options.onNotificationShown?.();
+  }, [options]);
+
   const closeNotification = useCallback(() => {
+    options.onNotificationDismissed?.();
     onClose(id);
-  }, [onClose]);
+  }, [onClose, options]);
 
   return (
     <>
@@ -82,7 +90,7 @@ export const UiNotificationWrapper: React.FC<UiNotificationProps> = ({
                 {notification.message && <UiText>{notification.message}</UiText>}
                 {notification.link && (
                   <UiLink>
-                    <a href={notification.link.url} target={notification.link.target}>
+                    <a href={notification.link.url} target={notification.link.target} onClick={options.onLinkClicked}>
                       {notification.link.label}
                     </a>
                   </UiLink>


### PR DESCRIPTION
## 🔥 Notifications callbacks and viewport logic
----------------------------------------------

### Description
- Adding notification callbacks as there are use cases were we want to track when notifications are shown, dismissed or clicked.
- Also updating the viewports logic to re-render on the client when hydrated to retrieve latest client width


### Screenshots

#### Before
N/A

#### After
N/A