### PR TITLE
refactor: bump react peer version

### DIFF
--- a/packages/badge/package.json
+++ b/packages/badge/package.json
@@ -33,8 +33,8 @@
   },
   "peerDependencies": {
     "@uireact/foundation": "^2.0.1",
-    "react": ">= 17 < 19",
-    "react-dom": ">= 17 < 19",
+    "react": ">= 17 < 20",
+    "react-dom": ">= 17 < 20",
     "tslib": "^2.5.0"
   }
 }

--- a/packages/button/package.json
+++ b/packages/button/package.json
@@ -31,8 +31,8 @@
     "@uireact/foundation": ">= 3",
     "@uireact/view": ">= 3",
     "framer-motion": ">= 11",
-    "react": ">= 17 < 19",
-    "react-dom": ">= 17 < 19",
+    "react": ">= 17 < 20",
+    "react-dom": ">= 17 < 20",
     "tslib": "^2.5.0"
   }
 }

--- a/packages/card/package.json
+++ b/packages/card/package.json
@@ -30,6 +30,6 @@
   "peerDependencies": {
     "@uireact/foundation": ">= 3",
     "framer-motion": ">= 11",
-    "react": ">= 17 < 19"
+    "react": ">= 17 < 20"
   }
 }

--- a/packages/charts/package.json
+++ b/packages/charts/package.json
@@ -33,8 +33,8 @@
     "@uireact/flex": ">= 3",
     "@uireact/foundation": ">= 3",
     "@uireact/text": ">= 3",
-    "react": ">= 17 < 19",
-    "react-dom": ">= 17 < 19",
+    "react": ">= 17 < 20",
+    "react-dom": ">= 17 < 20",
     "tslib": "^2.5.0"
   }
 }

--- a/packages/confirm-dialog/package.json
+++ b/packages/confirm-dialog/package.json
@@ -40,8 +40,8 @@
     "@uireact/icons": ">= 3",
     "@uireact/text": ">= 3.1.9",
     "framer-motion": ">= 11",
-    "react": ">= 17 < 19",
-    "react-dom": ">= 17 < 19",
+    "react": ">= 17 < 20",
+    "react-dom": ">= 17 < 20",
     "tslib": "^2.5.0"
   }
 }

--- a/packages/datepicker/package.json
+++ b/packages/datepicker/package.json
@@ -46,8 +46,8 @@
     "@uireact/menu": ">= 3",
     "@uireact/text": ">= 3",
     "framer-motion": ">= 11",
-    "react": ">= 17 < 19",
-    "react-dom": ">= 17 < 19",
+    "react": ">= 17 < 20",
+    "react-dom": ">= 17 < 20",
     "tslib": "^2.5.0"
   }
 }

--- a/packages/dialog/package.json
+++ b/packages/dialog/package.json
@@ -38,8 +38,8 @@
     "@uireact/icons": ">= 3",
     "@uireact/text": ">= 3",
     "framer-motion": ">= 11",
-    "react": ">= 17 < 19",
-    "react-dom": ">= 17 < 19",
+    "react": ">= 17 < 20",
+    "react-dom": ">= 17 < 20",
     "tslib": "^2.5.0"
   }
 }

--- a/packages/expando/package.json
+++ b/packages/expando/package.json
@@ -35,8 +35,8 @@
     "@uireact/foundation": ">= 3",
     "@uireact/icons": ">= 3",
     "@uireact/text": ">= 3",
-    "react": ">= 17 < 19",
-    "react-dom": ">= 17 < 19",
+    "react": ">= 17 < 20",
+    "react-dom": ">= 17 < 20",
     "tslib": "^2.5.0"
   }
 }

--- a/packages/ezforms/package.json
+++ b/packages/ezforms/package.json
@@ -43,8 +43,8 @@
     "@uireact/icons": ">= 3",
     "@uireact/text": ">= 3",
     "@uireact/validator": ">= 2.2.0",
-    "react": ">= 17 < 19",
-    "react-dom": ">= 17 < 19",
+    "react": ">= 17 < 20",
+    "react-dom": ">= 17 < 20",
     "tslib": "^2.5.0"
   }
 }

--- a/packages/flex/package.json
+++ b/packages/flex/package.json
@@ -29,8 +29,8 @@
   },
   "peerDependencies": {
     "@uireact/foundation": ">= 3",
-    "react": ">= 17 < 19",
-    "react-dom": ">= 17 < 19",
+    "react": ">= 17 < 20",
+    "react-dom": ">= 17 < 20",
     "tslib": "^2.5.0"
   }
 }

--- a/packages/form/package.json
+++ b/packages/form/package.json
@@ -31,8 +31,8 @@
   "peerDependencies": {
     "@uireact/foundation": ">= 3",
     "@uireact/text": ">= 3",
-    "react": ">= 17 < 19",
-    "react-dom": ">= 17 < 19",
+    "react": ">= 17 < 20",
+    "react-dom": ">= 17 < 20",
     "tslib": "^2.5.0"
   }
 }

--- a/packages/foundation/package.json
+++ b/packages/foundation/package.json
@@ -25,8 +25,8 @@
     "watch": "tsup src/index.ts --format cjs,esm --dts --watch"
   },
   "peerDependencies": {
-    "react": ">= 17 < 19",
-    "react-dom": ">= 17 < 19",
+    "react": ">= 17 < 20",
+    "react-dom": ">= 17 < 20",
     "tslib": "^2.5.0"
   }
 }

--- a/packages/grid/package.json
+++ b/packages/grid/package.json
@@ -29,8 +29,8 @@
   },
   "peerDependencies": {
     "@uireact/foundation": ">= 3",
-    "react": ">= 17 < 19",
-    "react-dom": ">= 17 < 19",
+    "react": ">= 17 < 20",
+    "react-dom": ">= 17 < 20",
     "tslib": "^2.5.0"
   }
 }

--- a/packages/header/package.json
+++ b/packages/header/package.json
@@ -29,8 +29,8 @@
   },
   "peerDependencies": {
     "@uireact/foundation": ">= 3",
-    "react": ">= 17 < 19",
-    "react-dom": ">= 17 < 19",
+    "react": ">= 17 < 20",
+    "react-dom": ">= 17 < 20",
     "tslib": "^2.5.0"
   }
 }

--- a/packages/icons/package.json
+++ b/packages/icons/package.json
@@ -33,8 +33,8 @@
     "@uireact/foundation": ">= 3",
     "@uireact/framer-animations": ">= 0",
     "framer-motion": ">= 11",
-    "react": ">= 17 < 19",
-    "react-dom": ">= 17 < 19",
+    "react": ">= 17 < 20",
+    "react-dom": ">= 17 < 20",
     "tslib": "^2.5.0"
   }
 }

--- a/packages/list/package.json
+++ b/packages/list/package.json
@@ -29,8 +29,8 @@
   },
   "peerDependencies": {
     "@uireact/foundation": ">= 3",
-    "react": ">= 17 < 19",
-    "react-dom": ">= 17 < 19",
+    "react": ">= 17 < 20",
+    "react-dom": ">= 17 < 20",
     "tslib": "^2.5.0"
   }
 }

--- a/packages/menu/package.json
+++ b/packages/menu/package.json
@@ -34,8 +34,8 @@
     "@uireact/foundation": ">= 3",
     "@uireact/framer-animations": ">= 0",
     "framer-motion": ">= 11",
-    "react": ">= 17 < 19",
-    "react-dom": ">= 17 < 19",
+    "react": ">= 17 < 20",
+    "react-dom": ">= 17 < 20",
     "tslib": "^2.5.0"
   }
 }

--- a/packages/navbar/package.json
+++ b/packages/navbar/package.json
@@ -32,8 +32,8 @@
     "@uireact/foundation": "^2.0.1",
     "@uireact/framer-animations": ">= 0",
     "framer-motion": ">= 11",
-    "react": ">= 17 < 19",
-    "react-dom": ">= 17 < 19",
+    "react": ">= 17 < 20",
+    "react-dom": ">= 17 < 20",
     "tslib": "^2.5.0"
   }
 }

--- a/packages/notifications/package.json
+++ b/packages/notifications/package.json
@@ -38,8 +38,8 @@
     "@uireact/icons": ">= 3",
     "@uireact/text": ">= 3",
     "@uireact/view": ">= 3.5.0",
-    "react": ">= 17 < 19",
-    "react-dom": ">= 17 < 19",
+    "react": ">= 17 < 20",
+    "react-dom": ">= 17 < 20",
     "tslib": "^2.5.0"
   }
 }

--- a/packages/progress-indicator/package.json
+++ b/packages/progress-indicator/package.json
@@ -33,8 +33,8 @@
     "@uireact/foundation": ">= 3",
     "@uireact/icons": ">= 3",
     "@uireact/text": ">= 3",
-    "react": ">= 17 < 19",
-    "react-dom": ">= 17 < 19",
+    "react": ">= 17 < 20",
+    "react-dom": ">= 17 < 20",
     "tslib": "^2.5.0"
   }
 }

--- a/packages/separator/package.json
+++ b/packages/separator/package.json
@@ -29,8 +29,8 @@
   },
   "peerDependencies": {
     "@uireact/foundation": ">= 3",
-    "react": ">= 17 < 19",
-    "react-dom": ">= 17 < 19",
+    "react": ">= 17 < 20",
+    "react-dom": ">= 17 < 20",
     "tslib": "^2.5.0"
   }
 }

--- a/packages/table/package.json
+++ b/packages/table/package.json
@@ -37,8 +37,8 @@
     "@uireact/foundation": ">= 3",
     "@uireact/grid": ">= 3",
     "@uireact/icons": ">= 3",
-    "react": ">= 17 < 19",
-    "react-dom": ">= 17 < 19",
+    "react": ">= 17 < 20",
+    "react-dom": ">= 17 < 20",
     "tslib": "^2.5.0"
   }
 }

--- a/packages/tabs/package.json
+++ b/packages/tabs/package.json
@@ -29,8 +29,8 @@
   },
   "peerDependencies": {
     "@uireact/foundation": ">= 3",
-    "react": ">= 17 < 19",
-    "react-dom": ">= 17 < 19",
+    "react": ">= 17 < 20",
+    "react-dom": ">= 17 < 20",
     "tslib": "^2.5.0"
   }
 }

--- a/packages/text/package.json
+++ b/packages/text/package.json
@@ -29,8 +29,8 @@
   },
   "peerDependencies": {
     "@uireact/foundation": ">= 3",
-    "react": ">= 17 < 19",
-    "react-dom": ">= 17 < 19",
+    "react": ">= 17 < 20",
+    "react-dom": ">= 17 < 20",
     "tslib": "^2.5.0"
   }
 }

--- a/packages/tooltip/package.json
+++ b/packages/tooltip/package.json
@@ -36,8 +36,8 @@
     "@uireact/icons": ">= 3",
     "@uireact/text": ">= 3",
     "framer-motion": ">= 11",
-    "react": ">= 17 < 19",
-    "react-dom": ">= 17 < 19",
+    "react": ">= 17 < 20",
+    "react-dom": ">= 17 < 20",
     "tslib": "^2.5.0"
   }
 }

--- a/packages/view/package.json
+++ b/packages/view/package.json
@@ -30,8 +30,8 @@
   "peerDependencies": {
     "@uireact/dialog": ">= 3",
     "@uireact/foundation": ">= 4",
-    "react": ">= 17 < 19",
-    "react-dom": ">= 17 < 19",
+    "react": ">= 17 < 20",
+    "react-dom": ">= 17 < 20",
     "tslib": "^2.5.0"
   }
 }


### PR DESCRIPTION
## 🔥 Bumping react peer version
----------------------------------------------

### Description
Bumping react peer version so applications running newer versions of React doesn't get a peers version mismatch warning. There isn't anything that is in use in the library that breaks with the new react version.

### Screenshots
N/A
