### PR TITLE
feat(datepicker): render datepicker flat

### DIFF
--- a/packages/datepicker/__tests__/ui-datepicker.spec.tsx
+++ b/packages/datepicker/__tests__/ui-datepicker.spec.tsx
@@ -294,4 +294,24 @@ describe('<UiDatepicker />', () => {
 
     expect(screen.queryByRole('menu')).not.toBeInTheDocument();
   });
+
+  describe('flat', () => {
+    it('renders fine and execute select date callback', async () => {
+      const onSelectedDate = jest.fn();
+      uiRender(<UiDatepicker date={date} onSelectDate={onSelectedDate} flatPicker />);
+      
+      expect(screen.getByText('January 2028')).toBeVisible();
+      expect(screen.getByText('Sun')).toBeVisible();
+      expect(screen.getByText('Mon')).toBeVisible();
+      expect(screen.getByText('Tue')).toBeVisible();
+      expect(screen.getByText('Wed')).toBeVisible();
+      expect(screen.getByText('Thu')).toBeVisible();
+      expect(screen.getByText('Fri')).toBeVisible();
+
+      fireEvent.click(screen.getByRole('button', { name: '15' }));
+
+      expect(onSelectedDate).toHaveBeenCalledTimes(1);
+      expect(onSelectedDate.mock.calls[0][0]).toStrictEqual(new Date(2028, 0, 15));
+    });
+  });
 });

--- a/packages/datepicker/docs/datepicker/page.mdx
+++ b/packages/datepicker/docs/datepicker/page.mdx
@@ -163,3 +163,13 @@ export const DatePickerLocalizedExample: React.FC = () => {
 };
 
 ```
+
+## Datepicker without menu
+
+If you need to just render a datepicker that is not floating then the prop `flatPicker` will render it as a block element:
+
+```jsx live scope={{UiDatepicker}}
+  <UiDatepicker flatPicker onSelectDate={(date) => console.log(date)} />
+```
+
+When rendering this component like this, the props related to the menu like `onClose` won't be relevant nor used.

--- a/packages/datepicker/src/types/datepicker-props.ts
+++ b/packages/datepicker/src/types/datepicker-props.ts
@@ -54,4 +54,6 @@ export type UiDatepickerProps = {
   selectInitDate?: boolean;
   /** Localized strings if you want to replace the current US locale labels */
   localizedLabels?: UiDatepickerLocalizedLabels;
+  /** Render the datepicker without a floating menu */
+  flatPicker?: boolean;
 } & UiReactElementProps;

--- a/packages/datepicker/src/ui-datepicker.scss
+++ b/packages/datepicker/src/ui-datepicker.scss
@@ -48,7 +48,7 @@
     justify-content: center;
     border-radius: 25px;
     cursor: pointer;
-    margin: 0;
+    margin: 0 auto;
     padding: 0;
     border: 0;
     background-color: transparent;


### PR DESCRIPTION
## 🔥 Render datepicker flat
----------------------------------------------

### Description
The datepicker currently renders on a menu, although some use cases include rendering a datepicker flat in the DOM without being floating.


### Screenshots
<img width="923" alt="Screenshot 2024-09-13 at 12 19 24 AM" src="https://github.com/user-attachments/assets/93fc6e74-4540-41a4-9d3a-d4091356977d">

