### PR TITLE
feat(menu): using close outside hook instead of wrapper to close menu

### DIFF
--- a/packages/menu/__tests__/ui-menu.spec.tsx
+++ b/packages/menu/__tests__/ui-menu.spec.tsx
@@ -13,9 +13,10 @@ import { UiMenu } from '../src';
 type MockedComponentProps = {
   fullscreenOnSmall?: boolean;
   visible?: boolean;
+  closeMenuSpy?: () => void;
 };
 
-const MockedComponent = ({ visible = false, fullscreenOnSmall = false }: MockedComponentProps) => {
+const MockedComponent = ({ visible = false, fullscreenOnSmall = false, closeMenuSpy }: MockedComponentProps) => {
   const [isVisible, setIsVisible] = React.useState(visible);
 
   const handleMenuOpen = React.useCallback(() => {
@@ -24,13 +25,15 @@ const MockedComponent = ({ visible = false, fullscreenOnSmall = false }: MockedC
 
   const closeMenu = React.useCallback(() => {
     setIsVisible(false);
-  }, [setIsVisible]);
+    closeMenuSpy?.();
+  }, [setIsVisible, closeMenuSpy]);
 
   return (
     <div>
       <div>
         <UiButton onClick={handleMenuOpen}>Open Menu</UiButton>
       </div>
+      <p data-testid="content-outside-menu">Some content outside menu</p>
       <UiMenu
         visible={isVisible}
         closeLabel="Close menu dialog"
@@ -111,6 +114,30 @@ describe('<UiMenu />', () => {
 
     await waitFor(() => {
       expect(screen.getByRole('menu')).toBeVisible();
+    });
+  });
+
+  it('closes menu when clicking outside menu', async () => {
+    uiRender(<MockedComponent visible />);
+
+    await waitFor(() => {
+      expect(screen.getByRole('menu')).toBeVisible();
+    });
+
+    fireEvent.click(screen.getByTestId('content-outside-menu'));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
+    });
+  });
+
+  it('Does not execute menu close when clicking outside menu if menu is not visible', async () => {
+    uiRender(<MockedComponent />);
+
+    fireEvent.click(screen.getByTestId('content-outside-menu'));
+
+    await waitFor(() => {
+      expect(screen.queryByRole('menu')).not.toBeInTheDocument();
     });
   });
 

--- a/packages/menu/docs/page.mdx
+++ b/packages/menu/docs/page.mdx
@@ -22,21 +22,19 @@ import { Metadata } from '@uireact/docs-tools';
 ```tsx live scope={{MenuExample}}
     <MenuExample />
 ```
-In this example we are making use of the animation `UiReactFadeUp` exported from `@uireact/framer-motion` package to give an animation of fade in upwards.
-This is passed through the `motion` prop like this:
 
-```tsx
-// Import animation prop
-import { UiReactFadeUp } from '@uireact/framer-animations';
+## Visibility Control
 
-// Pass it to the UiMenu component
+The menu is a controlled component, it means you have to handle the visibility and closure callback through 2 props:
 
-<UiMenu motion={UiReactFadeUp}>
-    Content...
-</UiMenu>
-```
+- visible
+- closeMenuCB
 
-#### Example combining with other animations
+The **visible** prop will set the visibility of the menu.
+
+The **closeMenuCB** prop will be executed when the user has performed an action to close the menu, such as `ESC` key or clicking outside the menu.
+
+## Animated menu
 
 You could create more complex animations when combining multiple components for instance:
 

--- a/packages/menu/docs/utils/menu-example.tsx
+++ b/packages/menu/docs/utils/menu-example.tsx
@@ -3,7 +3,7 @@ import React from 'react';
 
 import { MotionProps } from 'framer-motion';
 
-import { UiButton } from '@uireact/button';
+import { UiButton, UiPrimaryButton, UiTertiaryButton } from '@uireact/button';
 import { UiCard } from '@uireact/card';
 import { UiText } from '@uireact/text';
 import { UiReactFadeLeft } from '@uireact/framer-animations';
@@ -36,9 +36,17 @@ export const MenuExample: React.FC = () => {
         <UiSpacing margin={{ all: 'five' }}>
           <UiText align='center'>Menu Content</UiText>
           <div>
-            <UiButton onClick={closeMenu} category="secondary" fullWidth>
+            <UiPrimaryButton onClick={closeMenu} fullWidth>
               Close menu
-            </UiButton>
+            </UiPrimaryButton>
+          </div>
+        </UiSpacing>
+        <UiSpacing margin={{ all: 'five' }}>
+          <UiText align='center'>Menu Content</UiText>
+          <div>
+            <UiTertiaryButton fullWidth>
+              Some other button
+            </UiTertiaryButton>
           </div>
         </UiSpacing>
       </UiMenu>
@@ -73,7 +81,7 @@ export const AnimatedMenuExample: React.FC = () => {
   return (
     <UiSpacing padding={{ all: 'five' }}>
       <div>
-        <UiButton onClick={handleMenuOpen}>Open Menu</UiButton>
+        <UiPrimaryButton onClick={handleMenuOpen}>Open Menu</UiPrimaryButton>
       </div>
       <UiMenu visible={isVisible} closeMenuCB={closeMenu} fullscreenOnSmall>
         <UiSpacing margin={{ all: 'five' }}>

--- a/packages/menu/src/hooks/index.ts
+++ b/packages/menu/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export * from './useClickOutside';

--- a/packages/menu/src/hooks/useClickOutside.ts
+++ b/packages/menu/src/hooks/useClickOutside.ts
@@ -1,0 +1,36 @@
+import { RefObject, useCallback, useEffect } from "react"
+
+export const useClickOutside = (
+  ref: RefObject<HTMLElement | undefined>,
+  callback: () => void,
+  addEventListener: boolean,
+) => {
+  const handleClick = useCallback((event: MouseEvent) => {
+    if (ref.current && !isChild(event.target as HTMLElement, ref.current)) {
+      console.log('Closing menu');
+      callback();
+    }
+  }, [callback, ref]);
+
+  useEffect(() => {
+    if (addEventListener) {
+      document.body.addEventListener('click', handleClick)
+    }
+
+    return () => {
+      document.body.removeEventListener('click', handleClick)
+    }
+  }, [addEventListener, handleClick]);
+};
+
+const isChild = (obj: HTMLElement, parentObj: HTMLElement) => {
+  while (obj && obj.tagName.toUpperCase() != 'BODY'){
+      if (obj === parentObj){
+          return true;
+      }
+
+      obj = obj.parentNode as HTMLElement;
+  }
+
+  return false;
+}

--- a/packages/menu/src/ui-menu.tsx
+++ b/packages/menu/src/ui-menu.tsx
@@ -1,5 +1,5 @@
 'use client';
-import React from 'react';
+import React, { useCallback, useEffect } from 'react';
 
 import { motion as MotionParent } from 'framer-motion';
 
@@ -9,6 +9,7 @@ import { UiReactFadeUp } from '@uireact/framer-animations';
 
 import { UiMenuProps } from './types';
 import styles from './ui-menu.scss';
+import { useClickOutside } from './hooks';
 
 export const UiMenu: React.FC<UiMenuProps> = ({
   className = '',
@@ -33,24 +34,13 @@ export const UiMenu: React.FC<UiMenuProps> = ({
     menuClasses = `${menuClasses} ${styles.offset}`;
   }
 
-  const escCB = React.useCallback(
-    (event: KeyboardEvent) => {
-      if (event.key === 'Escape') {
-        closeMenuCB();
-      }
-    },
-    [closeMenuCB]
-  );
+  const escCB = useCallback((event: KeyboardEvent) => {
+    if (event.key === 'Escape') {
+      closeMenuCB();
+    }
+  }, [closeMenuCB]);
 
-  React.useEffect(() => {
-    document.addEventListener('keydown', escCB, false);
-
-    return () => {
-      document.removeEventListener('keydown', escCB, false);
-    };
-  }, [escCB]);
-
-  React.useEffect(() => {
+  useEffect(() => {
     if (visible && isSmall && !isOpen) {
       actions.openDialog();
     }
@@ -60,7 +50,7 @@ export const UiMenu: React.FC<UiMenuProps> = ({
     }
   }, [visible, isOpen, isSmall, actions]);
 
-  React.useEffect(() => {
+  useEffect(() => {
     // istanbul ignore this
     if (menuRef && menuRef.current && visible && typeof window !== undefined) {
       const position = menuRef.current.getBoundingClientRect();
@@ -72,6 +62,18 @@ export const UiMenu: React.FC<UiMenuProps> = ({
       }
     }
   }, [menuRef, visible]);
+
+  useEffect(() => {
+    if (visible) {
+      document.addEventListener('keydown', escCB, false);
+
+      return () => {
+        document.removeEventListener('keydown', escCB, false);
+      };
+    }
+  }, [visible, menuRef, escCB]);
+
+  useClickOutside(menuRef, closeMenuCB, visible);
 
   if (!visible) {
     return null;
@@ -91,7 +93,6 @@ export const UiMenu: React.FC<UiMenuProps> = ({
           </UiDialog>
         </UiViewport>
         <UiViewport criteria={'m|l|xl'}>
-          <div className={styles.wrapper} onClick={closeMenuCB}></div>
           <MotionParent.div className={menuClasses} role="menu" ref={menuRef} data-testid={testId} {...motion}>
             {children}
           </MotionParent.div>
@@ -102,7 +103,6 @@ export const UiMenu: React.FC<UiMenuProps> = ({
 
   return (
     <div>
-      <div className={styles.wrapper} onClick={closeMenuCB}></div>
       <MotionParent.div role="menu" className={menuClasses} ref={menuRef} data-testid={testId} {...motion}>
         {children}
       </MotionParent.div>


### PR DESCRIPTION
## 🔥 Removing menu wrapper in favor of hook
----------------------------------------------

### Description
I'm changing the way how the menu detects a click outside the component, this for a better experience when clicking outside the component.

### Screenshots

N/A