### PR TITLE
feat(switch): adding error label to UiSwitch

### DIFF
--- a/packages/form/__tests__/ui-switch.spec.tsx
+++ b/packages/form/__tests__/ui-switch.spec.tsx
@@ -13,6 +13,14 @@ describe('<UiSwitch />', () => {
     expect(screen.getByText('Select this')).toBeVisible();
   });
 
+  it('renders fine with error', () => {
+    uiRender(<UiSwitch label="Select this" name="checkbox" error="Please select the switch to continue" className='SomeClass' />);
+
+    expect(screen.getByRole('checkbox', { hidden: true })).toBeInTheDocument();
+    expect(screen.getByText('Select this')).toBeVisible();
+    expect(screen.getByText('Please select the switch to continue')).toBeVisible();
+  });
+
   it('renders fine when is checked', () => {
     uiRender(<UiSwitch label="Select this" name="checkbox" checked onChange={jest.fn()} />);
 

--- a/packages/form/docs/switch/page.mdx
+++ b/packages/form/docs/switch/page.mdx
@@ -4,19 +4,53 @@ import packageJson from './package-metadata.json';
 import { Metadata } from '@uireact/docs-tools';
 
 # UiSwitch
-<Metadata packageName='form' packageJson={packageJson} />
 
-> Component used to render switch inputs
-
-## Installation
-
-> npm i @uireact/foundation @uireact/form
+<Metadata packageName='form' packageJson={packageJson} includeInformation description='A switch component so user can toggle inputs' />
 
 ## Usage
+
+This is a controlled input so you need to control the state of the toggle. This is done through the `onChange` and `checked` props.
 
 ```jsx live scope={{SwitchExample}}
   <SwitchExample />
 ```
+
+SwitchExample:
+```tsx
+export const SwitchExample: React.FC = () => {
+  const [checked, setChecked] = useState(false);
+
+  const onChangeCB = useCallback(() => {
+    setChecked(!checked);
+  }, [checked, setChecked]);
+
+  return (
+    <>
+      <UiSwitch checked={checked} onChange={onChangeCB} name="switch-example" />
+      <p>Checked: {`${checked}`}</p>
+    </>
+  );
+};
+```
+
+### UiSwitch disabled
+
+```jsx live scope={{UiSwitch}}
+  <UiSwitch name="disabled-checkbox" label="Select option" disabled />
+```
+
+### UiSwitch with error
+
+```jsx live scope={{UiSwitch}}
+  <UiSwitch name="disabled-checkbox" label="Select option" error="Please select this option" />
+```
+
+### UiSwitch with label on the start
+
+```jsx live scope={{UiSwitch}}
+  <UiSwitch name="start-label-checkbox" label="Select option" disabled labelPosition="start" />
+```
+
 
 ### UiSwitch with POSITIVE category
 
@@ -36,14 +70,3 @@ import { Metadata } from '@uireact/docs-tools';
   <UiSwitch name="negative-checkbox" category="negative" checked />
 ```
 
-### UiSwitch disabled
-
-```jsx live scope={{UiSwitch}}
-  <UiSwitch name="disabled-checkbox" label="Select option" disabled />
-```
-
-### UiSwitch with label on the start
-
-```jsx live scope={{UiSwitch}}
-  <UiSwitch name="start-label-checkbox" label="Select option" disabled labelPosition="start" />
-```

--- a/packages/form/src/types/switch.ts
+++ b/packages/form/src/types/switch.ts
@@ -10,7 +10,7 @@ export type UiSwitchProps = {
   /** Label to render next to checkbox */
   label?: string;
   /** The error label to be rendered in this input */
-  error?: boolean;
+  error?: string;
   /** Label position */
   labelPosition?: 'start' | 'end';
   /** On change CB to handle checked state */

--- a/packages/form/src/types/switch.ts
+++ b/packages/form/src/types/switch.ts
@@ -9,6 +9,8 @@ export type UiSwitchProps = {
   name: string;
   /** Label to render next to checkbox */
   label?: string;
+  /** The error label to be rendered in this input */
+  error?: boolean;
   /** Label position */
   labelPosition?: 'start' | 'end';
   /** On change CB to handle checked state */

--- a/packages/form/src/ui-switch.scss
+++ b/packages/form/src/ui-switch.scss
@@ -1,6 +1,6 @@
 .switchLabel {
     font-size: var(--texts-regular);
-    display: flex;
+    display: inline-flex;
     align-items: center;
     justify-content: flex-start;
     cursor: pointer;
@@ -46,4 +46,5 @@
 .switch {
     position: relative;
     display: flex;
+    flex-direction: column;
 }

--- a/packages/form/src/ui-switch.tsx
+++ b/packages/form/src/ui-switch.tsx
@@ -1,6 +1,8 @@
 'use client';
 import React from 'react';
 
+import { UiText } from '@uireact/text';
+
 import { UiSwitchProps } from './types';
 import styles from './ui-switch.scss';
 
@@ -8,7 +10,8 @@ export const UiSwitch: React.FC<UiSwitchProps> = ({
   checked,
   disabled,
   label,
-  className,
+  error,
+  className = '',
   testId,
   labelPosition = 'end',
   name,
@@ -17,25 +20,28 @@ export const UiSwitch: React.FC<UiSwitchProps> = ({
   onChange,
 }: UiSwitchProps) => (
   <div className={`${className} ${styles.switch}`} data-testid={testId}>
-    <input
-      checked={checked}
-      disabled={disabled}
-      id={name}
-      name={name}
-      type="checkbox"
-      ref={ref}
-      onChange={onChange}
-      className={styles.checkboxInput}
-    />{' '}
-    <label htmlFor={name} className={styles.switchLabel}>
-      <>
-        {labelPosition === 'start' && <span>{label}</span>}
-        <span className={`${styles.checkboxPillWrapper} ${checked ? `bg-${category}-100` : 'bg-fonts-100'}`}>
-          <span className={`${styles.checkboxPillDot}  ${checked ? styles.checkedDot : ''}`} />
-        </span>
-        {labelPosition === 'end' && <span>{label}</span>}
-      </>
-    </label>
+    <div>
+      <input
+        checked={checked}
+        disabled={disabled}
+        id={name}
+        name={name}
+        type="checkbox"
+        ref={ref}
+        onChange={onChange}
+        className={styles.checkboxInput}
+      />
+      <label htmlFor={name} className={styles.switchLabel} tabIndex={0}>
+        <>
+          {labelPosition === 'start' && <span>{label}</span>}
+          <span className={`${styles.checkboxPillWrapper} ${checked ? `bg-${category}-100` : 'bg-fonts-100'}`} >
+            <span className={`${styles.checkboxPillDot}  ${checked ? styles.checkedDot : ''}`} />
+          </span>
+          {labelPosition === 'end' && <span>{label}</span>}
+        </>
+      </label>
+    </div>
+    {error && <UiText category='error'>{error}</UiText>}
   </div>
 );
 


### PR DESCRIPTION
## 🔥 Adding error label to UiSwitch
----------------------------------------------

### Description
I'm adding an error prop to be able to render errors on UiSwitch component

### Screenshots
<img width="871" alt="Screenshot 2024-09-18 at 1 48 43 PM" src="https://github.com/user-attachments/assets/fcfafc1b-154a-4439-80d0-9dc58b9c0ebc">

