### PR TITLE
feat(ezforms): text input inside range input

### DIFF
--- a/packages/ezforms/__tests__/ui-ez-form.spec.tsx
+++ b/packages/ezforms/__tests__/ui-ez-form.spec.tsx
@@ -138,6 +138,38 @@ describe('<UiEzForm />', () => {
     expect(onSubmit).toHaveBeenCalledTimes(1);
   });
 
+  it('Should update data correctly when using text input in range input', () => {
+    const onSubmit = jest.fn().mockImplementation((e) => {
+      e.preventDefault();
+    });
+
+    const schema = {
+      invest: validator
+        .field('numeric')
+        .range(0, 100)
+        .ezMetadata({ label: 'Investment', rangeWithTextInput: true })
+        .present("Select investment")
+    }
+
+    uiRender(<UiEzForm schema={schema} submitLabel='Submit' onSubmit={onSubmit} />);
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(onSubmit).toHaveBeenCalledTimes(0);
+    expect(screen.getByText('Select investment')).toBeVisible();
+
+    const slider = screen.getByRole('slider');
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 80 } });
+
+    expect(slider).toHaveValue("80");
+
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }));
+
+    expect(screen.queryByText('Select investment')).not.toBeInTheDocument();
+
+    expect(onSubmit).toHaveBeenCalledTimes(1);
+  });
+
   it('Should render errors on submit when there conditional errors', () => {
     const onSubmit = jest.fn().mockImplementation((e) => {
       e.preventDefault();

--- a/packages/ezforms/docs/example/ezform-example.tsx
+++ b/packages/ezforms/docs/example/ezform-example.tsx
@@ -43,8 +43,8 @@ const schema = {
   money: validator
     .field('numeric')
     .present("Please select a value")
-    .ezMetadata({ label: 'How much would you like to invest?', prefix: '$' })
-    .range(0, 100),
+    .ezMetadata({ label: 'How much would you like to invest?', prefix: '$', rangeWithTextInput: true })
+    .range(0, 100, "Only values between $0 and $100 are valid."),
   terms: validator
     .field('boolean')
     .ezMetadata({ label: 'Accept terms and conditions' })

--- a/packages/ezforms/docs/page.mdx
+++ b/packages/ezforms/docs/page.mdx
@@ -64,8 +64,8 @@ const schema = {
   money: validator
     .field('numeric')
     .present("Please select a value")
-    .ezMetadata({ label: 'How much would you like to invest?', prefix: '$' })
-    .range(0, 100),
+    .ezMetadata({ label: 'How much would you like to invest?', prefix: '$', rangeWithTextInput: true })
+    .range(0, 100, "Only values between $0 and $100 are valid."),
   terms: validator
     .field('boolean')
     .ezMetadata({ label: 'Accept terms and conditions' })

--- a/packages/ezforms/src/private/ez-form-field.tsx
+++ b/packages/ezforms/src/private/ez-form-field.tsx
@@ -16,6 +16,7 @@ type EzFormFieldProps = {
   onTextInputChange: (e: FormEvent<HTMLInputElement>) => void;
   onTextAreaChange: (e: FormEvent<HTMLTextAreaElement>) => void;
   onSelectInputChange: (value: string, name: string) => void;
+  onNumericInputChange: (value: number, name: string) => void;
   onDateInputChange: (date: string, name: string) => void;
   onBooleanToogle: (value: boolean, name: string) => void;
   onDigitsInputChange: (value: string, name: string) => void;
@@ -28,6 +29,7 @@ export const EzFormField = ({
   value, 
   useBrowserValidation, 
   onTextInputChange,
+  onNumericInputChange,
   onTextAreaChange,
   onDateInputChange,
   onBooleanToogle,
@@ -86,12 +88,13 @@ export const EzFormField = ({
           showRangeLabels
           name={name} 
           value={value} 
-          onChange={onTextInputChange} 
+          onChange={onNumericInputChange} 
           min={rules.range.min}
           max={rules.range.max}
           error={error}
           category={error ? 'error' : 'secondary'}
           prefix={ezMetadata.prefix}
+          showTextInput={ezMetadata.rangeWithTextInput}
         />
       )
     }

--- a/packages/ezforms/src/ui-ez-form.tsx
+++ b/packages/ezforms/src/ui-ez-form.tsx
@@ -90,6 +90,15 @@ export const UiEzForm: React.FC<UiEzFormProps> = ({
     onChange?.(newData);
   }, [data, onChange]);
 
+  const onNumericInputChange = useCallback((value: number, name: string) => {
+    const newData = { ...data, [name]: value };
+    setErrors({});
+    setData(newData);
+
+    // istanbul ignore next
+    onChange?.(newData);
+  }, [data, onChange]);
+
   const onBooleanToogle = useCallback((value: Boolean, name: string) => {
     const newData = { ...data, [name]: value };
     setErrors({});
@@ -126,6 +135,7 @@ export const UiEzForm: React.FC<UiEzFormProps> = ({
             onTextAreaChange={onTextAreaChange}
             onDateInputChange={onStringChange}
             onBooleanToogle={onBooleanToogle}
+            onNumericInputChange={onNumericInputChange}
             onSelectInputChange={onStringChange}
             onDigitsInputChange={onStringChange}
             useBrowserValidation={useBrowserValidation}

--- a/packages/form/__tests__/ui-range.spec.tsx
+++ b/packages/form/__tests__/ui-range.spec.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useState } from 'react';
 
 import { screen, fireEvent } from '@testing-library/react';
 
@@ -73,14 +73,44 @@ describe('<Component />', () => {
   });
 
   it('renders fine with text input', () => {
-    uiRender(<UiRangeInput icon={<UiIcon icon="Add" />} category='primary' label="Input" labelOnTop name="MyInput" max={100} min={50} value={70} showRangeLabels onChange={jest.fn()} showTextInput />);
+    const onChangeSpy = jest.fn();
+    const Component = ({ onChangeSpy }: { onChangeSpy: (value: number, name: string) => void }) => {
+      const [value, setValue] = useState(70);
 
-    expect(screen.getByRole('slider', { name: 'Input' })).toBeVisible();
+      return (
+        <UiRangeInput 
+          icon={<UiIcon icon="Add" />} 
+          category='primary' 
+          label="MyRangeInput" 
+          labelOnTop 
+          name="MyInput" 
+          max={100} 
+          min={50} 
+          value={value} 
+          showRangeLabels 
+          onChange={(value, name) => { setValue(value); onChangeSpy(value, name); }} 
+          showTextInput
+        />
+      )
+    }
+
+    uiRender(<Component onChangeSpy={onChangeSpy}  />);
+
+    expect(screen.getByRole('slider', { name: 'MyRangeInput' })).toBeVisible();
     expect(screen.getByRole('textbox')).toBeVisible();
     expect(screen.getByRole('textbox')).toHaveValue("70");
+
     expect(screen.getByText('50')).toBeVisible();
     expect(screen.getByText('100')).toBeVisible();
     expect(screen.getByText('70')).toBeVisible();
+
+    fireEvent.change(screen.getByRole('textbox'), { target: { value: 90 } });
+
+    expect(screen.getByRole('textbox')).toHaveValue("90");
+    expect(screen.getByRole('slider', { name: 'MyRangeInput' })).toHaveValue("90");
+
+    expect(onChangeSpy).toHaveBeenCalledTimes(1);
+    expect(onChangeSpy).toHaveBeenCalledWith(90, "MyInput");
   });
 
   it('triggerd on change successfully when value is changed', () => {
@@ -92,6 +122,7 @@ describe('<Component />', () => {
     fireEvent.change(screen.getByRole('slider'), { target: { value: 80 } });
 
     expect(onChangeSpy).toHaveBeenCalledTimes(1);
+    expect(onChangeSpy).toHaveBeenCalledWith(80, "MyInput");
   });
 
   it('renders fine with label, step and value is selectable', () => {

--- a/packages/form/docs/range/example/range-example.tsx
+++ b/packages/form/docs/range/example/range-example.tsx
@@ -6,8 +6,8 @@ import { UiRangeInput } from '@uireact/form';
 export const RangeExample = () => {
   const [value, setValue] = useState(50);
 
-  const onChange = useCallback((event: FormEvent<HTMLInputElement>) => {
-    setValue(parseInt(event.currentTarget.value));
+  const onChange = useCallback((value: number) => {
+    setValue(value);
   }, []);
 
   return (
@@ -21,8 +21,8 @@ export const RangeExample = () => {
 export const RangeNotSelectableExample = () => {
   const [value, setValue] = useState(80);
 
-  const onChange = useCallback((event: FormEvent<HTMLInputElement>) => {
-    setValue(parseInt(event.currentTarget.value));
+  const onChange = useCallback((value: number) => {
+    setValue(value);
   }, []);
 
   return (

--- a/packages/form/docs/range/page.mdx
+++ b/packages/form/docs/range/page.mdx
@@ -20,7 +20,7 @@ import { RangeExample, RangeNotSelectableExample } from './example';
 
 This renders an input type "range" and wraps it with the library styling so it looks and feels consistently across browsers. 
 
-This is a controlled component which means you have to handle the value and provide a `onChange` callback.
+This is a controlled component which means you have to handle the value and provide an `onChange` callback. The `onChange` callback will receive 2 properties: 1 the value as a number type, 2 the name of the given range field.
 
 ```jsx live scope={{RangeExample}}
   <RangeExample />

--- a/packages/form/src/types/range.ts
+++ b/packages/form/src/types/range.ts
@@ -20,7 +20,7 @@ export type UiRangeInputProps = {
   /** Label on top of field */
   labelOnTop?: boolean;
   /** CB for when value in input changes */
-  onChange: (e: React.FormEvent<HTMLInputElement>) => void;
+  onChange: (value: number, name: string) => void;
   /* React ref */
   ref?: React.Ref<HTMLInputElement>;
   /** Input field theme */

--- a/packages/form/src/ui-range.tsx
+++ b/packages/form/src/ui-range.tsx
@@ -43,8 +43,8 @@ export const UiRangeInput: React.FC<UiRangeInputProps> = ({
   const valueLabel = prefix ? `${prefix}${innerValue}` : innerValue;
 
   const internalOnChange = useCallback((value: FormEvent<HTMLInputElement>) => {
-    onChange(value);
-  }, [onChange]);
+    onChange(parseInt(value.currentTarget.value), name);
+  }, [onChange, name]);
 
   useEffect(() => {
     setPosition(getRangePosition(min, max, value, step));
@@ -106,6 +106,7 @@ export const UiRangeInput: React.FC<UiRangeInputProps> = ({
               {showRangeLabels && <p>{maxLabel}</p>}
               {showTextInput && <UiInput 
                 value={innerValue.toString()} 
+                name={`text-input-for-${name}`}
                 category={category}
                 className={styles.rangeTextInput} 
                 onChange={internalOnChange} 

--- a/packages/validator/src/types/schema-type.ts
+++ b/packages/validator/src/types/schema-type.ts
@@ -125,6 +125,8 @@ export type UiValidatorFieldMetadata = {
   hidden?: boolean;
   /** Tells EzForms to display a prefix on a range input */
   prefix?: string;
+  /** Tells EzForms to use the range input with a text input */
+  rangeWithTextInput?: boolean;
 }
 
 /** Set of possible rules for each field */


### PR DESCRIPTION
## 🔥 Rendering a text input inside a range input
----------------------------------------------

### Description
The range input has a prop to render a text input when needed, so this change adds an ezMetadata property to set it up from ezForms

### Screenshots
![Screenshot 2025-05-12 at 10 04 19 PM](https://github.com/user-attachments/assets/7585110e-fb4f-470b-996d-3812e8244e37)

