### PR TITLE
feat(table): adding sort and react node support

### DIFF
--- a/packages/table/__tests__/private/get-filtered-data.spec.tsx
+++ b/packages/table/__tests__/private/get-filtered-data.spec.tsx
@@ -1,0 +1,96 @@
+import React from 'react';
+
+import { UiText } from '@uireact/text';
+
+import { getFilteredData } from '../../src/private';
+import { UiTableData } from '../../src/types';
+
+const mockedStringData: UiTableData = {
+    headings: [],
+    items: [
+        {
+            id: 'item-1',
+            cols: [
+                'item 1'
+            ]
+        },
+        {
+            id: 'item-2',
+            cols: [
+                'item 2'
+            ]
+        }
+    ]
+}
+
+const mockedNumberData: UiTableData = {
+    headings: [],
+    items: [
+        {
+            id: 'item-1',
+            cols: [
+                2
+            ]
+        },
+        {
+            id: 'item-2',
+            cols: [
+                1
+            ]
+        },
+        {
+            id: 'item-3',
+            cols: [
+                2
+            ]
+        }
+    ]
+}
+
+const mockedReactNodeData: UiTableData = {
+    headings: [],
+    items: [
+        {
+            id: 'item-1',
+            cols: [
+                <UiText key="1">Some text</UiText>
+            ]
+        },
+        {
+            id: 'item-2',
+            cols: [
+                <UiText key="2">Some text</UiText>
+            ]
+        },
+    ]
+}
+
+
+describe('getFilteredData', () => {
+    describe('When items are string', () => {
+        it('Should filter data', () => {
+            const filteredData = getFilteredData(mockedStringData.items, 'item 1');
+
+            expect(filteredData).toHaveLength(1);
+            expect(filteredData[0].id).toBe('item-1');
+        });    
+    });
+
+    describe('When items are number', () => {
+        it('Should filter data', () => {
+            const filteredData = getFilteredData(mockedNumberData.items, '2');
+
+            expect(filteredData).toHaveLength(2);
+            expect(filteredData[0].id).toBe('item-1'); // Value 2
+            expect(filteredData[1].id).toBe('item-3'); // Value 2
+        });    
+    });
+
+    describe('When items are React nodes', () => {
+        it('Should filter all data as react nodes can not be compared', () => {
+            const filteredData = getFilteredData(mockedReactNodeData.items, 'Nothing');
+
+            expect(filteredData).toHaveLength(0);
+        });    
+    });
+});

--- a/packages/table/__tests__/private/get-sorted-data.spec.tsx
+++ b/packages/table/__tests__/private/get-sorted-data.spec.tsx
@@ -1,0 +1,118 @@
+import React from 'react';
+
+import { UiText } from '@uireact/text';
+
+import { getSortedData } from '../../src/private';
+import { UiTableData } from '../../src/types';
+
+const mockedStringData: UiTableData = {
+    headings: [],
+    items: [
+        {
+            id: 'item-1',
+            cols: [
+                'item 1'
+            ]
+        },
+        {
+            id: 'item-2',
+            cols: [
+                'item 2'
+            ]
+        }
+    ]
+}
+
+const mockedNumberData: UiTableData = {
+    headings: [],
+    items: [
+        {
+            id: 'item-1',
+            cols: [
+                2
+            ]
+        },
+        {
+            id: 'item-2',
+            cols: [
+                1
+            ]
+        },
+        {
+            id: 'item-3',
+            cols: [
+                2
+            ]
+        }
+    ]
+}
+
+const mockedReactNodeData: UiTableData = {
+    headings: [],
+    items: [
+        {
+            id: 'item-1',
+            cols: [
+                <UiText key="1">Some text</UiText>
+            ]
+        },
+        {
+            id: 'item-2',
+            cols: [
+                <UiText key="2">Some text</UiText>
+            ]
+        },
+    ]
+}
+
+describe('getSortedData', () => {
+    it('Should return the same order when cols index is null', () => {
+        const result = getSortedData(mockedStringData.items, 'DOWN', null);
+    
+        expect(result[0].id).toBe('item-1');
+        expect(result[1].id).toBe('item-2');
+    });
+
+    describe('When cols are string', () => {
+        it('Should sort data when orientation is upwards', () => {
+            const result = getSortedData(mockedStringData.items, 'UP', 0);
+    
+            expect(result[0].id).toBe('item-1');
+            expect(result[1].id).toBe('item-2');
+        });
+    
+        it('Should sort data when orientation is downwards', () => {
+            const result = getSortedData(mockedStringData.items, 'DOWN', 0);
+    
+            expect(result[0].id).toBe('item-2');
+            expect(result[1].id).toBe('item-1');
+        });
+    });
+
+    describe('When cols are number', () => {
+        it('Should sort data when orientation is upwards', () => {
+            const result = getSortedData(mockedNumberData.items, 'UP', 0);
+    
+            expect(result[0].id).toBe('item-2'); // value 1
+            expect(result[1].id).toBe('item-1'); // value 2
+            expect(result[2].id).toBe('item-3'); // value 2
+        });
+    
+        it('Should sort data when orientation is downwards', () => {
+            const result = getSortedData(mockedNumberData.items, 'DOWN', 0);
+    
+            expect(result[0].id).toBe('item-1'); // value 2
+            expect(result[1].id).toBe('item-3'); // value 2
+            expect(result[2].id).toBe('item-2'); // value 1
+        });
+    });
+
+    describe('When cols are React Node', () => {
+        it('Should get same order as can not compare react nodes', () => {
+            const result = getSortedData(mockedReactNodeData.items, 'DOWN', 0);
+    
+            expect(result[0].id).toBe('item-1');
+            expect(result[1].id).toBe('item-2');
+        });
+    });
+});

--- a/packages/table/__tests__/ui-table.spec.tsx
+++ b/packages/table/__tests__/ui-table.spec.tsx
@@ -10,8 +10,8 @@ describe('<Component />', () => {
   const data: UiTableData = {
     headings: ['id', 'summary'],
     items: [
-      { id: '1', cols: ['1', 'summary 1'] },
-      { id: '2', cols: ['2', 'summary 2'] },
+      { id: '1', cols: [1, 'summary 1'] },
+      { id: '2', cols: [2, 'summary 2'] },
     ],
   };
 
@@ -21,6 +21,12 @@ describe('<Component />', () => {
     expect(screen.getByRole('table')).toBeVisible();
     expect(screen.getByRole('columnheader', { name: /id/i })).toBeVisible();
     expect(screen.getByRole('cell', { name: /summary 1/i })).toBeVisible();
+
+    expect(screen.getAllByTestId('sort-icon')).toHaveLength(2);
+    expect(screen.queryByTestId('sort-icon-up')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('sort-icon-down')).not.toBeInTheDocument();
+
+    expect(screen.getAllByTestId('sort-icon')[0]).toBeVisible();
 
     expect(screen.getByRole('textbox')).toBeVisible();
   });
@@ -43,6 +49,17 @@ describe('<Component />', () => {
     expect(screen.getByRole('cell', { name: /summary 1/i })).toBeVisible();
 
     expect(screen.queryByRole('textbox')).not.toBeInTheDocument();
+  });
+
+  it('renders fine without sort', () => {
+    uiRender(<UiTable data={data} withSort={false} />);
+
+    expect(screen.getByRole('table')).toBeVisible();
+    expect(screen.getByRole('columnheader', { name: /id/i })).toBeVisible();
+    expect(screen.getByRole('cell', { name: /summary 1/i })).toBeVisible();
+
+    expect(screen.queryByTestId('sort-icon')).not.toBeInTheDocument();
+    expect(screen.getByRole('textbox')).toBeVisible();
   });
 
   it('renders fine with category', () => {
@@ -73,6 +90,79 @@ describe('<Component />', () => {
 
     expect(screen.getByRole('cell', { name: /summary 1/i })).toBeVisible();
     expect(screen.getByRole('cell', { name: /summary 2/i })).toBeVisible();
+  });
+
+  it('Sorts correctly and shows sort icon up when sorting upwards', () => {
+    uiRender(<UiTable data={data} />);
+
+    fireEvent.click(screen.getByText('summary'));
+
+    expect(screen.getByRole('cell', { name: /summary 1/i })).toBeVisible();
+    expect(screen.getByRole('cell', { name: /summary 2/i })).toBeVisible();
+
+    expect(screen.getAllByTestId('sort-icon')).toHaveLength(1);
+    expect(screen.getByTestId('sort-icon-up')).toBeVisible();
+    expect(screen.queryByTestId('sort-icon-down')).not.toBeInTheDocument();
+  });
+
+  it('Sorts correctly and shows sort icon down when sorting downwards', () => {
+    uiRender(<UiTable data={data} />);
+
+    //Clicking twice as 1 click is up sort, 2 click is down sort.
+
+    fireEvent.click(screen.getByText('summary'));
+    fireEvent.click(screen.getByText('summary'));
+
+    expect(screen.getByRole('cell', { name: /summary 1/i })).toBeVisible();
+    expect(screen.getByRole('cell', { name: /summary 2/i })).toBeVisible();
+
+    expect(screen.getAllByTestId('sort-icon')).toHaveLength(1);
+    expect(screen.queryByTestId('sort-icon-up')).not.toBeInTheDocument();
+    expect(screen.getByTestId('sort-icon-down')).toBeVisible();
+  });
+
+  it('Resets sort correctly when clicking on same heading after is sorting downwards', () => {
+    uiRender(<UiTable data={data} />);
+
+    //Clicking twice as 1 click is up sort, 2 click is down sort.
+
+    fireEvent.click(screen.getByText('summary'));
+    fireEvent.click(screen.getByText('summary'));
+    fireEvent.click(screen.getByText('summary'));
+
+    expect(screen.getByRole('cell', { name: /summary 1/i })).toBeVisible();
+    expect(screen.getByRole('cell', { name: /summary 2/i })).toBeVisible();
+
+    expect(screen.getAllByTestId('sort-icon')).toHaveLength(2);
+    expect(screen.queryByTestId('sort-icon-up')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('sort-icon-down')).not.toBeInTheDocument();
+  });
+
+  it('Sorts and filters correctly when used together', () => {
+    const data: UiTableData = {
+      headings: ['index', 'summary'],
+      items: [
+        { id: '1', cols: [1, 'summary'] },
+        { id: '2', cols: [2, 'summary'] },
+        { id: '3', cols: [3, 'something else'] },
+      ],
+    };
+
+    uiRender(<UiTable data={data} />);
+
+    expect(screen.getAllByRole('cell', { name: /summary/i })).toHaveLength(2);
+    expect(screen.getByRole('cell', { name: /something else/i })).toBeVisible();
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 'summary' } });
+
+    expect(screen.getAllByRole('cell', { name: /summary/i })).toHaveLength(2);
+    expect(screen.queryByRole('cell', { name: /something else/i })).not.toBeInTheDocument();
+
+    fireEvent.click(screen.getByText('index'));
+
+    expect(screen.getAllByRole('cell', { name: /summary/i })).toHaveLength(2);
+    expect(screen.queryByRole('cell', { name: /something else/i })).not.toBeInTheDocument();
+    expect(screen.getByTestId('sort-icon-up')).toBeVisible();
   });
 
   it('Executes onClick CB when row is selected and passes correct id', () => {

--- a/packages/table/docs/page.mdx
+++ b/packages/table/docs/page.mdx
@@ -1,4 +1,6 @@
 import { UiTable } from '@uireact/table';
+import { UiIcon } from '@uireact/icons';
+
 import packageJson from './package-metadata.json';
 import { Metadata } from '@uireact/docs-tools';
 
@@ -15,21 +17,24 @@ import { Metadata } from '@uireact/docs-tools';
 
 ## Usage
 
+The table will render the data as you pass it in the data prop, no sort / filter will be applied till the user interacts 
+with those elements.
+
 ```jsx live scope={{UiTable}}
   <UiTable
     data={{
       headings: ['No', 'Summary', 'Price'],
       items: [
-        { id: '1', cols: ['1', 'item 1', '$10'] },
-        { id: '2', cols: ['2', 'item 2', '$20'] },
-        { id: '3', cols: ['3', 'item 3', '$30'] },
-        { id: '4', cols: ['4', 'item 4', '$40'] },
-        { id: '5', cols: ['5', 'item 5', '$50'] },
-        { id: '6', cols: ['6', 'item 6', '$60'] },
-        { id: '7', cols: ['7', 'item 7', '$70'] },
-        { id: '8', cols: ['8', 'item 8', '$80'] },
-        { id: '9', cols: ['9', 'item 9', '$90'] },
-        { id: '10', cols: ['10', 'item 10', '$100'] },
+        { id: '1', cols: [1, 'item 1', '$10'] },
+        { id: '2', cols: [2, 'item 2', '$20'] },
+        { id: '3', cols: [3, 'item 3', '$30'] },
+        { id: '4', cols: [4, 'item 4', '$40'] },
+        { id: '5', cols: [5, 'item 5', '$50'] },
+        { id: '6', cols: [6, 'item 6', '$60'] },
+        { id: '7', cols: [7, 'item 7', '$70'] },
+        { id: '8', cols: [8, 'item 8', '$80'] },
+        { id: '9', cols: [9, 'item 9', '$90'] },
+        { id: '10', cols: [10, 'item 10', '$100'] },
       ],
     }}
     selected="3"
@@ -65,5 +70,34 @@ import { Metadata } from '@uireact/docs-tools';
     }}
     category="tertiary"
     filterBoxPosition="right"
+  />
+```
+
+### Removing filter and sort
+
+```jsx live scope={{UiTable}}
+  <UiTable
+    data={{
+      headings: ['Summary', 'Price'],
+      items: [{ id: '1', cols: ['item 1', '$10'] }],
+    }}
+    withFilter={false}
+    withSort={false}
+  />
+```
+
+### With a react component as part of the cols
+
+This is useful when you want to render a component in each of the elements.
+
+```jsx live scope={{UiTable, UiIcon}}
+  <UiTable
+    data={{
+      headings: ['Summary', 'Price', 'Actions'],
+      items: [
+        { id: '1', cols: ['item 1', '$10', <UiIcon icon="Edit" />] },
+        { id: '2', cols: ['item 2', '$20', <UiIcon icon="Edit" />] },
+      ]
+    }}
   />
 ```

--- a/packages/table/src/private/get-filtered-data.ts
+++ b/packages/table/src/private/get-filtered-data.ts
@@ -1,0 +1,19 @@
+import { UiTableItem } from "../types";
+
+export const getFilteredData = (items: UiTableItem[], filterPhrase: string) => {
+    const dataToFilter = [ ...items ];
+
+    const filteredData = dataToFilter.filter((field) => field.cols.filter((item) => {
+      if (typeof item === 'string') {
+        return item.includes(filterPhrase);
+      }
+
+      if (typeof item === 'number') {
+        return item.toString().includes(filterPhrase);
+      }
+
+      return false;
+    }).length > 0);
+
+    return filteredData;
+};

--- a/packages/table/src/private/get-sorted-data.ts
+++ b/packages/table/src/private/get-sorted-data.ts
@@ -1,0 +1,35 @@
+import { UiTableItem } from "../types";
+
+export const getSortedData = (items: UiTableItem[], orientation: 'UP' | 'DOWN', col: number | null) => {
+    if (col === null) {
+        return items;
+    }
+
+    const dataToSort = [ ...items ];
+
+    dataToSort.sort((fieldA, fieldB) => {
+      const colA = fieldA.cols[col];
+      const colB = fieldB.cols[col];
+
+      if ((
+          typeof colA === 'string' || 
+          typeof colA === 'number'
+        ) && (
+          typeof colB === 'string' || 
+          typeof colB === 'number'
+        )
+      ) {
+        if (colA > colB) {
+          return orientation === 'UP' ? 1 : -1;
+        }
+  
+        if (colA < colB) {
+          return orientation === 'UP' ? -1 : 1;
+        }
+      }
+
+      return 0;
+    });
+
+    return dataToSort;
+};

--- a/packages/table/src/private/index.ts
+++ b/packages/table/src/private/index.ts
@@ -1,1 +1,3 @@
 export * from './wrappers';
+export * from './get-filtered-data';
+export * from './get-sorted-data';

--- a/packages/table/src/private/wrappers.tsx
+++ b/packages/table/src/private/wrappers.tsx
@@ -17,9 +17,15 @@ export const Table = styled.table<privateTableProps>`
 `;
 
 export const TableHeadingCol = styled.th`
+  cursor: pointer;
   text-align: center;
   padding-top: 10px;
   padding-bottom: 10px;
+  color: var(--fonts-token_100);
+
+  &:hover {
+    color: var(--fonts-token_200);
+  }
 `;
 
 export const TableCol = styled.td`
@@ -49,4 +55,9 @@ export const TableRow = styled.tr<privateTableRowProps>`
         : ''
     }
   `}
+`;
+
+export const CaretsWrapper = styled.span`
+    display: inline-block;
+    width: var(--texts-regular);
 `;

--- a/packages/table/src/types/ui-table-data.ts
+++ b/packages/table/src/types/ui-table-data.ts
@@ -8,6 +8,8 @@ export type UiTableData = {
 };
 
 export type UiTableItem = {
-  id: string;
-  cols: string[];
+  id: string | number;
+  cols: UiTableItemCol[];
 };
+
+export type UiTableItemCol = string | number | React.ReactNode;


### PR DESCRIPTION
## 🔥 Adding sort to UiTable and support for react nodes in columns
----------------------------------------------

### Description
Sometimes there are use cases when we would like to render some sort of component in a table row, so this adds the support for it.
Also enables the long awaited sort logic by clicking in the cell heading.

### Screenshots

#### Before
N/A

#### After
![May-28-2024 18-59-28](https://github.com/inavac182/uireact/assets/16787893/a8f6ddf4-4514-4d81-97f1-a5d78ce17673)
