### PR TITLE
feat(menu): inverse coloration

### DIFF
--- a/packages/menu/docs/page.mdx
+++ b/packages/menu/docs/page.mdx
@@ -60,3 +60,11 @@ const getDelayedAnimation = (index: number): MotionProps => {
 ```
 
 This is just a small version of how this could potentially be used but your creative is your own limit.
+
+## Menu with inverse BG
+
+Using prop `inverse` in the `< UiMenu  />` component will render it using an inversed background.
+
+```tsx live scope={{MenuExample}}
+    <MenuExample inverse />
+```

--- a/packages/menu/docs/utils/menu-example.tsx
+++ b/packages/menu/docs/utils/menu-example.tsx
@@ -16,7 +16,11 @@ const buttonSpacing: UiSpacingProps['padding'] = {
   block: 'four'
 }
 
-export const MenuExample: React.FC = () => {
+type MenuExampleProps = {
+  inverse?: boolean;
+}
+
+export const MenuExample: React.FC = ({ inverse }: MenuExampleProps) => {
   const [isVisible, setIsVisible] = React.useState(false);
 
   const handleMenuOpen = React.useCallback(() => {
@@ -32,9 +36,9 @@ export const MenuExample: React.FC = () => {
       <div>
         <UiButton category='tertiary' onClick={handleMenuOpen}>Open Menu</UiButton>
       </div>
-      <UiMenu visible={isVisible} closeMenuCB={closeMenu} fullscreenOnSmall>
+      <UiMenu visible={isVisible} closeMenuCB={closeMenu} fullscreenOnSmall inverse={inverse}>
         <UiSpacing margin={{ all: 'five' }}>
-          <UiText align='center'>Menu Content</UiText>
+          <UiText align='center' inverseColoration={inverse}>Menu Content</UiText>
           <div>
             <UiPrimaryButton onClick={closeMenu} fullWidth>
               Close menu
@@ -42,7 +46,7 @@ export const MenuExample: React.FC = () => {
           </div>
         </UiSpacing>
         <UiSpacing margin={{ all: 'five' }}>
-          <UiText align='center'>Menu Content</UiText>
+          <UiText align='center' inverseColoration={inverse}>Menu Content</UiText>
           <div>
             <UiTertiaryButton fullWidth>
               Some other button

--- a/packages/menu/src/types/menu-props.ts
+++ b/packages/menu/src/types/menu-props.ts
@@ -14,4 +14,6 @@ export type UiMenuProps = {
   visible: boolean;
   /** CB for when menu is closed */
   closeMenuCB: () => void;
+  /** If menu should render with inverse BG */
+  inverse?: boolean;
 } & UiReactElementProps;

--- a/packages/menu/src/ui-menu.scss
+++ b/packages/menu/src/ui-menu.scss
@@ -1,11 +1,18 @@
 .menu {
-    background-color: var(--primary-token_50);
     box-shadow: rgba(50, 50, 93, 0.25) 0px 2px 5px -1px, rgba(0, 0, 0, 0.3) 0px 1px 3px -1px;
     position: absolute;
     border-radius: 5px;
     width: max-content;
     z-index: 10;
     margin-top: 5px;
+}
+
+.menuBg {
+    background-color: var(--primary-token_50);
+}
+
+.inverseMenu {
+    background-color: var(--inverse-primary-token_10);
 }
 
 .wrapper {

--- a/packages/menu/src/ui-menu.tsx
+++ b/packages/menu/src/ui-menu.tsx
@@ -21,13 +21,14 @@ export const UiMenu: React.FC<UiMenuProps> = ({
   motion = UiReactFadeUp,
   visible,
   testId,
+  inverse,
 }: UiMenuProps) => {
   const dialogId = menuId || 'menu-component';
   const menuRef = React.useRef<HTMLDivElement>(null);
   const [isOffset, setIsOffset] = React.useState(false);
   const { isSmall } = useViewport();
   const { isOpen, actions } = useDialog(dialogId);
-  let menuClasses = `${styles.menu} ${className}`;
+  let menuClasses = `${styles.menu} ${className} ${inverse ? styles.inverseMenu : styles.menuBg}`;
 
   //istanbul ignore next
   if (isOffset) {


### PR DESCRIPTION
## 🔥 Inverse menu coloration
----------------------------------------------

### Description
In some scenarios the menu coloration in dark themes is not enough to show the difference in content levels when opened, so using an inverse coloration help on distinguishing the menu content from the content behind it.

### Screenshots
![Screenshot 2025-06-03 at 12 52 56 PM](https://github.com/user-attachments/assets/413c728a-98b2-472e-af4d-8fb486667bd5)

