### PR TITLE
feat(form): render input under range on small

### DIFF
--- a/packages/form/__tests__/ui-range.spec.tsx
+++ b/packages/form/__tests__/ui-range.spec.tsx
@@ -5,8 +5,13 @@ import { screen, fireEvent } from '@testing-library/react';
 import { uiRender } from '../../../__tests__/utils/render';
 import { UiRangeInput } from '../src';
 import { UiIcon } from '@uireact/icons';
+import { BreakpointsSizes } from '@uireact/foundation/src/responsive/breakpoints-sizes';
 
 describe('<Component />', () => {
+  beforeEach(() => {
+    global.innerWidth = BreakpointsSizes.l.min;
+  });
+
   it('renders fine with label', () => {
     uiRender(<UiRangeInput label="Input" name="MyInput" max={100} min={50} value={70} showRangeLabels onChange={jest.fn()} />);
 
@@ -113,7 +118,37 @@ describe('<Component />', () => {
     expect(onChangeSpy).toHaveBeenCalledWith("MyInput", 90);
   });
 
-    it('gets correct inner and real value when text input is cleaned up', () => {
+  it('renders fine with text input on small', () => {
+    global.innerWidth = BreakpointsSizes.s.max;
+    const onChangeSpy = jest.fn();
+    const Component = ({ onChangeSpy }: { onChangeSpy: (name: string, value: number) => void }) => {
+      const [value, setValue] = useState<number>(70);
+
+      return (
+        <UiRangeInput 
+          icon={<UiIcon icon="Add" />} 
+          category='primary' 
+          label="MyRangeInput" 
+          labelOnTop 
+          name="MyInput" 
+          max={100} 
+          min={50} 
+          value={value} 
+          showRangeLabels 
+          onChange={(name, value) => { setValue(value); onChangeSpy(name, value); }} 
+          showTextInput
+        />
+      )
+    }
+
+    uiRender(<Component onChangeSpy={onChangeSpy}  />);
+
+    expect(screen.getByRole('slider', { name: 'MyRangeInput' })).toBeVisible();
+    expect(screen.getByRole('spinbutton')).toBeVisible();
+    expect(screen.getByRole('spinbutton')).toHaveValue(70);
+  });
+
+  it('gets correct inner and real value when text input is cleaned up', () => {
     const onChangeSpy = jest.fn();
     const Component = ({ onChangeSpy }: { onChangeSpy: (name: string, value: number) => void }) => {
       const [value, setValue] = useState<number>(70);

--- a/packages/form/src/ui-range.scss
+++ b/packages/form/src/ui-range.scss
@@ -175,4 +175,9 @@
 
 .rangeTextInput {
   max-width: 100px;
+
+  @media screen and (max-width: 580px) {
+    margin-top: var(--spacing-three);
+    max-width: 100%;
+  }
 }

--- a/packages/form/src/ui-range.tsx
+++ b/packages/form/src/ui-range.tsx
@@ -1,7 +1,7 @@
 import React, { FormEvent, useCallback, useEffect, useState } from 'react';
 
 import { UiText, UiLabel } from '@uireact/text';
-import { SpacingDistribution, getSpacingClass } from '@uireact/foundation';
+import { SpacingDistribution, getSpacingClass, useViewport } from '@uireact/foundation';
 
 import { UiRangeInputProps } from './types';
 import styles from './ui-range.scss';
@@ -34,6 +34,7 @@ export const UiRangeInput: React.FC<UiRangeInputProps> = ({
   showTextInput,
   ...props
 }: UiRangeInputProps) => {
+  const { isSmall } = useViewport();
   const [innerValue, setInnerValue] = useState<number>(value || min);
   const [visibleValue, setVisibleValue] = useState<number>(value || min);
   const [position, setPosition] = useState(0);
@@ -109,7 +110,7 @@ export const UiRangeInput: React.FC<UiRangeInputProps> = ({
                 />
               </div>
               {showRangeLabels && <p>{maxLabel}</p>}
-              {showTextInput && <UiInput 
+              {showTextInput && !isSmall && <UiInput 
                 value={visibleValue.toString()} 
                 name={`text-input-for-${name}`}
                 category={category}
@@ -119,6 +120,15 @@ export const UiRangeInput: React.FC<UiRangeInputProps> = ({
                 />
               }
           </div>
+          {showTextInput && isSmall && <UiInput 
+              value={visibleValue.toString()} 
+              name={`text-input-for-${name}`}
+              category={category}
+              type='number'
+              className={styles.rangeTextInput} 
+              onChange={internalOnChange} 
+              />
+            }
         </div>
         {error && <UiText category={category}>{error}</UiText>}
       </div>


### PR DESCRIPTION
## 🔥 Small render range text input
----------------------------------------------

### Description
On small breakpoints the range text input will render underneath the range bar to allow for better spacing.

### Screenshots

#### Before
![Screenshot 2025-05-20 at 11 30 03 PM](https://github.com/user-attachments/assets/7ccef814-64dd-4bcb-9a9c-f9f71a5b4ed6)

#### After
