### PR TITLE
feat(view): skip font name prop

### DIFF
--- a/apps/docs/src/app/create-theme/fonts/page.tsx
+++ b/apps/docs/src/app/create-theme/fonts/page.tsx
@@ -59,6 +59,8 @@ p {
 }
                     `}
                 </Pre>
+                <UiText fontStyle="bold"><UiIcon icon="Info" /> If you are using a framework that preloads fonts like NextJS, then you can SHOULD use prop `skipFontName` in UiView.</UiText>
+                <br />
                 <FontNameForm />
                 <br />
                 <FontColor />

--- a/apps/docs/src/app/create-theme/fonts/page.tsx
+++ b/apps/docs/src/app/create-theme/fonts/page.tsx
@@ -59,7 +59,7 @@ p {
 }
                     `}
                 </Pre>
-                <UiText fontStyle="bold"><UiIcon icon="Info" /> If you are using a framework that preloads fonts like NextJS, then you can SHOULD use prop `skipFontName` in UiView.</UiText>
+                <UiText fontStyle="bold"><UiIcon icon="Info" /> If you are using a framework that preloads fonts like NextJS, then you SHOULD use prop `skipFontName` in UiView.</UiText>
                 <br />
                 <FontNameForm />
                 <br />

--- a/apps/docs/src/app/hero-section/hero-components/hero-message.tsx
+++ b/apps/docs/src/app/hero-section/hero-components/hero-message.tsx
@@ -9,7 +9,7 @@ const HeroHeading = styled.h1`
   text-align: center;
   font-size: 36px;
   margin: 0 auto;
-  font-family: "Press Start 2P", system-ui;
+  font-family: var(--press-start-font-family);
   color: #e0dede;
 
   @media screen and (max-width: 500px) {
@@ -20,6 +20,7 @@ const HeroHeading = styled.h1`
 const HeroLetter = styled(motion.span)`
   display: inline-block;
   color: var(--tertiary-token_100);
+  font-family: var(--press-start-font-family);
 
   @media screen and (max-width: '500px') {
     font-size: 10px;
@@ -31,7 +32,6 @@ const HeroLettersContainer = styled.div`
   font-size: 48px;
   font-weight: bold;
   margin: 50px auto;
-  font-family: "Press Start 2P", system-ui;
 
   @media screen and (max-width: 500px) {
     font-size: 18px;

--- a/apps/docs/src/app/internal/script-card.tsx
+++ b/apps/docs/src/app/internal/script-card.tsx
@@ -18,7 +18,7 @@ export const ScriptCardContainer = styled(motion.div)`
 `;
 
 export const ScriptSpan = styled(motion.span)`
-  font-family: "Press Start 2P", system-ui;
+  font-family: var(--press-start-font-family);
   text-wrap: wrap;
   font-size: 10px;
   cursor: pointer;
@@ -37,7 +37,7 @@ export const ScriptCard = ({ script }: ScriptCardProps) => {
     <ScriptCardContainer whileHover={{ scale: 1.2 }} whileTap={{ scale: 0.8 }} onClick={onScriptClick}>
       <UiFlexGrid direction='row' columnGap='four' alignItems='center'>
         <UiIcon icon="AngleSquareRight" />
-        <span>{script}</span>
+        <ScriptSpan>{script}</ScriptSpan>
       </UiFlexGrid>
     </ScriptCardContainer>
   )

--- a/apps/docs/src/app/layout.tsx
+++ b/apps/docs/src/app/layout.tsx
@@ -1,4 +1,5 @@
 import type { Metadata } from "next";
+import { Press_Start_2P, Sen } from 'next/font/google'
 
 import { ViewWrapper } from "@/lib/page-wrapper";
 import { StyledComponentsRegistry } from "@/lib/styled-components-registry";
@@ -12,6 +13,10 @@ export const metadata: Metadata = {
   keywords: 'uireact, react, js, nodejs, react js, themed components, react components, react library, ui react library, dark theme react ui library, light theme react ui library '
 };
 
+const sen = Sen({ subsets: ['latin'], variable: '--font-family' });
+
+const pressStart = Press_Start_2P({ variable: '--press-start-font-family', style: 'normal', weight: '400', subsets: ['latin'] });
+
 export default function RootLayout({
   children,
 }: Readonly<{
@@ -19,15 +24,8 @@ export default function RootLayout({
 }>) {
   return (
     <html lang="en" className={styles.globalStyles}>
-      <head>
-        <link rel="preconnect" href="https://fonts.googleapis.com" />
-        <link rel="preconnect" href="https://fonts.gstatic.com" />
-        <link
-          href="https://fonts.googleapis.com/css2?family=Sen:wght@400;500;600;700;800&family=Press+Start+2P&display=swap"
-          rel="stylesheet"
-        />
-      </head>
-      <body>
+      <head />
+      <body className={`${sen.variable} ${pressStart.variable}`}>
         <StyledComponentsRegistry>
           <DocsThemeProvider>
             <ViewWrapper>

--- a/apps/docs/src/lib/page-wrapper.tsx
+++ b/apps/docs/src/lib/page-wrapper.tsx
@@ -15,7 +15,7 @@ export const ViewWrapper = ({ children }: ViewWrapperProps) => {
   const { selectedTheme } = useContext(DocsThemeContext);
 
   return (
-    <UiView theme={DocsTheme} selectedTheme={selectedTheme} noBackground className="viewWrapper">
+    <UiView theme={DocsTheme} selectedTheme={selectedTheme} noBackground className="viewWrapper" skipFontName>
       {children}
     </UiView>
   );

--- a/packages/view/__tests__/ui-view.spec.tsx
+++ b/packages/view/__tests__/ui-view.spec.tsx
@@ -13,6 +13,7 @@ type MockedComponentProps = {
   noBackground?: boolean;
   selectedTheme?: ThemeColor;
   skipThemeDetector?: boolean;
+  skipFontName?: boolean;
 };
 
 const closeDialogMockedFn = jest.fn();
@@ -48,6 +49,7 @@ const MockedComponent = (props: MockedComponentProps) => (
     centeredContent={props.centeredContent}
     noBackground={props.noBackground}
     skipThemeDetector={props.skipThemeDetector}
+    skipFontName={props.skipFontName}
   >
     <p>Content</p>
     <DialogComponent />
@@ -96,6 +98,12 @@ describe('<UiView />', () => {
 
   it('renders fine with skip theme detector', () => {
     render(<MockedComponent  skipThemeDetector selectedTheme={ThemeColor.light} />);
+
+    expect(screen.getByText('Content')).toBeVisible();
+  });
+
+  it('renders fine with skip font name', () => {
+    render(<MockedComponent selectedTheme={ThemeColor.light} skipFontName />);
 
     expect(screen.getByText('Content')).toBeVisible();
   });

--- a/packages/view/docs/page.mdx
+++ b/packages/view/docs/page.mdx
@@ -28,20 +28,60 @@ This doc page is wrapped in a `< UiView />` component
 This is an example of our wrapper:
 
 ```jsx
-export const ViewExample: React.FC = () => {
-  const [selectedTheme, setTheme] = React.useState<ThemeColor>(ThemeColor.light);
-  const toogleTheme = () => {
-    setTheme(selectedTheme === ThemeColor.light ? ThemeColor.dark : ThemeColor.light);
-  };
-
-  return (
-    <UiView theme={DefaultTheme} selectedTheme={selectedTheme}>
-      <p>All the react tree should render inside here</p>
-      <UiButton onClick={toogleTheme}>Toggle theme</UiButton>
-    </UiView>
-  );
-};
+export const ViewExample: React.FC = () => (
+  <UiView theme={DefaultTheme}>
+    <p>All the react tree should render inside here</p>
+  </UiView>
+);
 ```
+By default, the `<UiView />` component will attach an event listener to the user's appearance selector. Meaning that they could control their
+theme through their device theme settings.
+
+### NextJS - Fonts optimized frameworks
+
+There are frameworks such as NextJS that [optimizes the font loading](https://nextjs.org/docs/app/building-your-application/optimizing/fonts), when you use this frameworks
+ you should rely on them for font loading, so the suggestion is to assign your main font to the `--font-name` variable, so all components
+ in the library can reference to it.  
+
+For example for NextJS this would look like:
+
+app/layout.tsx:
+
+```tsx
+
+import { Sen } from 'next/font/google'
+
+const sen = Sen({ subsets: ['latin'], variable: '--font-family' }); // Very IMPORTANT, variable should be --font-family.
+
+export default function RootLayout({
+  children,
+}: Readonly<{
+  children: React.ReactNode;
+}>) {
+  return (
+    <html lang="en">
+      <head />
+      <body className={sen.variable}> {/** Make sure the variable is used on the class name */}
+        <StyledComponentsRegistry>
+          <ViewWrapper>
+            {children}
+          </ViewWrapper>
+        </StyledComponentsRegistry>
+      </body>
+    </html>
+  );
+}
+
+```
+Once that is set up you can then use `skipFontName` prop on UiView component:
+
+```tsx
+  <UiView theme={DefaultTheme} skipFontName>
+      {...content...}
+  </UiView>
+```
+
+If you used the automatic script to create your NextJS application, the generated project already handles this font set up.
 
 ### UiViewRow
 

--- a/packages/view/src/types/ui-view-props.ts
+++ b/packages/view/src/types/ui-view-props.ts
@@ -12,6 +12,8 @@ export type UiViewProps = {
   noBackground?: boolean;
   /** Disables the theme detector for user's device */
   skipThemeDetector?: boolean;
+  /** Skips font name style rule, useful for frameworks that handle font installation like NextJS */
+  skipFontName?: boolean;
 } & UiReactElementProps;
 
 export type UiViewRowProps = {

--- a/packages/view/src/ui-view.tsx
+++ b/packages/view/src/ui-view.tsx
@@ -31,6 +31,7 @@ import {
 } from './__private';
 import { useThemeDetector } from './hooks';
 
+/* istanbul ignore next */
 const GlobalStyle = createGlobalStyle<{ $customTheme: Theme, $skipFontName?: boolean }>`
   * {
     margin: 0;

--- a/packages/view/src/ui-view.tsx
+++ b/packages/view/src/ui-view.tsx
@@ -31,7 +31,7 @@ import {
 } from './__private';
 import { useThemeDetector } from './hooks';
 
-const GlobalStyle = createGlobalStyle<{ $customTheme: Theme }>`
+const GlobalStyle = createGlobalStyle<{ $customTheme: Theme, $skipFontName?: boolean }>`
   * {
     margin: 0;
     padding: 0;
@@ -45,7 +45,7 @@ const GlobalStyle = createGlobalStyle<{ $customTheme: Theme }>`
     ${DarkThemeStyleVariables}
     ${SizesVariables}
     ${SpacingVariables}
-    ${FontFamilyVariable}
+    ${props => !props.$skipFontName ? FontFamilyVariable : ''}
   }
 
   html.light {
@@ -60,10 +60,13 @@ const GlobalStyle = createGlobalStyle<{ $customTheme: Theme }>`
     font-weight: 400;
     width: 100%;
   }
+
+  a,p,span,label,input,select,button,h1,h2,h3,h4,h5,h6 {
+    font-family: var(--font-family);
+  }
 `;
 
 const Div = styled.div<privateViewProps>`
-  font-family: var(--font-family);
   font-size: var(--texts-regular);
   background-color: ${(props) => (props.$noBackground ? 'transparent' : 'var(--primary-token_100)')};
   transition: background 0.2s;
@@ -77,7 +80,8 @@ export const UiView: React.FC<UiViewProps> = ({
   selectedTheme,
   children,
   noBackground = false,
-  skipThemeDetector
+  skipThemeDetector,
+  skipFontName
 }: UiViewProps) => {
   const defaultDialogController = useDialogController();
   const notificationsController = useNotificationsController();
@@ -111,7 +115,7 @@ export const UiView: React.FC<UiViewProps> = ({
 
   return (
     <>
-      <GlobalStyle $customTheme={theme} />
+      <GlobalStyle $customTheme={theme} $skipFontName={skipFontName} />
       <Div className={className} data-testid="UiView" $noBackground={noBackground}>
         <ThemeContext.Provider value={{ theme, selectedTheme: internalSelectedTheme }}>
           <UiDialogsControllerContext.Provider value={dialogController ?? defaultDialogController}>

--- a/turbo.json
+++ b/turbo.json
@@ -46,8 +46,9 @@
     },
     "watch": {
       "dependsOn": ["^watch"],
+      "outputs": ["dist/**"],
       "persistent": true,
-      "cache": false
+      "cache": true
     }
   }
 }


### PR DESCRIPTION
## 🔥 Adding skip font name prop
----------------------------------------------

### Description
This prop will be useful when using a framework that controls the font preloading and import such as NextJS. As the framework is capable of installing and generating its own CSS variable.

### Screenshots
N/A
