### PR TITLE
refactor(button-link): match button styling and add rounded prop

### DIFF
--- a/packages/text/__tests__/ui-button-link.spec.tsx
+++ b/packages/text/__tests__/ui-button-link.spec.tsx
@@ -45,6 +45,17 @@ describe('<UiLink />', () => {
     expect(screen.getByRole('link')).toHaveClass('buttonLink bg-positive-100 hover-bg-positive-150 active-bg-positive-200 fullWidth bold color-inverse-fonts-100 size-large wrap padding-top-three padding-bottom-three padding-left-four padding-right-four');
   });
 
+  it('renders fine with rounded', () => {
+    uiRender(
+      <UiButtonLink category="positive" size="large" rounded>
+        <a href="#">Link</a>
+      </UiButtonLink>
+    );
+
+    expect(screen.getByRole('link', { name: 'Link' })).toBeVisible();
+    expect(screen.getByRole('link')).toHaveClass('buttonLink bg-positive-100 border-positive-100 hover-border-positive-150 hover-bg-positive-150 active-bg-positive-200 color-fonts-100 size-large padding-top-three padding-bottom-three padding-left-four padding-right-four radius-large');
+  });
+
   it('renders fine with font style bold', () => {
     uiRender(
       <UiButtonLink fontStyle="bold">

--- a/packages/text/__tests__/utils/get-button-link-styling.spec.ts
+++ b/packages/text/__tests__/utils/get-button-link-styling.spec.ts
@@ -3,7 +3,7 @@ import { getButtonLinkStyling } from '../../src/utils';
 describe('getButtonLinkStyling', () => {
   it('Should retrieve correct classes when styling is clear', () => {
     const result = getButtonLinkStyling('primary', 'clear');
-    expect(result).toBe('hover-bg-primary-150 hover-border-primary-150 active-bg-primary-200 active-border-primary-200 buttonLinkRadius');
+    expect(result).toBe('hover-bg-primary-150 hover-border-primary-150 active-bg-primary-200 active-border-primary-200');
   });
 
   it('Should retrieve correct classes when styling is clear', () => {
@@ -13,6 +13,6 @@ describe('getButtonLinkStyling', () => {
 
   it('Should retrieve correct classes when no styling provided', () => {
     const result = getButtonLinkStyling('primary');
-    expect(result).toBe('bg-primary-100 border-primary-100 hover-border-primary-150 hover-bg-primary-150 active-bg-primary-200 buttonLinkRadius');
+    expect(result).toBe('bg-primary-100 border-primary-100 hover-border-primary-150 hover-bg-primary-150 active-bg-primary-200');
   });
 });

--- a/packages/text/docs/button-link/page.mdx
+++ b/packages/text/docs/button-link/page.mdx
@@ -8,7 +8,7 @@ import { Metadata } from '@uireact/docs-tools';
 
 <Metadata packageName='text' packageJson={packageJson} />
 
-> This component adds classes to the passed children link so it renders as a button rather than a link, but it behaves as a link.
+> This component has to wrap a link component in order to properly work. It will add custom classes to its children to make it look like a button although for a11y it will still be a button.
 
 ## Installation
 
@@ -56,6 +56,19 @@ import { Metadata } from '@uireact/docs-tools';
   </UiButtonLink>{" "}
   <UiButtonLink styling='icon'>
     <a href="https://uireact.io/" target="_blank"><UiIcon icon="SettingsBig" /></a>
+  </UiButtonLink>
+</>
+```
+
+### UiButtonLink with rounded properties
+
+```jsx live scope={{UiButtonLink, UiIcon}}
+<>
+  <UiButtonLink rounded>
+    <a href="https://uireact.io/" target="_blank">Some link</a>
+  </UiButtonLink>{" "}
+  <UiButtonLink rounded size="xlarge">
+    <a href="https://uireact.io/" target="_blank">Some link</a>
   </UiButtonLink>
 </>
 ```

--- a/packages/text/src/types/ui-button-link-props.ts
+++ b/packages/text/src/types/ui-button-link-props.ts
@@ -27,4 +27,6 @@ export type UiButtonLinkProps = {
   padding?: SpacingDistribution;
   /** The styling of the button */
   styling?: 'clear' | 'icon';
+  /** If the button is rounded */
+  rounded?: boolean;
 } & UiReactElementProps & AriaAttributes;

--- a/packages/text/src/ui-button-link.tsx
+++ b/packages/text/src/ui-button-link.tsx
@@ -20,7 +20,9 @@ export const UiButtonLink: React.FC<UiButtonLinkProps> = ({
   inverseTextColoration,
   margin,
   padding,
-  styling
+  styling,
+  rounded = false,
+  ...props
 }: UiButtonLinkProps) => {
   let classes = `${className} ${styles.buttonLink} ${getButtonLinkStyling(category, styling)}`;
   classes = `${classes} color-${inverseTextColoration ? 'inverse-' : ''}fonts-100 size-${size}`;
@@ -51,8 +53,16 @@ export const UiButtonLink: React.FC<UiButtonLinkProps> = ({
     classes = `${classes} ${getSpacingClass('padding', defaultPadding)}`;
   }
 
+  if (styling !== 'icon') {
+    if (rounded) {
+      classes = `${classes} radius-${size}`;
+    } else {
+      classes = `${classes} ${styles.buttonLinkRadius}`;
+    }
+  }
+
   if (children && React.isValidElement(children)) {
-    const Element = React.cloneElement(children as React.ReactElement, { className: classes });
+    const Element = React.cloneElement(children as React.ReactElement, { className: classes, ...props });
 
     return (
       <>

--- a/packages/text/src/ui-text.scss
+++ b/packages/text/src/ui-text.scss
@@ -54,7 +54,7 @@
 }
 
 .buttonLinkRadius {
-    border-radius: 10px;
+    border-radius: 3px;
 }
 
 .buttonLinkIcon {

--- a/packages/text/src/utils/get-button-link-styling.ts
+++ b/packages/text/src/utils/get-button-link-styling.ts
@@ -4,12 +4,12 @@ type ColorCategory = 'primary' | 'secondary' | 'tertiary' | 'positive' | 'negati
 
 export const getButtonLinkStyling = (category?: ColorCategory, styling?: 'clear' | 'icon') => {
   if (styling === 'clear') {
-    return `hover-bg-${category}-150 hover-border-${category}-150 active-bg-${category}-200 active-border-${category}-200 ${styles.buttonLinkRadius}`;
+    return `hover-bg-${category}-150 hover-border-${category}-150 active-bg-${category}-200 active-border-${category}-200`;
   }
 
   if (styling === 'icon') {
     return `hover-bg-${category}-150 hover-border-${category}-150 active-bg-${category}-200 active-border-${category}-200 ${styles.buttonLinkIcon}`;
   }
 
-  return `bg-${category}-100 border-${category}-100 hover-border-${category}-150 hover-bg-${category}-150 active-bg-${category}-200 ${styles.buttonLinkRadius}`;
+  return `bg-${category}-100 border-${category}-100 hover-border-${category}-150 hover-bg-${category}-150 active-bg-${category}-200`;
 };


### PR DESCRIPTION
## 🔥 Matching the UiButton styling
----------------------------------------------

### Description
The UiButtonLink has a slight different border radius than the UiButton so this change is to make sure they match. Also adding the `rounded` prop so they both can render similarly.

### Screenshots

#### Before

![Screenshot 2024-08-14 at 7 56 30 PM](https://github.com/user-attachments/assets/4d857fcc-b990-4755-b421-787fb925e4d5)

#### After

![Screenshot 2024-08-14 at 7 56 10 PM](https://github.com/user-attachments/assets/18268f10-3da2-4bb0-840c-24047d9adee6)
![Screenshot 2024-08-14 at 7 56 07 PM](https://github.com/user-attachments/assets/38c21280-890c-471e-8047-1bc1cc51901f)

