### PR TITLE
feat(ezforms): adding password field

### DIFF
--- a/packages/ezforms/__tests__/ui-ez-form.spec.tsx
+++ b/packages/ezforms/__tests__/ui-ez-form.spec.tsx
@@ -22,7 +22,8 @@ const schema = {
     .else(validator.is().present("The email is required if you don't provide your phone number.")),
   terms: validator.field('boolean').ezMetadata({ label: 'Terms and conditions' }),
   type: validator.field('choice').ezMetadata({ label: 'Account type' }).oneOf(['user', 'admin', 'editor']),
-  description: validator.field('text').ezMetadata({ label: 'Description', paragraph: true })
+  description: validator.field('text').ezMetadata({ label: 'Description', paragraph: true }),
+  password: validator.field('text').ezMetadata({ label: 'Password', protected: true })
 }
 
 describe('<UiEzForm />', () => {
@@ -47,6 +48,8 @@ describe('<UiEzForm />', () => {
     expect(screen.getByRole('textbox', { name: 'Your Phone' })).toBeVisible();
     expect(screen.getByRole('textbox', { name: 'Description' })).toBeVisible();
     expect(screen.getByRole('combobox', { name: 'Account type' })).toBeVisible();
+    expect(screen.getByRole('textbox', { name: 'Password' })).toBeVisible();
+    expect(screen.getByRole('textbox', { name: 'Password' })).toHaveAttribute('type', 'password');
   });
 
   it('Should initialize form with given data', () => {

--- a/packages/ezforms/__tests__/ui-ez-form.spec.tsx
+++ b/packages/ezforms/__tests__/ui-ez-form.spec.tsx
@@ -48,8 +48,8 @@ describe('<UiEzForm />', () => {
     expect(screen.getByRole('textbox', { name: 'Your Phone' })).toBeVisible();
     expect(screen.getByRole('textbox', { name: 'Description' })).toBeVisible();
     expect(screen.getByRole('combobox', { name: 'Account type' })).toBeVisible();
-    expect(screen.getByRole('textbox', { name: 'Password' })).toBeVisible();
-    expect(screen.getByRole('textbox', { name: 'Password' })).toHaveAttribute('type', 'password');
+    expect(screen.getByLabelText('Password')).toBeVisible();
+    expect(screen.getByLabelText('Password')).toHaveAttribute('type', 'password');
   });
 
   it('Should initialize form with given data', () => {

--- a/packages/ezforms/docs/page.mdx
+++ b/packages/ezforms/docs/page.mdx
@@ -207,3 +207,19 @@ By default the form buttons render inline, although you can pass `buttonsAlignme
     cancelLabel='Cancel' 
   />
 ```
+
+#### Passwords 
+
+In order to use a password field, we need to tell in the metadata that the field is protected, this ONLY works for text inputs.
+
+```jsx live scope={{UiEzForm, UiValidator}}
+  <UiEzForm 
+    schema={{
+      username: new UiValidator().field("text").ezMetadata({ label: "Username:" }),
+      password: new UiValidator().field("text").ezMetadata({ label: "Password:", protected: true })
+    }}
+    buttonsAlignment='stacked'
+    submitLabel='Log in' 
+    cancelLabel='Cancel' 
+  />
+```

--- a/packages/ezforms/docs/page.mdx
+++ b/packages/ezforms/docs/page.mdx
@@ -112,6 +112,7 @@ The `field()` function will set a initial type for that specific field in the sc
 ```ts
   text -> <UiInput type="text" />
   text with .ezMetadata({ paragraph: true }) -> <UiTextarea />
+  text with .ezMetadata({ protected: true }) -> <UiInput type="password" />
   numeric -> <UiInput type="number" />
   email -> <UiInput type="email" />
   phone -> <UiInput type="text" />

--- a/packages/ezforms/src/private/ez-form-field.tsx
+++ b/packages/ezforms/src/private/ez-form-field.tsx
@@ -60,8 +60,9 @@ export const EzFormField = ({
     rules.type.expected === 'phone';
   const inputType = 
     rules.type.expected === 'numeric' ? 'number' : 
-    rules.type.expected === 'email' ? 'email' : 
-    undefined
+    rules.type.expected === 'email' ? 'email' :
+    ezMetadata.protected ? 'password' :
+    undefined;
 
   if (isTextInput) {
     if (ezMetadata.paragraph) {

--- a/packages/validator/src/types/schema-type.ts
+++ b/packages/validator/src/types/schema-type.ts
@@ -86,6 +86,8 @@ export type UiValidatorFieldMetadata = {
   icon?: string;
   dateFormat?: 'yyyy/mm/dd' | 'yyyy-mm-dd' | 'mm/dd/yyyy' | 'dd/mm/yyyy';
   paragraph?: boolean;
+  /** Tells EzForms to display field as password */
+  protected?: boolean;
 }
 
 /** Set of possible rules for each field */


### PR DESCRIPTION
## 🔥 Adding password field to EzForms
----------------------------------------------

### Description
There are use cases where a password field is needed so this will make sure the EzForms can render a password type input.

### Screenshots
<img width="853" alt="Screenshot 2025-01-05 at 5 19 36 PM" src="https://github.com/user-attachments/assets/f80c2717-76e0-46b7-a7fc-1f26244303c9" />
