### PR TITLE
refactor: text size on notification title

### DIFF
--- a/packages/notifications/__tests__/ui-notifications.spec.tsx
+++ b/packages/notifications/__tests__/ui-notifications.spec.tsx
@@ -36,7 +36,7 @@ export const NotificationsExample: React.FC<NotificationsExampleProps> = ({
   const addLinkNotification = useCallback(() => {
     showNotification({
       icon: 'Link',
-      title: 'Notification with link',
+      title: 'Notification with link title',
       message: 'This is a new notification that shows a link',
       link: {
         label: 'Ui React docs',
@@ -53,7 +53,7 @@ export const NotificationsExample: React.FC<NotificationsExampleProps> = ({
   const addNotificationWithOptions = useCallback(() => {
     showNotification({
       icon: 'ArrowTrendDown',
-      title: 'Notification with options',
+      title: 'Notification with options title',
       options: {
         category: 'error',
         closeButton: false,
@@ -112,7 +112,7 @@ describe('<UiNotifications />', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Add notification' }));
 
-    expect(screen.getByRole('heading', { name: 'New notification' })).toBeVisible();
+    expect(screen.getByText('New notification')).toBeVisible();
     expect(screen.getByText('This is a new notification')).toBeVisible();
     expect(screen.getByTestId('notification-close-button')).toBeVisible();
 
@@ -131,7 +131,7 @@ describe('<UiNotifications />', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Add notification' }));
 
-    expect(screen.getByRole('heading', { name: 'New notification' })).toBeVisible();
+    expect(screen.getByText('New notification')).toBeVisible();
     expect(screen.getByText('This is a new notification')).toBeVisible();
     expect(screen.getByTestId('notification-close-button')).toBeVisible();
 
@@ -147,7 +147,7 @@ describe('<UiNotifications />', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Notification with link' }));
 
-    expect(screen.getByRole('heading', { name: 'Notification with link' })).toBeVisible();
+    expect(screen.getByText('Notification with link title')).toBeVisible();
     expect(screen.getByText('This is a new notification that shows a link')).toBeVisible();
     expect(screen.getByRole('link', { name: 'Ui React docs' })).toBeVisible();
     expect(screen.getByRole('link', { name: 'Ui React docs' })).toHaveAttribute('href', 'https://uireact.io');
@@ -155,7 +155,7 @@ describe('<UiNotifications />', () => {
 
     fireEvent.click(screen.getByTestId('notification-close-button'));
 
-    expect(screen.queryByRole('heading', { name: 'Notification with link' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Notification with link title')).not.toBeInTheDocument();
   });
 
   it('renders fine without close button', () => {
@@ -163,7 +163,7 @@ describe('<UiNotifications />', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Notification with options' }));
 
-    expect(screen.getByRole('heading', { name: 'Notification with options' })).toBeVisible();
+    expect(screen.getByText('Notification with options title')).toBeVisible();
     expect(screen.queryByTestId('notification-close-button')).not.toBeInTheDocument();
   });
 
@@ -172,7 +172,7 @@ describe('<UiNotifications />', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'No timer' }));
 
-    expect(screen.getByRole('heading', { name: 'Notification with no timer' })).toBeVisible();
+    expect(screen.getByText('Notification with no timer')).toBeVisible();
     expect(screen.queryByTestId('notification-close-button')).toBeVisible();
   });
 
@@ -189,14 +189,14 @@ describe('<UiNotifications />', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Notification with link' }));
 
-    expect(screen.getByRole('heading', { name: 'Notification with link' })).toBeVisible();
+    expect(screen.getByText('Notification with link title')).toBeVisible();
 
     fireEvent.click(screen.getByTestId('notification-close-button'));
 
     expect(onNotificationDismissed).toHaveBeenCalledTimes(1);
     expect(onNotificationShown).toHaveBeenCalledTimes(1);
 
-    expect(screen.queryByRole('heading', { name: 'Notification with link' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Notification with link title')).not.toBeInTheDocument();
   });
 
   it('notiticaion does not appear again when resizing', () => {
@@ -206,36 +206,36 @@ describe('<UiNotifications />', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Notification with link' }));
 
-    expect(screen.getByRole('heading', { name: 'Notification with link' })).toBeVisible();
+    expect(screen.getByText('Notification with link title')).toBeVisible();
 
     fireEvent.click(screen.getByTestId('notification-close-button'));
 
-    expect(screen.queryByRole('heading', { name: 'Notification with link' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Notification with link title')).not.toBeInTheDocument();
 
     act(() => {
       global.innerWidth = 1000;
       global.dispatchEvent(new Event('resize'));
     });
 
-    expect(screen.queryByRole('heading', { name: 'Notification with link' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Notification with link title')).not.toBeInTheDocument();
   });
 
-  it('Only new notifications are rendered, closed notifications doe not appear', () => {
+  it('Only new notifications are rendered, closed notifications does not appear', () => {
     global.innerWidth = 400;
 
     uiRender(<NotificationsExample />);
 
     fireEvent.click(screen.getByRole('button', { name: 'Notification with link' }));
 
-    expect(screen.getByRole('heading', { name: 'Notification with link' })).toBeVisible();
+    expect(screen.getByText('Notification with link title')).toBeVisible();
 
     fireEvent.click(screen.getByTestId('notification-close-button'));
 
-    expect(screen.queryByRole('heading', { name: 'Notification with link' })).not.toBeInTheDocument();
+    expect(screen.queryByRole('Notification with link')).not.toBeInTheDocument();
 
     fireEvent.click(screen.getByRole('button', { name: 'Notification with options' }));
 
-    expect(screen.getByRole('heading', { name: 'Notification with options' })).toBeVisible();
+    expect(screen.getByText('Notification with options title')).toBeVisible();
   });
 
   it('Timer should not reset when another notification is closed', () => {
@@ -245,30 +245,30 @@ describe('<UiNotifications />', () => {
 
     fireEvent.click(screen.getByRole('button', { name: 'Notification with link' }));
 
-    expect(screen.getByRole('heading', { name: 'Notification with link' })).toBeVisible();
+    expect(screen.getByText('Notification with link title')).toBeVisible();
 
     act(() => {
       jest.advanceTimersByTime(2000);
     });
 
-    expect(screen.getByRole('heading', { name: 'Notification with link' })).toBeVisible();
+    expect(screen.getByText('Notification with link title')).toBeVisible();
 
     fireEvent.click(screen.getByRole('button', { name: 'Add notification' }));
 
-    expect(screen.getByRole('heading', { name: 'New notification' })).toBeVisible();
+    expect(screen.getByText('New notification')).toBeVisible();
 
     act(() => {
       jest.advanceTimersByTime(3000);
     });
 
-    expect(screen.queryByRole('heading', { name: 'Notification with link' })).not.toBeInTheDocument();
-    expect(screen.getByRole('heading', { name: 'New notification' })).toBeVisible();
+    expect(screen.queryByText('Notification with link title')).not.toBeInTheDocument();
+    expect(screen.getByText('New notification')).toBeVisible();
 
     act(() => {
       jest.advanceTimersByTime(2000);
     });
 
-    expect(screen.queryByRole('heading', { name: 'Notification with link' })).not.toBeInTheDocument();
-    expect(screen.queryByRole('heading', { name: 'New notification' })).not.toBeInTheDocument();
+    expect(screen.queryByText('Notification with link title')).not.toBeInTheDocument();
+    expect(screen.queryByText('New notification')).not.toBeInTheDocument();
   });
 });

--- a/packages/notifications/src/private/ui-notiication.tsx
+++ b/packages/notifications/src/private/ui-notiication.tsx
@@ -56,15 +56,15 @@ export const UiNotificationWrapper: React.FC<UiNotificationProps> = ({
     <>
       <div className={`${styles.notificationWrapper} bg-${notification.options?.category || 'primary'}-100`}>
         <div className={styles.notificationContent}>
-          <UiFlexGrid columnGap="four" alignItems="center">
+          <UiFlexGrid columnGap="three" alignItems="center">
             {notification.icon && (
               <div className={styles.iconWrapper}>
-                <UiIcon icon={notification.icon as UiIconProps['icon']} />
+                <UiIcon icon={notification.icon as UiIconProps['icon']} size='large' />
               </div>
             )}
             <UiFlexGridItem grow={1}>
-              <UiFlexGrid direction="column" rowGap="three">
-                {notification.title && <UiHeading>{notification.title}</UiHeading>}
+              <UiFlexGrid direction="column" rowGap="two">
+                {notification.title && <UiText size='large' fontStyle='bold'>{notification.title}</UiText>}
                 {notification.message && <UiText>{notification.message}</UiText>}
                 {notification.link && (
                   <UiLink>


### PR DESCRIPTION
## 🔥 Text size on notification title
----------------------------------------------

### Description
The notifications title was massive, so changing from heading to text with large size and bold font

### Screenshots

#### Before
![Screenshot 2024-09-04 at 7 57 56 PM](https://github.com/user-attachments/assets/b82bdd89-85b3-467f-b1aa-1548a29f05ca)

#### After
![Screenshot 2024-09-04 at 7 57 36 PM](https://github.com/user-attachments/assets/7d22b2cc-e801-4c2d-859d-5dfdaa42e26e)
