### PR TITLE
feat(icons): adding weight prop

### DIFF
--- a/packages/button/docs/page.mdx
+++ b/packages/button/docs/page.mdx
@@ -62,6 +62,18 @@ These buttons already have and uses a cohesive styling that helps improve the us
   </UiFlexGrid>
 ```
 
+## Example
+
+### Using an UiIcon
+
+This is simulating a disabled button that is waiting on a triggered action:
+
+```jsx live scope={{UiPrimaryButton, UiSpacing, Sizing, UiIcon}}
+  <UiPrimaryButton margin={{ all: 'two' }} padding={{ inline: 'four', block: 'two' }} disabled>
+    <UiIcon icon="LoadingSpinner" category="secondary" weight="200" />
+  </UiPrimaryButton>
+```
+
 ### Usage of a customizable UiButton
 
 The UiButton allows for customization of the styling and colorations, this component can be used to create your own level components in your applications:

--- a/packages/icons/__tests__/ui-icon.spec.tsx
+++ b/packages/icons/__tests__/ui-icon.spec.tsx
@@ -15,6 +15,13 @@ describe('<UiIcon />', () => {
     expect(screen.getByTestId('UiIcon')).toHaveClass('icon fill-fonts-100 size-regular w-regular h-regular');
   });
 
+  it('renders fine with weight', () => {
+    uiRender(<UiIcon icon="Search" testId="UiIcon" weight='200' />);
+
+    expect(screen.getByTestId('Icon')).toBeVisible();
+    expect(screen.getByTestId('UiIcon')).toHaveClass('icon fill-fonts-200 size-regular w-regular h-regular');
+  });
+
   it('renders fine with motion animation', async () => {
     uiRender(<UiIcon icon="Search" testId="UiIcon" motion={UiReactFadeUp} />);
 

--- a/packages/icons/docs/page.mdx
+++ b/packages/icons/docs/page.mdx
@@ -33,6 +33,20 @@ as that requires some rework on the icons itself.
 
 You can see the docs for [@uireact/framer-animations](./framer-animations) package to see the full list of available animations.
 
+## UiIcon with weight
+
+Default is weight 100
+
+```jsx live scope={{UiIcon}}
+<>
+  <UiIcon icon="Search" size="xlarge" category="tertiary" weight="10" />
+  <UiIcon icon="Search" size="xlarge" category="tertiary" weight="50" />
+  <UiIcon icon="Search" size="xlarge" category="tertiary" />
+  <UiIcon icon="Search" size="xlarge" category="tertiary" weight="150" />
+  <UiIcon icon="Search" size="xlarge" category="tertiary" weight="200" />
+</>
+```
+
 ## UiIcon with inverse coloration
 
 ```jsx live scope={{UiIcon}}

--- a/packages/icons/src/types/icons-props.ts
+++ b/packages/icons/src/types/icons-props.ts
@@ -1,4 +1,4 @@
-import { ColorCategory, SizesProp, UiReactElementProps } from '@uireact/foundation';
+import { ColorCategory, ColorToken, SizesProp, UiReactElementProps } from '@uireact/foundation';
 import { MotionProps } from 'framer-motion';
 
 import * as SvgsComponent from '../public/svgs';
@@ -24,4 +24,6 @@ export type UiIconProps = {
   coloration?: 'dark' | 'light';
   /* Framer motion props */
   motion?: MotionProps;
+  /** Color weight of the icon */
+  weight?: ColorToken;
 } & UiReactElementProps & AriaAttributes;

--- a/packages/icons/src/ui-icon.tsx
+++ b/packages/icons/src/ui-icon.tsx
@@ -16,10 +16,11 @@ export const UiIcon: React.FC<UiIconProps> = ({
   testId,
   inverseColoration,
   motion,
+  weight = '100',
   ...props
 }: UiIconProps) => {
   return (
-    <MotionParent.span className={`${className} ${styles.icon} ${coloration ? coloration : ''} inline-block fill-${inverseColoration ? 'inverse-' : ''}${category}-100 size-${size} w-${size} h-${size}`} data-testid={testId} {...motion} {...props}>
+    <MotionParent.span className={`${className} ${styles.icon} ${coloration ? coloration : ''} inline-block fill-${inverseColoration ? 'inverse-' : ''}${category}-${weight} size-${size} w-${size} h-${size}`} data-testid={testId} {...motion} {...props}>
       <IconComponent icon={icon} />
     </MotionParent.span>
   );


### PR DESCRIPTION
## 🔥 Adding weight prop to icons
----------------------------------------------

### Description
This is useful if we need to give a stronger/lighter color to the icon being rendered.

### Screenshots
![Screenshot 2024-09-04 at 5 54 39 PM](https://github.com/user-attachments/assets/ec017ca6-1d8e-46e4-b1e9-e50b1de48f20)
