### PR TITLE
feat(text): calculate line-height using text size

### DIFF
--- a/packages/text/docs/headings/page.mdx
+++ b/packages/text/docs/headings/page.mdx
@@ -21,7 +21,7 @@ import { Metadata } from '@uireact/docs-tools';
 ### UiHeading with inverse coloration
 
 ```jsx live scope={{UiHeading}}
-  <UiHeading level={1} inverseColoration>
+  <UiHeading level={2} inverseColoration>
     Some heading
   </UiHeading>
 ```
@@ -29,7 +29,7 @@ import { Metadata } from '@uireact/docs-tools';
 ### UiHeading centered
 
 ```jsx live scope={{UiHeading}}
-  <UiHeading level={1} centered>
+  <UiHeading level={3} centered>
     Some heading
   </UiHeading>
 ```
@@ -37,7 +37,7 @@ import { Metadata } from '@uireact/docs-tools';
 ### UiHeading wrapped
 
 ```jsx live scope={{UiHeading}}
-  <UiHeading level={1} wrap>
+  <UiHeading level={4} wrap>
     This is a very very very very very loooooong heading so it can be wrapped
   </UiHeading>
 ```
@@ -46,10 +46,10 @@ import { Metadata } from '@uireact/docs-tools';
 
 ```jsx live scope={{UiHeading}}
 <>
-  <UiHeading level={1} coloration="dark">
+  <UiHeading level={5} coloration="dark">
     Will always render with DARK coloration
   </UiHeading>
-  <UiHeading level={1} coloration="light">
+  <UiHeading level={5} coloration="light">
     Will always render with LIGHT coloration
   </UiHeading>
 </>
@@ -58,7 +58,7 @@ import { Metadata } from '@uireact/docs-tools';
 ### UiHeading with spacing
 
 ```jsx live scope={{UiHeading}}
-  <UiHeading level={1} padding={{all: 'five'}}>
+  <UiHeading level={6} padding={{all: 'five'}}>
     Some heading
   </UiHeading>
 ```

--- a/packages/text/src/ui-link.tsx
+++ b/packages/text/src/ui-link.tsx
@@ -37,7 +37,7 @@ export const UiLink: React.FC<UiLinkProps> = ({
   }
 
   if (fontStyle) {
-    classes = `${classes} ${fontStyle}`;
+    classes = `${classes} ${styles[fontStyle]}`;
   }
 
   if (children && React.isValidElement(children)) {

--- a/packages/view/src/ui-view.scss
+++ b/packages/view/src/ui-view.scss
@@ -92,7 +92,7 @@ GLOBAL STYLES
 
     :global(.size-#{$size}) {
         font-size: var(--texts-#{$size});
-        line-height: calc(var(--texts-#{$size}) * 1.025);
+        line-height: calc(var(--texts-#{$size}) * 1.25);
     }
 
     :global(.w-#{$size}) {

--- a/packages/view/src/ui-view.scss
+++ b/packages/view/src/ui-view.scss
@@ -92,7 +92,7 @@ GLOBAL STYLES
 
     :global(.size-#{$size}) {
         font-size: var(--texts-#{$size});
-        line-height: var(--texts-#{$size});
+        line-height: calc(var(--texts-#{$size}) * 1.025);
     }
 
     :global(.w-#{$size}) {
@@ -107,7 +107,7 @@ GLOBAL STYLES
 @each $hSize in $hSizes {
     :global(.heading-#{$hSize}) {
         font-size: var(--headings-#{$hSize});
-        line-height: var(--headings-#{$hSize});
+        line-height: calc(var(--headings-#{$hSize}) * 0.85);
     }
 }
 


### PR DESCRIPTION
## 🔥 line-height for text components
----------------------------------------------

### Description
Small change for text components to calculate line-height based on their font size.

### Screenshots

#### Before
<img width="824" alt="Screenshot 2024-08-15 at 2 12 58 PM" src="https://github.com/user-attachments/assets/f104da38-05ee-4a0f-a397-4caf28cc0e08">

#### After
<img width="831" alt="Screenshot 2024-08-15 at 2 15 34 PM" src="https://github.com/user-attachments/assets/4fa6b804-346d-47ed-839b-0f04d4163a91">
