### PR TITLE
fix(validator): numeric comparison with stringified value

### DIFF
--- a/packages/validator/__tests__/ui-validator-greater-than.spec.ts
+++ b/packages/validator/__tests__/ui-validator-greater-than.spec.ts
@@ -16,6 +16,19 @@ describe('greaterThan validation', () => {
     expect(result.errors).toStrictEqual({});
   });
 
+  it('Should validate when value is string and is greater than baseline', () => {
+    const schema = {
+      test: validator.ruler().greaterThan(10),
+    };
+    const data = {
+      test: "11",
+    };
+
+    const result = validator.validate(schema, data, false);
+    expect(result.passed).toBeTruthy();
+    expect(result.errors).toStrictEqual({});
+  });
+
   it('Should use default messaging if none is passed in schema', () => {
     const schema = {
       test: validator.ruler().greaterThan(10),

--- a/packages/validator/src/ui-validator.ts
+++ b/packages/validator/src/ui-validator.ts
@@ -137,13 +137,14 @@ export class UiValidator {
    * @param value The value that will be compared
    * */
   private validComparable(baseline: number | Date, value: unknown, action: 'greaterThan' | 'lessThan'): boolean {
-    if (typeof baseline === 'number' && typeof value === 'number') {
+    if (typeof baseline === 'number' && (typeof value === 'number' || typeof value === 'string')) {
       /** Numeric comparisson */
+      const parsedValued = parseInt(value as string);
 
       if (action === 'greaterThan') {
-        return value > baseline;
+        return parsedValued > baseline;
       } else {
-        return value < baseline;
+        return parsedValued < baseline;
       }
     } else if (baseline instanceof Date) {
       /** Date comparisson */


### PR DESCRIPTION
## 🔥 Fix numeric comparison validator
----------------------------------------------

### Description
The numeric comparison is not working properly when passing a stringified value, with this change this will be fixed and now passing a stringified value will correctly be compared with the values number.

### Screenshots
N/A