### PR TITLE
fix: use flex-end instead of end

### DIFF
--- a/packages/form/src/ui-range.scss
+++ b/packages/form/src/ui-range.scss
@@ -182,5 +182,5 @@
   width: 100%;
   position: relative;
   display: flex;
-  justify-content: end;
+  justify-content: flex-end;
 }

--- a/packages/grid/src/ui-grid.scss
+++ b/packages/grid/src/ui-grid.scss
@@ -19,7 +19,7 @@ $noSpaces: 1,2,3,4,5,6,7,8,9,10;
 }
 
 .justify-end {
-    justify-items: end;
+    justify-items: flex-end;
 }
 
 .justify-center {


### PR DESCRIPTION
## 🔥 Replace end with flex-end
----------------------------------------------

### Description
There was a warning in the styles coming from using `end` , so fixed it by using `flex-end`.

### Screenshots

N/A
