### PR TITLE
fix(confirm-dialog): buttons spacing

### DIFF
--- a/packages/confirm-dialog/src/ui-confirm-dialog.tsx
+++ b/packages/confirm-dialog/src/ui-confirm-dialog.tsx
@@ -28,7 +28,7 @@ const animation: MotionProps = {
   }
 };
 
-const confirmButtonPadding: UiSpacingProps['padding'] = { block: 'four', inline: 'six' };
+const confirmButtonPadding: UiSpacingProps['padding'] = { block: 'two', inline: 'four' };
 
 export const UiConfirmDialog: React.FC = () => {
   const [confirmLoading, setConfirmLoading] = useState(false);


### PR DESCRIPTION
## 🔥 fix confirm dialog buttons spacing
----------------------------------------------

### Description
The buttons padding was too big

### Screenshots

#### Before
<img width="498" alt="Screenshot 2025-04-08 at 12 14 53 PM" src="https://github.com/user-attachments/assets/19612708-08c4-4254-90d5-411cce930824" />

#### After
<img width="438" alt="Screenshot 2025-04-08 at 12 14 42 PM" src="https://github.com/user-attachments/assets/3c396999-6ce3-4f12-99bc-da9f0db49a9e" />
