### PR TITLE
feat(form): range to render text input underneath

### DIFF
--- a/packages/ezforms/docs/example/ezform-example.tsx
+++ b/packages/ezforms/docs/example/ezform-example.tsx
@@ -43,7 +43,7 @@ const schema = {
   money: validator
     .field('numeric')
     .present("Please select a value")
-    .ezMetadata({ label: 'How much would you like to invest?', prefix: '$', rangeWithTextInput: true })
+    .ezMetadata({ label: 'How much would you like to invest?', prefix: '$', rangeWithTextInput: true, icon: 'DollarCircle' })
     .range(1, 100, "Only values between $1 and $100 are valid."),
   terms: validator
     .field('boolean')

--- a/packages/ezforms/docs/page.mdx
+++ b/packages/ezforms/docs/page.mdx
@@ -64,7 +64,7 @@ const schema = {
   money: validator
     .field('numeric')
     .present("Please select a value")
-    .ezMetadata({ label: 'How much would you like to invest?', prefix: '$', rangeWithTextInput: true })
+    .ezMetadata({ label: 'How much would you like to invest?', prefix: '$', rangeWithTextInput: true, icon: 'DollarCircle' })
     .range(1, 100, "Only values between $1 and $100 are valid."),
   terms: validator
     .field('boolean')

--- a/packages/ezforms/src/private/ez-form-field.tsx
+++ b/packages/ezforms/src/private/ez-form-field.tsx
@@ -89,10 +89,11 @@ export const EzFormField = ({
           name={name} 
           value={value} 
           onChange={onNumericInputChange} 
+          icon={icon}
           min={rules.range.min}
           max={rules.range.max}
           error={error}
-          category={error ? 'error' : 'secondary'}
+          category={error ? 'error' : undefined}
           prefix={ezMetadata.prefix}
           showTextInput={ezMetadata.rangeWithTextInput}
         />

--- a/packages/form/src/ui-range.scss
+++ b/packages/form/src/ui-range.scss
@@ -174,10 +174,13 @@
 }
 
 .rangeTextInput {
-  max-width: 100px;
+  max-width: 200px;
+}
 
-  @media screen and (max-width: 580px) {
-    margin-top: var(--spacing-three);
-    max-width: 100%;
-  }
+.smallInputWrapper {
+  margin-top: var(--spacing-three);
+  width: 100%;
+  position: relative;
+  display: flex;
+  justify-content: end;
 }

--- a/packages/form/src/ui-range.tsx
+++ b/packages/form/src/ui-range.tsx
@@ -34,7 +34,6 @@ export const UiRangeInput: React.FC<UiRangeInputProps> = ({
   showTextInput,
   ...props
 }: UiRangeInputProps) => {
-  const { isSmall } = useViewport();
   const [innerValue, setInnerValue] = useState<number>(value || min);
   const [visibleValue, setVisibleValue] = useState<number>(value || min);
   const [position, setPosition] = useState(0);
@@ -85,53 +84,45 @@ export const UiRangeInput: React.FC<UiRangeInputProps> = ({
           </UiLabel>
       )}
       <div className={inputStyles.inputDiv}>
-        <div className={inputStyles.inputContentDiv}>
-          {icon && <div className={inputStyles.inputIconContainer} aria-hidden>{icon}</div>}
-          <div className={`${styles.inputContainer} ${icon ? styles.inputIcon : ''} ${paddingClass}`}>
-            {showRangeLabels && <p>{minLabel}</p>}
-              <div className={styles.rangeContainer}>
-                <div className={styles.selectedValueLabelContainer}>
-                  <p className={styles.selectedValueLabel} style={{ left: `${position}%`, transform: `translateX(-${position}%)` }}>{valueLabel}</p>
-                </div>
-                <input
-                  disabled={disabled}
-                  className={`${className} ${category ? styles[category] : "tertiary"} ${styles.uiRangeInput}`}
-                  id={name}
-                  name={name}
-                  step={step}
-                  onChange={internalOnChange}
-                  ref={ref}
-                  type="range"
-                  value={innerValue}
-                  required={required}
-                  min={min}
-                  max={max}
-                  {...props}
-                />
+        <div className={`${styles.inputContainer} ${paddingClass}`}>
+          {showRangeLabels && <p>{minLabel}</p>}
+            <div className={styles.rangeContainer}>
+              <div className={styles.selectedValueLabelContainer}>
+                <p className={styles.selectedValueLabel} style={{ left: `${position}%`, transform: `translateX(-${position}%)` }}>{valueLabel}</p>
               </div>
-              {showRangeLabels && <p>{maxLabel}</p>}
-              {showTextInput && !isSmall && <UiInput 
-                value={visibleValue.toString()} 
-                name={`text-input-for-${name}`}
-                category={category}
-                type='number'
-                className={styles.rangeTextInput} 
-                onChange={internalOnChange} 
-                />
-              }
-          </div>
-          {showTextInput && isSmall && <UiInput 
+              <input
+                disabled={disabled}
+                className={`${className} ${category ? styles[category] : "tertiary"} ${styles.uiRangeInput}`}
+                id={name}
+                name={name}
+                step={step}
+                onChange={internalOnChange}
+                ref={ref}
+                type="range"
+                value={innerValue}
+                required={required}
+                min={min}
+                max={max}
+                {...props}
+              />
+            </div>
+            {showRangeLabels && <p>{maxLabel}</p>}
+        </div>
+        {showTextInput && (
+          <div className={styles.smallInputWrapper}>
+            <UiInput 
               value={visibleValue.toString()} 
               name={`text-input-for-${name}`}
+              icon={icon}
               category={category}
               type='number'
               className={styles.rangeTextInput} 
               onChange={internalOnChange} 
               />
-            }
-        </div>
-        {error && <UiText category={category}>{error}</UiText>}
+            </div>
+        )}
       </div>
+      {error && <UiText category={category}>{error}</UiText>}
     </div>
   );
 };


### PR DESCRIPTION
## 🔥 Move text input from range input
----------------------------------------------

### Description
The text input in range inputs was too small for some use cases so we decided to move it underneath for better spacing and cleaner readability

### Screenshots

#### Before

#### After
![Screenshot 2025-05-21 at 12 03 01 AM](https://github.com/user-attachments/assets/23e6574c-698c-4975-b037-d14bb95b9777)
