### PR TITLE
fix(text): break line property for text

### DIFF
--- a/packages/text/src/ui-text.scss
+++ b/packages/text/src/ui-text.scss
@@ -1,3 +1,7 @@
+.text {
+    max-width: 100%;
+}
+
 .alignLeft {
     text-align: left;
 }
@@ -60,4 +64,12 @@
 .buttonLinkIcon {
     border-radius: 50%;
     padding: 10px;
+}
+
+.breakLine {
+    white-space: pre-wrap;
+    white-space: -moz-pre-wrap;
+    white-space: -pre-wrap;
+    white-space: -o-pre-wrap;
+    word-wrap: break-word;
 }

--- a/packages/text/src/ui-text.tsx
+++ b/packages/text/src/ui-text.tsx
@@ -19,7 +19,7 @@ export const UiText: React.FC<UiTextProps> = ({
   margin,
   padding
 }: UiTextProps) => {
-  let classes = `${className} color-${inverseColoration ? 'inverse-' : ''}${category}-100 size-${size}`;
+  let classes = `${className} ${styles.text} color-${inverseColoration ? 'inverse-' : ''}${category}-100 size-${size}`;
 
   if (align === 'center') {
     classes = `${classes} ${styles.alignCenter}`;
@@ -35,6 +35,8 @@ export const UiText: React.FC<UiTextProps> = ({
 
   if (wrap) {
     classes = `${classes} ${styles.wrap}`;
+  } else {
+    classes = `${classes} ${styles.breakLine}`;
   }
 
   if (margin || padding) {


### PR DESCRIPTION
## 🔥 Text break line styling
----------------------------------------------

### Description
The text element was missing the break line styling so in some scenarios it was overflowing its containers.

### Screenshots

#### Before
![Screenshot 2024-08-14 at 8 07 47 PM](https://github.com/user-attachments/assets/e1d47c22-2590-4fbc-8481-f359e3d777fe)

#### After
![Screenshot 2024-08-14 at 8 07 35 PM](https://github.com/user-attachments/assets/a29c8f00-77f5-4e09-8360-fd677aad0921)
