### PR TITLE
refactor: change switch colorations

### DIFF
--- a/packages/form/src/ui-switch.scss
+++ b/packages/form/src/ui-switch.scss
@@ -23,6 +23,8 @@
     border-radius: 50px;
     position: relative;
     transition: background-color 0.2s;
+    border-width: 1px;
+    border-style: solid;
 }
 
 .checkboxPillDot {
@@ -35,7 +37,7 @@
     border-radius: 20px;
     transition: 0.2s;
     box-shadow: 0 0 2px 0 rgba(10, 10, 10, 0.29);
-    background-color: var(--inverse-fonts-token_100);
+    background-color: var(--inverse-primary-token_100);
 }
 
 .checkedDot {

--- a/packages/form/src/ui-switch.tsx
+++ b/packages/form/src/ui-switch.tsx
@@ -34,7 +34,7 @@ export const UiSwitch: React.FC<UiSwitchProps> = ({
       <label htmlFor={name} className={styles.switchLabel} tabIndex={0}>
         <>
           {labelPosition === 'start' && <span>{label}</span>}
-          <span className={`${styles.checkboxPillWrapper} ${checked ? `bg-${category}-100` : 'bg-fonts-100'}`} >
+          <span className={`${styles.checkboxPillWrapper} ${checked ? `bg-${category}-100` : 'bg-primary-100'} border-primary-200`} >
             <span className={`${styles.checkboxPillDot}  ${checked ? styles.checkedDot : ''}`} />
           </span>
           {labelPosition === 'end' && <span>{label}</span>}


### PR DESCRIPTION
## 🔥 Changing switch colorations
----------------------------------------------

### Description
The switch was using fonts colors, although we shouldn't use those colors as are reserver for fonts.

### Screenshots

#### Before
![Screenshot 2025-05-08 at 3 41 23 PM](https://github.com/user-attachments/assets/68dad2f6-45bb-4b8e-8413-a7fa3994a1ab)

#### After
![Screenshot 2025-05-08 at 3 40 40 PM](https://github.com/user-attachments/assets/da280af3-1e7d-4fee-bceb-7e8bd75a9fd7)
