### PR TITLE
feat: adding text input to range slider

### DIFF
--- a/packages/form/__tests__/__private/get-range-position.spec.ts
+++ b/packages/form/__tests__/__private/get-range-position.spec.ts
@@ -11,8 +11,18 @@ describe('getRangePosition() - position is a %', () => {
     expect(position).toBe(0);
   });
 
+  it('Should get the correct range position when value is less than min', () => {
+    const position = getRangePosition(10, 50, 5);
+    expect(position).toBe(0);
+  });
+
   it('Should get the correct range position when value is max', () => {
     const position = getRangePosition(10, 50, 50);
+    expect(position).toBe(100);
+  });
+
+  it('Should get the correct range position when value is more than max', () => {
+    const position = getRangePosition(10, 50, 100);
     expect(position).toBe(100);
   });
 

--- a/packages/form/__tests__/ui-range.spec.tsx
+++ b/packages/form/__tests__/ui-range.spec.tsx
@@ -72,6 +72,17 @@ describe('<Component />', () => {
     expect(screen.getByText('70')).toBeVisible();
   });
 
+  it('renders fine with text input', () => {
+    uiRender(<UiRangeInput icon={<UiIcon icon="Add" />} category='primary' label="Input" labelOnTop name="MyInput" max={100} min={50} value={70} showRangeLabels onChange={jest.fn()} showTextInput />);
+
+    expect(screen.getByRole('slider', { name: 'Input' })).toBeVisible();
+    expect(screen.getByRole('textbox')).toBeVisible();
+    expect(screen.getByRole('textbox')).toHaveValue("70");
+    expect(screen.getByText('50')).toBeVisible();
+    expect(screen.getByText('100')).toBeVisible();
+    expect(screen.getByText('70')).toBeVisible();
+  });
+
   it('triggerd on change successfully when value is changed', () => {
     const onChangeSpy = jest.fn();
     uiRender(<UiRangeInput label="Input" name="MyInput" max={100} min={50} value={70} onChange={onChangeSpy} />);

--- a/packages/form/docs/range/example/range-example.tsx
+++ b/packages/form/docs/range/example/range-example.tsx
@@ -13,7 +13,7 @@ export const RangeExample = () => {
   return (
     <div>
       <p>Value: {value}</p>
-      <UiRangeInput value={value} onChange={onChange} name="range-input-1" min={20} max={100} />
+      <UiRangeInput value={value} onChange={onChange} name="range-input-1" min={20} max={100} showTextInput />
     </div>
   )
 }

--- a/packages/form/docs/range/page.mdx
+++ b/packages/form/docs/range/page.mdx
@@ -73,6 +73,25 @@ The icon and labelOnTop prop adds styling to the slider so those elements can re
   />
 ```
 
+## UiRangeInput with text input
+
+Sometimes in mobile devices is hard to move accurately the slider when the values are too separated. So, a text input could help improve the experience.
+
+```jsx live scope={{UiRangeInput, UiIcon}}
+  <UiRangeInput min="0" max="100"
+    showRangeLabels
+    label="Select a value:"
+    labelOnTop
+    icon={<UiIcon icon="CreditCard" size="xlarge" />}
+    prefix="$"
+    value={50}
+    showTextInput
+    onChange={(value) => {
+      console.log(value);
+    }}
+  />
+```
+
 ## UiRangeInput with steps
 
 The step prop tells each clickable step value for the range.

--- a/packages/form/src/__private/get-range-position.ts
+++ b/packages/form/src/__private/get-range-position.ts
@@ -3,15 +3,25 @@ export const getRangePosition = (min: number, max: number, value?: number, step?
     return 0;
   }
 
+  const numericValue = parseInt(value.toString());
+
+  if (numericValue < min) {
+    return 0;
+  }
+
+  if (numericValue > max) {
+    return 100;
+  }
+
   const range = max - min;
-  let selected = value - min;
+  let selected = numericValue - min;
 
   if (step) {
-    const baseValue = value - min;
+    const baseValue = numericValue - min;
     const isSelectable = (baseValue % step) === 0;
 
     if (!isSelectable) {
-      const nextSelectable = value + (baseValue % step);
+      const nextSelectable = numericValue + (baseValue % step);
       selected = nextSelectable - min;
     }
   }

--- a/packages/form/src/types/range.ts
+++ b/packages/form/src/types/range.ts
@@ -43,4 +43,6 @@ export type UiRangeInputProps = {
   required?: boolean;
   /** The ticks information to render in the range */
   ticks?: UiRangeInputTick[];
+  /** If a text input should be rendered next to the range to type in the value */
+  showTextInput?: boolean;
 } & UiReactElementProps & AriaAttributes;

--- a/packages/form/src/ui-range.scss
+++ b/packages/form/src/ui-range.scss
@@ -144,7 +144,7 @@
   display: flex;
   flex-direction: row;
   justify-content: space-between;
-  align-items: flex-end;
+  align-items: center;
   gap: var(--spacing-two);
 }
 
@@ -171,4 +171,8 @@
   top: 100%;
   z-index: 5;
   box-shadow: rgba(50, 50, 93, 0.25) 0px 2px 5px -1px, rgba(0, 0, 0, 0.3) 0px 1px 3px -1px;
+}
+
+.rangeTextInput {
+  max-width: 100px;
 }

--- a/packages/form/src/ui-range.tsx
+++ b/packages/form/src/ui-range.tsx
@@ -7,6 +7,7 @@ import { UiRangeInputProps } from './types';
 import styles from './ui-range.scss';
 import inputStyles from './ui-input.scss';
 import { getRangePosition } from './__private';
+import { UiInput } from './ui-input';
 
 const defaultPadding: SpacingDistribution = { block: 'one', inline: 'one' };
 
@@ -30,6 +31,7 @@ export const UiRangeInput: React.FC<UiRangeInputProps> = ({
   step,
   required,
   prefix,
+  showTextInput,
   ...props
 }: UiRangeInputProps) => {
   const [innerValue, setInnerValue] = useState<number>(value || min);
@@ -102,6 +104,13 @@ export const UiRangeInput: React.FC<UiRangeInputProps> = ({
                 />
               </div>
               {showRangeLabels && <p>{maxLabel}</p>}
+              {showTextInput && <UiInput 
+                value={innerValue.toString()} 
+                category={category}
+                className={styles.rangeTextInput} 
+                onChange={internalOnChange} 
+                />
+              }
           </div>
         </div>
         {error && <UiText category={category}>{error}</UiText>}


### PR DESCRIPTION
## 🔥 Adding text input to range slider
----------------------------------------------

### Description
In some cases in mobile devices the range is not as easy to manipulate so an option to add a text box next to the range makes sense.

### Screenshots

![Screenshot 2025-05-08 at 3 30 58 PM](https://github.com/user-attachments/assets/c8ee5b9d-35e8-499b-add3-76f0f501fc04)
