### PR TITLE
fix(text): render all props in text elements

### DIFF
--- a/packages/text/src/ui-heading.tsx
+++ b/packages/text/src/ui-heading.tsx
@@ -19,7 +19,8 @@ export const UiHeading: React.FC<UiHeadingProps> = ({
   margin,
   padding,
   gradient,
-  animated
+  animated,
+  ...props
 }: UiHeadingProps) => {
   let classes = `${className}`;
 
@@ -52,43 +53,43 @@ export const UiHeading: React.FC<UiHeadingProps> = ({
   switch (level) {
     case 1:
       return (
-        <h1 className={classes}>
+        <h1 className={classes} {...props}>
           {children}
         </h1>
       );
     case 2:
       return (
-        <h2 className={classes}>
+        <h2 className={classes} {...props}>
           {children}
         </h2>
       );
     case 3:
       return (
-        <h3 className={classes}>
+        <h3 className={classes} {...props}>
           {children}
         </h3>
       );
     case 4:
       return (
-        <h4 className={classes}>
+        <h4 className={classes} {...props}>
           {children}
         </h4>
       );
     case 5:
       return (
-        <h5 className={classes}>
+        <h5 className={classes} {...props}>
           {children}
         </h5>
       );
     case 6:
       return (
-        <h6 className={classes}>
+        <h6 className={classes} {...props}>
           {children}
         </h6>
       );
     default:
       return (
-        <h3 className={classes}>
+        <h3 className={classes} {...props}>
           {children}
         </h3>
       );

--- a/packages/text/src/ui-label.tsx
+++ b/packages/text/src/ui-label.tsx
@@ -12,7 +12,8 @@ export const UiLabel: React.FC<UiLabelProps> = ({
   size = 'small',
   category = 'fonts',
   margin,
-  padding
+  padding,
+  ...props
 }: UiLabelProps) => {
   let classes = `${className} color-${category}-100 size-${size}`;
 
@@ -25,7 +26,7 @@ export const UiLabel: React.FC<UiLabelProps> = ({
   }
 
   return (
-    <label htmlFor={htmlFor} className={classes}>
+    <label htmlFor={htmlFor} className={classes} {...props}>
       {children}
     </label>
   );

--- a/packages/text/src/ui-link.tsx
+++ b/packages/text/src/ui-link.tsx
@@ -16,7 +16,8 @@ export const UiLink: React.FC<UiLinkProps> = ({
   size = 'regular',
   wrap = 'normal',
   margin,
-  padding
+  padding,
+  ...props
 }: UiLinkProps) => {
   let classes = `${className} color-${category}-100 size-${size}`;
 
@@ -41,7 +42,7 @@ export const UiLink: React.FC<UiLinkProps> = ({
   }
 
   if (children && React.isValidElement(children)) {
-    return React.cloneElement(children as React.ReactElement, { className: classes });
+    return React.cloneElement(children as React.ReactElement, { className: classes, ...props });
   }
 
   return null;

--- a/packages/text/src/ui-text.tsx
+++ b/packages/text/src/ui-text.tsx
@@ -17,7 +17,8 @@ export const UiText: React.FC<UiTextProps> = ({
   inverseColoration,
   wrap = 'normal',
   margin,
-  padding
+  padding,
+  ...props
 }: UiTextProps) => {
   let classes = `${className} ${styles.text} color-${inverseColoration ? 'inverse-' : ''}${category}-100 size-${size}`;
 
@@ -54,7 +55,7 @@ export const UiText: React.FC<UiTextProps> = ({
   }
 
   return (
-    <p className={classes}>
+    <p className={classes} {...props}>
       {children}
     </p>
   );


### PR DESCRIPTION
## 🔥 Rendering all props in text elements
----------------------------------------------

### Description
Noticed that aria props as well as data props were not rendered in texts elements, this was due to not passing it to the text element. This fixes it.

### Screenshots

#### Before

#### After
