### PR TITLE
feat(ezforms): adding decorators

### DIFF
--- a/packages/ezforms/__tests__/ui-ez-form.spec.tsx
+++ b/packages/ezforms/__tests__/ui-ez-form.spec.tsx
@@ -5,7 +5,8 @@ import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { UiValidator } from '@uireact/validator';
 
 import { uiRender } from '../../../__tests__/utils';
-import { UiEzForm } from '../src';
+import { UiEzForm, UiEzFormDecoratorsPositions } from '../src';
+import { UiText } from '@uireact/text';
 
 const validator = new UiValidator();
 
@@ -372,5 +373,17 @@ describe('<UiEzForm />', () => {
 
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(onCancel).toHaveBeenCalledTimes(1);
+  });
+
+  it('Should render correctly the decorators', () => {
+    const decorators: UiEzFormDecoratorsPositions = {
+      aboveActions: <UiText>Above actions decorator</UiText>,
+      belowActions: <UiText>Below actions decorator</UiText>
+    };
+
+    uiRender(<UiEzForm schema={{ name: validator.field("text") }} cancelLabel='Reset' submitLabel='Submit' decorators={decorators} />);
+
+    expect(screen.getByText('Above actions decorator')).toBeVisible();
+    expect(screen.getByText('Below actions decorator')).toBeVisible();
   });
 });

--- a/packages/ezforms/docs/page.mdx
+++ b/packages/ezforms/docs/page.mdx
@@ -1,4 +1,5 @@
 import { UiIcon } from '@uireact/icons';
+import { UiText } from '@uireact/text';
 import { UiReactViewRotating } from '@uireact/framer-animations';
 import { UiValidator } from '@uireact/validator';
 import { UiEzForm } from '@uireact/ezforms';
@@ -222,5 +223,21 @@ In order to use a password field, we need to tell in the metadata that the field
     buttonsAlignment='stacked'
     submitLabel='Log in' 
     cancelLabel='Cancel' 
+  />
+```
+
+#### Decorators 
+
+Sometimes we need to add elements around the form to decorate our forms and give more information to users. So, this prop is used to pass react components as props that get rendered based on the position of the decorator.
+
+```jsx live scope={{UiEzForm, UiValidator, UiText}}
+  <UiEzForm 
+    schema={{
+      username: new UiValidator().field("text").ezMetadata({ label: "Username:" }),
+      password: new UiValidator().field("text").ezMetadata({ label: "Password:", protected: true })
+    }}
+    decorators={{ aboveActions: <UiText>Terms and conditions</UiText>, belowActions: <UiText align='center'>30 days free</UiText> }}
+    buttonsAlignment='stacked'
+    submitLabel='Sign up' 
   />
 ```

--- a/packages/ezforms/src/ui-ez-form.tsx
+++ b/packages/ezforms/src/ui-ez-form.tsx
@@ -6,6 +6,11 @@ import { UiValidator, UiValidatorData, UiValidatorErrors, UiValidatorField, UiVa
 
 import { EzFormField, generateInitialData } from './private';
 
+export type UiEzFormDecoratorsPositions = {
+  aboveActions?: React.ReactNode;
+  belowActions?: React.ReactNode;
+}
+
 export type UiEzFormProps = {
   action?: string;
   buttonsAlignment?: 'stacked' | 'inline';
@@ -17,7 +22,8 @@ export type UiEzFormProps = {
   onSubmit?: (e: FormEvent<HTMLFormElement>, data: UiValidatorData) => void;
   onCancel?: () => void;
   useBrowserValidation?: boolean;
-}
+  decorators?: UiEzFormDecoratorsPositions;
+};
 
 const validator = new UiValidator();
 
@@ -32,6 +38,7 @@ export const UiEzForm: React.FC<UiEzFormProps> = ({
   cancelLabel,
   submitLabel,
   useBrowserValidation,
+  decorators,
   onSubmit, 
   onCancel
 }) => {
@@ -97,6 +104,7 @@ export const UiEzForm: React.FC<UiEzFormProps> = ({
             useBrowserValidation={useBrowserValidation}
           />
         )}
+        {decorators?.aboveActions}
         {buttonsAlignment === 'stacked' ? (
           <>
             <UiPrimaryButton type='submit'>
@@ -120,6 +128,7 @@ export const UiEzForm: React.FC<UiEzFormProps> = ({
             )}
           </UiFlexGrid>
         )}
+        {decorators?.belowActions}
       </UiFlexGrid>
     </form>
   );


### PR DESCRIPTION
## 🔥 Adding decorators props to EzForms
----------------------------------------------

### Description
Some use cases need to add content around a form we will use the decorators prop to set up the content inside an EzForm.

### Screenshots
<img width="887" alt="Screenshot 2025-01-06 at 2 00 14 PM" src="https://github.com/user-attachments/assets/44ce4384-3a63-4603-9b67-3522af35b050" />

