### PR TITLE
feat(table): making table heading an object

### DIFF
--- a/packages/table/__tests__/ui-table.spec.tsx
+++ b/packages/table/__tests__/ui-table.spec.tsx
@@ -8,7 +8,7 @@ import { UiTableData } from '../src/types';
 
 describe('<Component />', () => {
   const data: UiTableData = {
-    headings: ['id', 'summary'],
+    headings: [{ label: 'id' }, { label: 'summary' }],
     items: [
       { id: '1', cols: [1, 'summary 1'] },
       { id: '2', cols: [2, 'summary 2'] },
@@ -17,6 +17,23 @@ describe('<Component />', () => {
 
   it('renders fine', () => {
     uiRender(<UiTable data={data} />);
+
+    expect(screen.getByRole('table')).toBeVisible();
+    expect(screen.getByRole('columnheader', { name: /id/i })).toBeVisible();
+    expect(screen.getByRole('cell', { name: /summary 1/i })).toBeVisible();
+
+    expect(screen.getAllByTestId('sort-icon')).toHaveLength(2);
+    expect(screen.queryByTestId('sort-icon-up')).not.toBeInTheDocument();
+    expect(screen.queryByTestId('sort-icon-down')).not.toBeInTheDocument();
+
+    expect(screen.getAllByTestId('sort-icon')[0]).toBeVisible();
+
+    expect(screen.getByRole('textbox')).toBeVisible();
+  });
+
+  
+  it('renders fine with styling', () => {
+    uiRender(<UiTable data={data} bordered />);
 
     expect(screen.getByRole('table')).toBeVisible();
     expect(screen.getByRole('columnheader', { name: /id/i })).toBeVisible();
@@ -140,7 +157,7 @@ describe('<Component />', () => {
 
   it('Sorts and filters correctly when used together', () => {
     const data: UiTableData = {
-      headings: ['index', 'summary'],
+      headings: [{ label: 'index' }, { label: 'summary' }],
       items: [
         { id: '1', cols: [1, 'summary'] },
         { id: '2', cols: [2, 'summary'] },

--- a/packages/table/docs/page.mdx
+++ b/packages/table/docs/page.mdx
@@ -22,8 +22,9 @@ with those elements.
 
 ```jsx live scope={{UiTable}}
   <UiTable
+    bordered
     data={{
-      headings: ['No', 'Summary', 'Price'],
+      headings: [{ label: 'No.' }, { label: 'Summary', sort: false } , { label: 'Price' }],
       items: [
         { id: '1', cols: [1, 'item 1', '$10'] },
         { id: '2', cols: [2, 'item 2', '$20'] },
@@ -48,12 +49,17 @@ with those elements.
 - If a row is selected the `onClick` CB is executed
 - If you pass a `selected` id to the table that row will show as selected in the table
 
+#### Stylizing
+
+In the previous example we are using the prop `bordered` to display borders although is not enable by default given that tables are hard to stylized for multiple use cases. So, to stylized the table we recommend passing 
+a `className` value, this will be attached to the `Table` element and you can style the table from there.
+
 ### With category
 
 ```jsx live scope={{UiTable}}
   <UiTable
     data={{
-      headings: ['Summary', 'Price'],
+      headings: [{ label: 'Summary'}, { label: 'Price'}],
       items: [{ id: '1', cols: ['item 1', '$10'] }],
     }}
     category="tertiary"
@@ -65,7 +71,7 @@ with those elements.
 ```jsx live scope={{UiTable}}
   <UiTable
     data={{
-      headings: ['Summary', 'Price'],
+      headings: [{ label: 'Summary'}, { label: 'Price'}],
       items: [{ id: '1', cols: ['item 1', '$10'] }],
     }}
     category="tertiary"
@@ -78,13 +84,27 @@ with those elements.
 ```jsx live scope={{UiTable}}
   <UiTable
     data={{
-      headings: ['Summary', 'Price'],
+      headings: [{ label: 'Summary'}, { label: 'Price'}],
       items: [{ id: '1', cols: ['item 1', '$10'] }],
     }}
     withFilter={false}
     withSort={false}
   />
 ```
+
+### Removing sort from a column
+
+```jsx live scope={{UiTable}}
+  <UiTable
+    data={{
+      headings: [{ label: 'Summary', sort: false}, { label: 'Price'}],
+      items: [{ id: '1', cols: ['item 1', '$10'] }],
+    }}
+    withFilter={false}
+    withSort={false}
+  />
+```
+
 
 ### With a react component as part of the cols
 
@@ -93,7 +113,7 @@ This is useful when you want to render a component in each of the elements.
 ```jsx live scope={{UiTable, UiIcon}}
   <UiTable
     data={{
-      headings: ['Summary', 'Price', 'Actions'],
+      headings: [{ label: 'Summary'}, { label: 'Price'}, { label: 'Actions', sort: false }],
       items: [
         { id: '1', cols: ['item 1', '$10', <UiIcon icon="Edit" />] },
         { id: '2', cols: ['item 2', '$20', <UiIcon icon="Edit" />] },

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -3,7 +3,7 @@
   "description": "table package from @uireact library",
   "repository": "https://github.com/inavac182/ui-react",
   "license": "GNU",
-  "version": "1.6.16",
+  "version": "2.0.0",
   "publishConfig": {
     "access": "public"
   },

--- a/packages/table/src/types/ui-table-data.ts
+++ b/packages/table/src/types/ui-table-data.ts
@@ -2,8 +2,13 @@ export type UiTableItemData = {
   [key in string]: string;
 };
 
+export type UiTableHeading = {
+  label: string;
+  sort?: boolean;
+}
+
 export type UiTableData = {
-  headings: string[];
+  headings: UiTableHeading[];
   items: UiTableItem[];
 };
 

--- a/packages/table/src/ui-table.scss
+++ b/packages/table/src/ui-table.scss
@@ -34,3 +34,29 @@
     cursor: pointer;
     transition: background .2s;
 }
+
+.borderedTable {
+    border: 2px solid var(--tertiary-token_100);
+    padding: 10px;
+    border-radius: 10px;
+
+    table {
+        border-collapse: collapse;
+    }
+
+    thead > tr {
+        border-bottom: 5px solid var(--secondary-token_150);
+    }
+
+    tbody > tr {
+        border-bottom: 2px solid var(--primary-token_150);
+        border-left: 2px solid transparent;
+        
+    }
+
+    tbody > tr {
+        &:hover {
+            border-left: 2px solid var(--tertiary-token_100);
+        }
+    }
+}

--- a/packages/table/src/ui-table.tsx
+++ b/packages/table/src/ui-table.tsx
@@ -1,6 +1,6 @@
 import React, { FormEvent, useCallback, useEffect, useState } from 'react';
 
-import { ColorCategory, UiReactElementProps } from '@uireact/foundation';
+import { ColorCategory, UiReactElementProps, UiSpacing, UiSpacingProps } from '@uireact/foundation';
 import { UiInput } from '@uireact/form';
 import { UiIcon } from '@uireact/icons';
 import { UiGrid, UiGridItem } from '@uireact/grid';
@@ -12,8 +12,14 @@ import { getFilteredData, getSortedData } from './private';
 import styles from './ui-table.scss';
 
 export type UiTableProps = {
+  /** Padding to be added to each heading cell */
+  headingPadding?: UiSpacingProps['padding'];
+  /** Padding to be added to each table cell */
+  cellPadding?: UiSpacingProps['padding'];
   /** The data object that will be rendered in the table */
   data: UiTableData;
+  /** If the table should render borders */
+  bordered?: boolean;
   /** The theme category that will be applied to the styling */
   category?: ColorCategory;
   /** Flag to disable the filter bar */
@@ -29,7 +35,10 @@ export type UiTableProps = {
 } & UiReactElementProps;
 
 export const UiTable: React.FC<UiTableProps> = ({
+  bordered,
   className = '',
+  cellPadding = {},
+  headingPadding = {},
   data,
   category = 'primary',
   testId,
@@ -86,7 +95,7 @@ export const UiTable: React.FC<UiTableProps> = ({
   }, [data]);
 
   return (
-    <div>
+    <div className={`${bordered ? styles.borderedTable : ''}`}>
       {withFilter && (
         <UiGrid cols={{ small: 1, medium: 2, large: 3, xlarge: 3 }}>
           <UiGridItem cols={!filterBoxPosition ? 3 : 1} startingCol={filterBoxPosition === 'right' ? 3 : 1}>
@@ -99,18 +108,20 @@ export const UiTable: React.FC<UiTableProps> = ({
           <tr>
             {_data.headings.map((heading, index) => (
               <th className={styles.tableHeadingCol} key={`table-heading-${index}`} onClick={() => { onSort(index) }}>
-                <UiFlexGrid>
-                  <UiFlexGridItem grow={1}>
-                    {heading}
-                  </UiFlexGridItem>
-                  {withSort && (
-                    <UiFlexGridItem>
-                      {sortedCol === index && sortedOrientation === 'UP' && <UiIcon icon="CaretUp" testId='sort-icon-up' />}
-                      {sortedCol === index && sortedOrientation === 'DOWN' && <UiIcon icon="CaretDown" testId='sort-icon-down' />}
-                      {sortedCol !== index && <UiIcon icon='Sort' testId='sort-icon' />}
+                <UiSpacing padding={headingPadding}>
+                  <UiFlexGrid>
+                    <UiFlexGridItem grow={1}>
+                      {heading.label}
                     </UiFlexGridItem>
-                  )}
-                </UiFlexGrid>
+                    {withSort && heading.sort !== false && (
+                      <UiFlexGridItem>
+                        {sortedCol === index && sortedOrientation === 'UP' && <UiIcon icon="CaretUp" testId='sort-icon-up' />}
+                        {sortedCol === index && sortedOrientation === 'DOWN' && <UiIcon icon="CaretDown" testId='sort-icon-down' />}
+                        {sortedCol !== index && <UiIcon icon='Sort' testId='sort-icon' />}
+                      </UiFlexGridItem>
+                    )}
+                  </UiFlexGrid>
+                </UiSpacing>
               </th>
             ))}
           </tr>
@@ -123,7 +134,11 @@ export const UiTable: React.FC<UiTableProps> = ({
               onClick={() => handleClick(field.id)}
             >
               {field.cols.map((text, index) => (
-                <td className={styles.tableCol} key={`table-item-${rowIndex}-colum-index-${index}`}>{text}</td>
+                <td className={styles.tableCol} key={`table-item-${rowIndex}-colum-index-${index}`}>
+                  <UiSpacing padding={cellPadding}>
+                    {text}
+                  </UiSpacing>
+                </td>
               ))}
             </tr>
           ))}


### PR DESCRIPTION
## 🔥 Making the table headings objects so we can pass options
----------------------------------------------

### Description
There have been use cases for the table headings to add options so we are changing the type from a simple string to an object so more options can be added. Also I added the `bordered` prop that will add some basic styling to the tables, as well as props for passing custom paddings for cells and headings

### Screenshots

![Screenshot 2024-08-09 at 12 19 07 PM](https://github.com/user-attachments/assets/fca01c3c-9219-481e-8c97-6af8b5ff58cd)
