### PR TITLE
refactor: deprecate viewport in foundation package

### DIFF
--- a/packages/foundation/docs/viewport/page.mdx
+++ b/packages/foundation/docs/viewport/page.mdx
@@ -1,17 +1,21 @@
 import { UiViewport, Breakpoints, ThemeContext } from '@uireact/foundation';
 
 import { UiCard } from '@uireact/card';
+import { UiHeading, UiText } from '@uireact/text';
 
 import packageJson from './package-metadata.json';
 import { Metadata } from '@uireact/docs-tools';
 
 # UiViewport
 
-<Metadata packageName='foundation' packageJson={packageJson} description='This component make it easy to render/remove components from the DOM based on the breakpoint.' includeInformation />
-
-This component is exported as part of **@uireact/foundation** so if you have already set up the library you can just import it from the foundation package.
+<Metadata packageName='foundation' packageJson={packageJson} description='This component make it easy to render/remove components from the DOM based on the breakpoint.' includeInformation deprecated />
 
 ## Usages 🛠️
+
+<UiCard category='warning'>
+  <UiHeading>Deprecated</UiHeading>
+  <UiText>This component has been deprecated and will be removed in the next major version. Migrate over to the one exported from [@uireact/tools](./ui-viewport)</UiText>
+</UiCard>
 
 ### Specific breakpoint
 

--- a/packages/foundation/src/hooks/use-viewport.ts
+++ b/packages/foundation/src/hooks/use-viewport.ts
@@ -10,6 +10,7 @@ export type useViewportResponse = {
   isXLarge: boolean;
 };
 
+/** @deprecated Migrate over to UiViewport in "@uireact/tools" - this will be removed in the next major version. */
 export const useViewport = (): useViewportResponse => {
   const { width } = useWindowDimensions();
   const [hydratred, setHydrated] = useState(false);

--- a/packages/foundation/src/responsive/viewport.tsx
+++ b/packages/foundation/src/responsive/viewport.tsx
@@ -14,6 +14,7 @@ interface ViewportProps {
   skipSSr?: boolean;
 }
 
+/** @deprecated Migrate over to UiViewport in "@uireact/tools" - this will be removed in the next major version. */
 export const UiViewport: React.FC<ViewportProps> = ({ children, criteria, skipSSr }: ViewportProps) => {
   const [hydrated, setHydrated] = React.useState(false);
   const { isSmall, isMedium, isLarge, isXLarge } = useViewport();

--- a/packages/tools/docs/ui-viewport/page.mdx
+++ b/packages/tools/docs/ui-viewport/page.mdx
@@ -3,7 +3,7 @@ import { Metadata } from '@uireact/docs-tools';
 
 import { UiViewportExample } from './example/ui-viewport-example';
 
-# UiTooltip
+# UiViewport
 <Metadata packageName='tools' packageJson={packageJson} description='Component used to render content in specific breakpoints.' includeInformation />
 
 ## Usage

--- a/platform/docs-tools/src/metadata.tsx
+++ b/platform/docs-tools/src/metadata.tsx
@@ -15,6 +15,7 @@ import { DocSubHeading } from './doc-subheading';
 type MetadataProps = {
   description: string;
   includeInformation: boolean;
+  deprecated?: boolean;
   packageName: string;
   packageJson: {
     version: string,
@@ -55,7 +56,7 @@ const badgesInfo: BadgesInfo = {
   }
 }
 
-export const Metadata = ({ packageName, packageJson, includeInformation, description }: MetadataProps) => {
+export const Metadata = ({ packageName, packageJson, includeInformation, description, deprecated }: MetadataProps) => {
   const peers = Object.keys(packageJson.peerDependencies);
   const version = packageJson.version;
   const badges = [];
@@ -86,6 +87,7 @@ export const Metadata = ({ packageName, packageJson, includeInformation, descrip
           </UiLink>
         </sup>
         {badges.map((badge, index) => badge && <UiBadge category={badge.category} key={`metadata-version-${index}`}>{badge.text}</UiBadge>)}
+        {deprecated && <UiBadge category='warning' >⚠️ Deprecated</UiBadge>}
       </UiFlexGrid>
       {includeInformation && (
         <>


### PR DESCRIPTION
## 🔥 Deprecating UiViewport from foundation package
----------------------------------------------

### Description
We will be removing the `<UiViewport />` component in the foundation package as there is already another in `@uireact/tools` that will replace it.

### Screenshots

N/A