### PR TITLE
feat(ezforms): clear data of field when field type mutates

### DIFF
--- a/packages/ezforms/__tests__/ui-ez-form-mutating.spec.tsx
+++ b/packages/ezforms/__tests__/ui-ez-form-mutating.spec.tsx
@@ -1,0 +1,75 @@
+import React from 'react';
+import { fireEvent, screen } from '@testing-library/react';
+
+import { UiValidator } from '@uireact/validator';
+
+import { uiRender } from '../../../__tests__/utils';
+import { UiEzForm } from '../src';
+
+
+const validator = new UiValidator();
+
+const schema = {
+  country: validator
+    .field('choice')
+    .ezMetadata({ label: "Country", icon: "EarthAmericas" })
+    .present("Country is required")
+    .oneOf([{ label: 'Mexico', value: '1' }, { label: 'Estados Unidos de America', value: '2' }]),
+  state: validator
+    .field('choice')
+    .ezMetadata({ label: "State", icon: "City" })
+    .when('country', validator.is().equals('1'))
+    .run(validator.is().present("State is required").oneOf(['Colima', 'Jalisco']))
+    .else(validator.is().mutate('text').present("State is required"))
+}
+
+describe('Mutating fields', () => {
+  it('Should render text field', () => {
+    uiRender(<UiEzForm schema={schema} submitLabel='Submit' />);
+
+    expect(screen.getByRole('combobox', { name: 'Country' })).toBeVisible();
+    expect(screen.getByRole('textbox', { name: 'State' })).toBeVisible();
+  });
+
+  it('Should mutate correctly between different types', () => {
+    uiRender(<UiEzForm schema={schema} submitLabel='Submit' />);
+
+    // Verify first render
+    const countrySelect = screen.getByRole('combobox', { name: 'Country' });
+    const stateInput = screen.getByRole('textbox', { name: 'State' });
+
+    // Add some value and verify the text element
+    fireEvent.change(stateInput, { target: { value: 'Washington' } });
+
+    expect(countrySelect).toBeVisible();
+
+    expect(screen.getByRole('textbox', { name: 'State' })).toBeVisible();
+    expect(screen.getByRole('textbox', { name: 'State' })).toHaveValue('Washington');
+
+    // Change country to the value that triggers mutation
+
+    fireEvent.change(countrySelect, { target: { value: '1' } });
+
+    // Verify mutated field
+
+    expect(screen.queryByRole('textbox', { name: 'State' })).not.toBeInTheDocument();
+    expect(screen.getByRole('combobox', { name: 'State' })).toBeVisible();
+    expect(screen.getByRole('combobox', { name: 'State' })).toHaveValue('');
+
+    // Select an option in the mutated field
+
+    const stateSelect = screen.getByRole('combobox', { name: 'State' });
+    fireEvent.change(stateSelect, { target: { value: 'Colima' } });
+
+    expect(stateSelect).toHaveValue('Colima');
+
+    // Change country to another value that triggers basic type to be rendered
+
+    fireEvent.change(countrySelect, { target: { value: '2' } });
+
+    // Verify default field renders
+    expect(screen.queryByRole('combobox', { name: 'State' })).not.toBeInTheDocument();
+    expect(screen.getByRole('textbox', { name: 'State' })).toBeVisible();
+    expect(screen.getByRole('textbox', { name: 'State' })).toHaveValue('');
+  });
+});

--- a/packages/ezforms/docs/page.mdx
+++ b/packages/ezforms/docs/page.mdx
@@ -258,14 +258,35 @@ Using the `mutate()` function we can change the a field's type based on the vali
 ```jsx live scope={{UiEzForm, UiValidator}}
   <UiEzForm 
     schema={{
-      transport: new UiValidator().field("choice").ezMetadata({ label: "Transport:" }).present().oneOf(['Car', 'Boat']),
-      part: new UiValidator()
-        .field('choice')
-        .ezMetadata({ label: 'Part:' })
-        .when('transport', new UiValidator().is().equals('Car'))
-        .run(new UiValidator().is().oneOf(['Tire', 'Wheels'], 'Please select a valid part of a car'))
-        .else(new UiValidator().is().mutate('text').present('Please mention a part of a Boat'))
-    }}
+    name: new UiValidator()
+      .field('text')
+      .ezMetadata({ label: "Name", icon: "Building" })
+      .present("Name is requried"),
+    phone: new UiValidator()
+      .field('phone')
+      .ezMetadata({ label: "Phone", icon: "CirclePhone" })
+      .present("Phone is required"),
+    country: new UiValidator() 
+      .field('choice')
+      .ezMetadata({ label: "Country", icon: "EarthAmericas" })
+      .present("Country is required")
+      .oneOf([{ label: 'Mexico', value: 1 }, { label: 'Estados Unidos de America', value: 2 }]),
+    state: new UiValidator() 
+      .field('choice')
+      .ezMetadata({ label: "State", icon: "City" })
+      .when('country', new UiValidator().is().equals('1'))
+      .run(new UiValidator().is().present("State is required").oneOf(['Colima', 'Jalisco']))
+      .else(new UiValidator().is().mutate('text').present("State is required")),
+    city: new UiValidator() 
+      .field('text')
+      .ezMetadata({ label: "City", icon: "City" })
+      .present("City is required"),
+    street: new UiValidator() 
+      .field('text')
+      .ezMetadata({ label: "Street", icon: "MapMarker" })
+      .present("Street is required"),
+    bid: new UiValidator().field('text').ezMetadata({ hidden: true }).optional()
+  }}
     onSubmit={(e, data) => {e.preventDefault();console.log(data)}}
     buttonsAlignment='stacked'
     submitLabel='Submit'

--- a/packages/ezforms/src/private/ez-form-field.tsx
+++ b/packages/ezforms/src/private/ez-form-field.tsx
@@ -1,9 +1,9 @@
-import React, { FormEvent, useCallback, useMemo } from 'react';
+import React, { FormEvent, useCallback, useEffect, useMemo, useState } from 'react';
 
 import { UiInputDatepicker } from '@uireact/datepicker';
 import { UiDigitsInput, UiInput, UiRangeInput, UiSelect, UiSwitch, UiTextArea } from '@uireact/form';
 import { UiIcon, UiIconProps } from '@uireact/icons';
-import type { UiValidatorData, UiValidatorField, UiValidatorWhen } from '@uireact/validator';
+import type { UiValidatorData, UiValidatorField, UiValidatorFieldTypes, UiValidatorWhen } from '@uireact/validator';
 
 import { getFieldData } from './get-field-data';
 import { getFieldRules } from './get-field-rules';
@@ -23,6 +23,7 @@ type EzFormFieldProps = {
   onDateInputChange: (date: string, name: string) => void;
   onBooleanToogle: (value: boolean, name: string) => void;
   onDigitsInputChange: (value: string, name: string) => void;
+  clearData: (name: string) => void;
 }
 
 export const EzFormField = ({ 
@@ -38,11 +39,13 @@ export const EzFormField = ({
   onDateInputChange,
   onBooleanToogle,
   onSelectInputChange,
-  onDigitsInputChange
+  onDigitsInputChange,
+  clearData
 }: EzFormFieldProps) => {
   const fieldData = getFieldData(field);
   const ezMetadata = fieldData.getEzMetadata() || {};
   const rules = getFieldRules(field);
+  const [fieldType, setFieldType] = useState(getFieldType(field, allData));
   const icon = ezMetadata.icon ? <UiIcon icon={ezMetadata.icon as UiIconProps['icon']} /> : undefined;
   const onDateChangeWrapper = useCallback((date: string) => {
     onDateInputChange(date, name);
@@ -61,9 +64,17 @@ export const EzFormField = ({
     onDigitsInputChange(value || "", name);
   }, [name, onDigitsInputChange]);
 
-  const fieldType = useMemo(() => {
-    return getFieldType(field, allData);
-  }, [field, allData]);
+  useEffect(() => {
+    const type = getFieldType(field, allData);
+
+    if (type !== fieldType) {
+      clearData(name);
+    }
+
+    if (type) {
+      setFieldType(type);
+    }
+  }, [field, allData, fieldType, name]);
 
   // istanbul ignore next
   if (!rules || !fieldType) {

--- a/packages/ezforms/src/ui-ez-form.tsx
+++ b/packages/ezforms/src/ui-ez-form.tsx
@@ -121,6 +121,15 @@ export const UiEzForm: React.FC<UiEzFormProps> = ({
     }
   }, [data, onSubmit, schema]);
 
+  const onClear = useCallback((name: string) => {
+    const newData = { ...data, [name]: "" };
+    setErrors({});
+    setData(newData);
+
+    // istanbul ignore next
+    onChange?.(newData);
+  }, [data, onChange]);
+
   return (
     <form onSubmit={onSubmitCB} action={action} method={method}>
       <UiFlexGrid gap='three' direction={direction && direction === 'inline' ? 'row' : 'column'}>
@@ -140,6 +149,7 @@ export const UiEzForm: React.FC<UiEzFormProps> = ({
             onSelectInputChange={onStringChange}
             onDigitsInputChange={onStringChange}
             useBrowserValidation={useBrowserValidation}
+            clearData={onClear}
           />
         )}
         {decorators?.aboveActions}


### PR DESCRIPTION
## 🔥 EzForms Reset value on mutating field types
----------------------------------------------

### Description
The EzForm keeps the previous value, this changes the behavior to reset the value when the field type mutates, this to prevent stale values in new field types.

### Screenshots

#### Before
![Sep-03-2025 18-56-40](https://github.com/user-attachments/assets/d646319a-6ea6-4149-b40d-3d10324a8647)

#### After
![Sep-03-2025 18-55-31](https://github.com/user-attachments/assets/8d9ef846-8a76-41b8-adfe-0871f3bbbc3d)
