### PR TITLE
feat(ezforms): show loading spinner

### DIFF
--- a/packages/ezforms/__tests__/ui-ez-form.spec.tsx
+++ b/packages/ezforms/__tests__/ui-ez-form.spec.tsx
@@ -520,4 +520,30 @@ describe('<UiEzForm />', () => {
     expect(onSubmit).toHaveBeenCalledTimes(1);
     expect(onSubmit.mock.calls[0][1]).toStrictEqual({ token: 'some-hidden-value' });
   });
+
+  it('Should disabled submit button if is loading', () => {
+    const schema = {
+      name: validator.field('text').ezMetadata({ label: 'Some input' })
+    }
+    const onSubmit = jest.fn();
+
+    uiRender(<UiEzForm schema={schema} loading submitLabel='Submit' onSubmit={onSubmit} />);
+
+    expect(screen.getByRole('textbox', { name: 'Some input' })).toBeVisible();
+
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
+
+  it('Should disabled submit button if is loading and stacked', () => {
+    const schema = {
+      name: validator.field('text').ezMetadata({ label: 'Some input' })
+    }
+    const onSubmit = jest.fn();
+
+    uiRender(<UiEzForm schema={schema} loading submitLabel='Submit' onSubmit={onSubmit} buttonsAlignment='stacked' />);
+
+    expect(screen.getByRole('textbox', { name: 'Some input' })).toBeVisible();
+
+    expect(screen.getByRole('button')).toBeDisabled();
+  });
 });

--- a/packages/ezforms/docs/page.mdx
+++ b/packages/ezforms/docs/page.mdx
@@ -287,3 +287,20 @@ By default the form buttons render inline, although you can pass `buttonsAlignme
     cancelLabel='Cancel' 
   />
 ```
+
+## Loading
+
+The EzForm component exposes a `loading` prop that when passed it will render a loading spinner in the primary button. The primary button will also be disabled. You are responsible for setting its value as true / false to showcase loading behavior.
+
+```jsx live scope={{UiEzForm, UiValidator}}
+  <UiEzForm 
+    schema={{
+      newPassword: new UiValidator().field("text").ezMetadata({ label: "New password:", protected: true }).present("New password is needed"),
+      token: new UiValidator().field("text").ezMetadata({ hidden: true })
+    }}
+    initialData={{ token: 'some-super-secure-token', newPassword: '' }}
+    submitLabel='Submit' 
+    loading
+    onSubmit={(e, data) => {e.preventDefault(); console.log(data);}}
+  />
+```

--- a/packages/ezforms/docs/page.mdx
+++ b/packages/ezforms/docs/page.mdx
@@ -171,6 +171,7 @@ In some forms we want to render hidden inputs to hold data that will be submitte
     }}
     initialData={{ token: 'some-super-secure-token', newPassword: '' }}
     submitLabel='Submit' 
+    loading
     onSubmit={(e, data) => {e.preventDefault(); console.log(data);}}
   />
 ```

--- a/packages/ezforms/src/ui-ez-form.tsx
+++ b/packages/ezforms/src/ui-ez-form.tsx
@@ -2,10 +2,10 @@ import React, { FormEvent, useCallback, useState } from 'react';
 
 import { UiButtonProps, UiPrimaryButton, UiTertiaryButton } from '@uireact/button';
 import { UiFlexGrid } from '@uireact/flex';
-import { UiValidator, UiValidatorData, UiValidatorErrors, UiValidatorField, UiValidatorSchema } from '@uireact/validator';
+import { UiIcon } from '@uireact/icons';
+import { UiValidator, UiValidatorData, UiValidatorErrors, UiValidatorSchema } from '@uireact/validator';
 
 import { EzFormField, generateInitialData } from './private';
-import { UiIcon } from '@uireact/icons';
 
 export type UiEzFormDecoratorsPositions = {
   aboveActions?: React.ReactNode;

--- a/packages/ezforms/src/ui-ez-form.tsx
+++ b/packages/ezforms/src/ui-ez-form.tsx
@@ -5,6 +5,7 @@ import { UiFlexGrid } from '@uireact/flex';
 import { UiValidator, UiValidatorData, UiValidatorErrors, UiValidatorField, UiValidatorSchema } from '@uireact/validator';
 
 import { EzFormField, generateInitialData } from './private';
+import { UiIcon } from '@uireact/icons';
 
 export type UiEzFormDecoratorsPositions = {
   aboveActions?: React.ReactNode;
@@ -23,6 +24,7 @@ export type UiEzFormProps = {
   onCancel?: () => void;
   useBrowserValidation?: boolean;
   decorators?: UiEzFormDecoratorsPositions;
+  loading?: boolean;
 };
 
 const validator = new UiValidator();
@@ -39,12 +41,12 @@ export const UiEzForm: React.FC<UiEzFormProps> = ({
   submitLabel,
   useBrowserValidation,
   decorators,
+  loading,
   onSubmit, 
   onCancel
 }) => {
   const [data, setData] = useState<UiValidatorData>(generateInitialData(schema, initialData));
   const [errors, setErrors] = useState<UiValidatorErrors>();
-  const [loading, setLoading] = useState(false);
 
   const onTextInputChange = useCallback((e: FormEvent<HTMLInputElement>) => {
     setErrors({});
@@ -78,7 +80,6 @@ export const UiEzForm: React.FC<UiEzFormProps> = ({
 
   const onSubmitCB = useCallback((e: FormEvent<HTMLFormElement>) => {
     setErrors({});
-    setLoading(true);
     const result = validator.validate(schema, data);
 
     if (result.passed) {
@@ -87,7 +88,6 @@ export const UiEzForm: React.FC<UiEzFormProps> = ({
       e.preventDefault();
 
       setErrors(result.errors);
-      setLoading(false);
     }
   }, [data, onSubmit, schema]);
 
@@ -113,8 +113,8 @@ export const UiEzForm: React.FC<UiEzFormProps> = ({
         {decorators?.aboveActions}
         {buttonsAlignment === 'stacked' ? (
           <>
-            <UiPrimaryButton type='submit'>
-              {submitLabel}
+            <UiPrimaryButton type='submit' disabled={loading}>
+              {submitLabel} {loading && <UiIcon icon="LoadingSpinner" inverseColoration />}
             </UiPrimaryButton>
             {cancelLabel && (
               <UiTertiaryButton onClick={onCancel}>
@@ -124,8 +124,8 @@ export const UiEzForm: React.FC<UiEzFormProps> = ({
           </>
         ) : (
           <UiFlexGrid gap='four'>
-            <UiPrimaryButton type='submit' padding={inlineButtonSpacing}>
-              {submitLabel}
+            <UiPrimaryButton type='submit' padding={inlineButtonSpacing} disabled={loading}>
+              {submitLabel} {loading && <UiIcon icon="LoadingSpinner" inverseColoration />}
             </UiPrimaryButton>
             {cancelLabel && (
               <UiTertiaryButton onClick={onCancel} padding={inlineButtonSpacing}>


### PR DESCRIPTION
## 🔥 Render loading spinner and disable button
----------------------------------------------

### Description
When `loading` prop is passed a loading spinner will render and the primary button will be disabled,

### Screenshots
<img width="851" alt="Screenshot 2025-01-12 at 6 00 24 PM" src="https://github.com/user-attachments/assets/9b2f84d9-fb12-49a6-ba8a-752df0af4c71" />
