### PR TITLE
refactor: any type for form action

### DIFF
--- a/packages/ezforms/src/ui-ez-form.tsx
+++ b/packages/ezforms/src/ui-ez-form.tsx
@@ -12,7 +12,7 @@ export type UiEzFormDecoratorsPositions = {
 }
 
 export type UiEzFormProps = {
-  action?: string;
+  action?: any;
   buttonsAlignment?: 'stacked' | 'inline';
   method?: string;
   schema: UiValidatorSchema;


### PR DESCRIPTION
## 🔥 Using any as type for action form
----------------------------------------------

### Description
The reason for this is because in a context of NextJS the Form can be used to pass a server action, in other contexts there might be other use cases as is unknown for us, we will just leave it as any.

### Screenshots

N/A
