### PR TITLE
feat(button): lighter colors for clear and outlined button

### DIFF
--- a/packages/button/__tests__/button.spec.tsx
+++ b/packages/button/__tests__/button.spec.tsx
@@ -63,7 +63,7 @@ describe('<UiButton />', () => {
     uiRender(<UiButton styling="clear">MyButton</UiButton>);
 
     expect(screen.getByRole('button')).toBeVisible();
-    expect(screen.getByRole('button')).toHaveClass('button buttonClear hover-bg-primary-100 active-bg-primary-200');
+    expect(screen.getByRole('button')).toHaveClass('button buttonClear hover-bg-primary-10 active-bg-primary-50 buttonRadius');
   });
 
   test('renders full height', () => {
@@ -176,6 +176,6 @@ describe('<UiButton />', () => {
     );
 
     expect(screen.getByRole('button', { name: 'Button' })).toBeVisible();
-    expect(screen.getByRole('button')).toHaveClass('button buttonOutlined border-primary-100 hover-bg-primary-100 active-bg-primary-200 color-primary-100 hover-color-primary-10');
+    expect(screen.getByRole('button')).toHaveClass('button buttonOutlined border-primary-100 hover-bg-primary-10 active-bg-primary-50 color-primary-100 hover-color-primary-100 buttonRadius');
   });
 });

--- a/packages/button/docs/page.mdx
+++ b/packages/button/docs/page.mdx
@@ -101,7 +101,7 @@ import { Metadata } from '@uireact/docs-tools';
 #### Clear button
 
 ```jsx live scope={{UiCard, UiFlexGrid, UiButton}}
-  <UiCard>
+  <UiCard category="primary">
     <UiFlexGrid gap="three">
       <UiButton category="tertiary" styling="clear" padding={{ all: 'three' }}>
         Button! ✨

--- a/packages/button/src/helpers/get-button-styling-classes.ts
+++ b/packages/button/src/helpers/get-button-styling-classes.ts
@@ -7,11 +7,11 @@ export const getButtonStylingClasses = (styling: 'filled' | 'clear' | 'icon' | '
     }
 
     if (styling === 'clear') {
-        return `${styles.buttonClear} hover-bg-${category}-100 active-bg-${category}-200`;
+        return `${styles.buttonClear} hover-bg-${category}-10 active-bg-${category}-50`;
     }
 
     if (styling === 'outlined') {
-        return `${styles.buttonOutlined} border-${category}-100 hover-bg-${category}-100 active-bg-${category}-200 color-${category}-100 hover-color-${category}-10`;
+        return `${styles.buttonOutlined} border-${category}-100 hover-bg-${category}-10 active-bg-${category}-50 color-${category}-100 hover-color-${category}-100`;
     }
 
     return `bg-${category}-100 border-${category}-150 hover-bg-${category}-150 active-bg-${category}-200`;


### PR DESCRIPTION
## 🔥 Using lighter colors for clear and outlined button
----------------------------------------------

### Description
The clear and outlined buttons use normal coloration although as they start on a clear bg the change seems to be very aggressive, lighting the colors a bit looks better.

### Screenshots

#### Before
<img width="176" alt="Screenshot 2024-06-05 at 10 29 11 AM" src="https://github.com/inavac182/uireact/assets/16787893/495ecd87-120c-451a-bc45-a1e7a53567b6">

#### After
<img width="138" alt="Screenshot 2024-06-05 at 10 29 23 AM" src="https://github.com/inavac182/uireact/assets/16787893/3d2a8e73-1471-4c6c-98bd-30a318054ee1">

